### PR TITLE
Add Netlify and GitHub Pages deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,32 @@ Reframe is a fully static app. Deploy the `out/` folder anywhere:
 | **GitHub Pages** | Push `out/` to `gh-pages` branch |
 | **Cloudflare Pages** | Connect your fork in the Cloudflare dashboard |
 
+### Deploying to Netlify
+
+1. Push your fork to GitHub
+2. Open Netlify and import the repository
+3. Configure:
+   - Build command: `bun run build`
+   - Publish directory: `out`
+4. Deploy the site
+
+> Note: FFmpeg browser features may require proper CORS headers depending on hosting setup.
+
+### Deploying to GitHub Pages
+
+Build the static export:
+
+```bash
+bun run build
+```
+
+The production files will be generated in the `out/` directory.
+
+You can deploy the `out/` folder using:
+- GitHub Pages
+- `gh-pages` branch
+- GitHub Actions workflow
+
 ---
 
 ## How It Works


### PR DESCRIPTION
## Summary

* Added Netlify deployment section to README
* Added GitHub Pages deployment section
* Included static export and hosting notes

Fixes #225
