### PR TITLE
Add explicit button types

### DIFF
--- a/src/components/AudioSpeedControl.tsx
+++ b/src/components/AudioSpeedControl.tsx
@@ -14,6 +14,7 @@ export default function AudioSpeedControl({ recipe, onChange }: Props) {
   return (
     <div className="space-y-4">
       <button
+        type="button"
         onClick={() => onChange({ keepAudio: !recipe.keepAudio })}
         className={`
           w-full flex items-center gap-3 p-3 rounded-lg border transition-all duration-150

--- a/src/components/DownloadResult.tsx
+++ b/src/components/DownloadResult.tsx
@@ -47,6 +47,7 @@ export default function DownloadResult({ result, onReset }: Props) {
           Download {result.format.toUpperCase()}
         </a>
         <button
+          type="button"
           onClick={onReset}
           className="flex items-center gap-2 px-4 py-3 border border-[var(--border)] text-[var(--muted)] text-sm rounded-lg hover:bg-[var(--bg)] transition-colors"
         >

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -43,6 +43,7 @@ export default function FileUpload({ onFileSelect, currentFile }: Props) {
           <p className="text-xs text-[var(--muted)]">{fmt(currentFile.size)}</p>
         </div>
         <button
+          type="button"
           onClick={() => inputRef.current?.click()}
           className="text-xs font-heading font-semibold text-film-600 hover:text-film-700 uppercase tracking-wide shrink-0 transition-colors"
         >

--- a/src/components/FramingControl.tsx
+++ b/src/components/FramingControl.tsx
@@ -16,6 +16,7 @@ export default function FramingControl({ recipe, onChange }: Props) {
         const active = recipe.framing === mode;
         return (
           <button
+            type="button"
             key={mode}
             onClick={() => onChange({ framing: mode })}
             className={`

--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -34,6 +34,7 @@ export default function PresetSelector({ recipe, onChange }: Props) {
           const active = recipe.preset === preset.id;
           return (
             <button
+              type="button"
               key={preset.id}
               onClick={() => onChange({ preset: preset.id })}
               title={`${preset.label} — ${preset.platform}`}
@@ -60,6 +61,7 @@ export default function PresetSelector({ recipe, onChange }: Props) {
         })}
 
         <button
+          type="button"
           onClick={() => onChange({ preset: "custom" })}
           className={`
             flex items-center gap-2.5 p-2.5 rounded-lg border text-left transition-all duration-150

--- a/src/components/RotateControl.tsx
+++ b/src/components/RotateControl.tsx
@@ -17,6 +17,7 @@ export default function RotateControl({ recipe, onChange }: Props) {
         const active = recipe.rotate === deg;
         return (
           <button
+            type="button"
             key={deg}
             onClick={() => onChange({ rotate: deg })}
             className={`

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -133,6 +133,7 @@ export default function VideoEditor() {
             </div>
 
             <button
+              type="button"
               onClick={handleExport}
               disabled={!file || isProcessing}
               className={`


### PR DESCRIPTION
Closes #46

## Summary
- Added explicit `type="button"` attributes to buttons in `src/components`
- Prevents accidental form submission behavior if these controls are rendered inside forms
- No visual changes intended

## Validation
- Confirmed all button elements in `src/components` now declare `type="button"`
- `git diff --check` passes

Note: I could not complete the project lint locally because the dependency install was incomplete in my environment; this change is limited to JSX attributes only.