### PR TITLE
fix(a11y): hide decorative lottie animations

### DIFF
--- a/src/components/LottiePlayer.tsx
+++ b/src/components/LottiePlayer.tsx
@@ -8,6 +8,7 @@ interface Props {
   autoplay?: boolean;
   className?: string;
   style?: React.CSSProperties;
+  label?: string;
 }
 
 export default function LottiePlayer({
@@ -16,6 +17,7 @@ export default function LottiePlayer({
   autoplay = true,
   className,
   style,
+  label,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -43,5 +45,15 @@ export default function LottiePlayer({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return <div ref={containerRef} className={className} style={style} />;
+  return (
+    <>
+      <div
+        ref={containerRef}
+        className={className}
+        style={style}
+        aria-hidden="true"
+      />
+      {label && <span className="sr-only">{label}</span>}
+    </>
+  );
 }


### PR DESCRIPTION
## Summary
- mark the Lottie animation container as `aria-hidden` so decorative SVG animation output is skipped by assistive tech
- add an optional `label` prop that renders a `sr-only` text fallback when an animation needs its own description
- leave current call sites unlabeled because they already have adjacent visible text, avoiding duplicate screen reader announcements

Closes #202

## Validation
- `bun install --frozen-lockfile`
- `bun run build`
- `bun run lint`
- `git diff --check`

Note: Next.js reports a workspace-root warning because this machine has another lockfile at `/home/tq/package-lock.json`; the build and lint both complete successfully.