### PR TITLE
fix(a11y): add screen reader text to icon controls

### DIFF
--- a/src/components/AudioSpeedControl.tsx
+++ b/src/components/AudioSpeedControl.tsx
@@ -25,6 +25,9 @@ export default function AudioSpeedControl({ recipe, onChange }: Props) {
         `}
       >
         {recipe.keepAudio ? <Volume2 size={16} /> : <VolumeX size={16} />}
+        <span className="sr-only">
+          {recipe.keepAudio ? "Turn audio off" : "Turn audio on"}
+        </span>
         <span className="text-sm font-heading font-semibold">
           {recipe.keepAudio ? "Audio on" : "Muted"}
         </span>

--- a/src/components/FramingControl.tsx
+++ b/src/components/FramingControl.tsx
@@ -28,6 +28,9 @@ export default function FramingControl({ recipe, onChange }: Props) {
             `}
           >
             <Icon size={18} />
+            <span className="sr-only">
+              Set framing to {mode === "fit" ? "fit within frame" : "fill frame by cropping"}
+            </span>
             <div className="text-center">
               <p className="text-xs font-heading font-semibold uppercase tracking-wider">
                 {mode === "fit" ? "Fit" : "Fill"}

--- a/src/components/RotateControl.tsx
+++ b/src/components/RotateControl.tsx
@@ -29,6 +29,7 @@ export default function RotateControl({ recipe, onChange }: Props) {
             `}
           >
             <RotateCw size={15} style={{ transform: `rotate(${deg}deg)` }} className="transition-transform" />
+            <span className="sr-only">Rotate video to {deg} degrees</span>
             {deg}
           </button>
         );


### PR DESCRIPTION
## Summary
- Add visually hidden text descriptions to icon-led rotate, framing, and audio controls
- Improve screen reader context without changing the visible UI

Fixes #70

## Verification
- git diff --check