### PR TITLE
feat: add descriptive title tooltips to preset buttons

### DIFF
--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -8,6 +8,13 @@ interface Props {
   recipe: EditRecipe;
   onChange: (patch: Partial<EditRecipe>) => void;
 }
+function getOrientationLabel(width: number, height: number): string {
+  const gcd = (a: number, b: number): number => (b === 0 ? a : gcd(b, a % b));
+  const d = gcd(width, height);
+  const ratio = `${width / d}:${height / d}`;
+  const orientation = width === height ? "Square" : width > height ? "Landscape" : "Portrait";
+  return `${orientation} ${ratio}`;
+}
 
 function RatioBox({ width, height, active }: { width: number; height: number; active: boolean }) {
   const MAX = 32;
@@ -37,7 +44,7 @@ export default function PresetSelector({ recipe, onChange }: Props) {
               type="button"
               key={preset.id}
               onClick={() => onChange({ preset: preset.id })}
-              title={`${preset.label} — ${preset.platform}`}
+              title={`${preset.label} — ${preset.width}×${preset.height} — ${getOrientationLabel(preset.width, preset.height)}`}
               className={`
                 flex items-center gap-2.5 p-2.5 rounded-lg border text-left transition-all duration-150
                 hover:scale-[1.02] active:scale-[0.98]
@@ -62,6 +69,7 @@ export default function PresetSelector({ recipe, onChange }: Props) {
 
         <button
           type="button"
+          title="Custom — Set your own dimensions"
           onClick={() => onChange({ preset: "custom" })}
           className={`
             flex items-center gap-2.5 p-2.5 rounded-lg border text-left transition-all duration-150


### PR DESCRIPTION
Closes #214

Added `title` attributes to all preset buttons in `PresetSelector.tsx`.

- Preset buttons now show: `Name — Width×Height — Orientation Ratio`
- Orientation and ratio computed dynamically via `getOrientationLabel()` using GCD
- Custom button shows: `Custom — Set your own dimensions`