### PR TITLE
Add output resolution display in DownloadResult

### DIFF
--- a/src/components/DownloadResult.tsx
+++ b/src/components/DownloadResult.tsx
@@ -23,6 +23,9 @@ export default function DownloadResult({ result, onReset }: Props) {
         <div>
           <p className="font-heading font-bold text-base text-[var(--text)]">Export complete</p>
           <p className="text-xs text-[var(--muted)] mt-0.5">Ready to download</p>
+          <p className="text-sm text-[var(--text)]">
+            Resolution: {result.width} × {result.height}
+          </p>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

* Added output resolution display in DownloadResult
* Shows resolution in Width × Height format above download button

Fixes #228
 
<img width="1232" height="310" alt="image" src="https://github.com/user-attachments/assets/b5e6a08e-1523-40fd-be07-47bbd614d093" />
