### PR TITLE
refactor: convert class string concatenations to cn utility

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,12 +7,14 @@
       "dependencies": {
         "@ffmpeg/ffmpeg": "^0.12.10",
         "@ffmpeg/util": "^0.12.2",
+        "clsx": "^2.1.1",
         "lottie-react": "^2.4.0",
         "lottie-web": "^5.12.2",
         "lucide-react": "^0.469.0",
         "next": "^15.1.8",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "tailwind-merge": "^3.6.0",
       },
       "devDependencies": {
         "@types/node": "^22",
@@ -302,6 +304,8 @@
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -742,6 +746,8 @@
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
     "tailwindcss": ["tailwindcss@3.4.19", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ=="],
 

--- a/package.json
+++ b/package.json
@@ -11,12 +11,14 @@
   "dependencies": {
     "@ffmpeg/ffmpeg": "^0.12.10",
     "@ffmpeg/util": "^0.12.2",
+    "clsx": "^2.1.1",
     "lottie-react": "^2.4.0",
     "lottie-web": "^5.12.2",
     "lucide-react": "^0.469.0",
     "next": "^15.1.8",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/src/components/AudioSpeedControl.tsx
+++ b/src/components/AudioSpeedControl.tsx
@@ -2,6 +2,7 @@
 
 import { EditRecipe, SPEED_STEPS } from "@/lib/types";
 import { Volume2, VolumeX, Gauge } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 interface Props {
   recipe: EditRecipe;
@@ -16,14 +17,13 @@ export default function AudioSpeedControl({ recipe, onChange }: Props) {
       <button
         type="button"
         onClick={() => onChange({ keepAudio: !recipe.keepAudio })}
-        className={`
-          w-full flex items-center gap-3 p-3 rounded-lg border transition-all duration-150
-          hover:scale-[1.01] active:scale-[0.99]
-          ${recipe.keepAudio
+        className={cn(
+          "w-full flex items-center gap-3 p-3 rounded-lg border transition-all duration-150",
+          "hover:scale-[1.01] active:scale-[0.99]",
+          recipe.keepAudio
             ? "border-film-300 bg-film-50 text-film-700"
             : "border-[var(--border)] bg-[var(--surface)] text-[var(--muted)]"
-          }
-        `}
+        )}
       >
         {recipe.keepAudio ? <Volume2 size={16} /> : <VolumeX size={16} />}
         <span className="sr-only">

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from "react";
 import { Film, FolderOpen } from "lucide-react";
 import LottiePlayer from "./LottiePlayer";
 import uploadAnim from "@/lib/lottie/upload.json";
+import { cn } from "@/lib/utils";
 
 interface Props {
   onFileSelect: (file: File) => void;
@@ -69,14 +70,13 @@ export default function FileUpload({ onFileSelect, currentFile }: Props) {
       onDragLeave={() => setDragging(false)}
       onDrop={handleDrop}
       onClick={() => inputRef.current?.click()}
-      className={`
-        group flex flex-col items-center justify-center gap-4 py-12 px-6
-        border-2 border-dashed rounded-xl cursor-pointer transition-all duration-200
-        ${dragging
+      className={cn(
+        "group flex flex-col items-center justify-center gap-4 py-12 px-6",
+        "border-2 border-dashed rounded-xl cursor-pointer transition-all duration-200",
+        dragging
           ? "border-film-500 bg-film-50 scale-[1.01]"
           : "border-[var(--border)] bg-[var(--bg)] hover:border-film-400 hover:bg-film-50/40"
-        }
-      `}
+      )}
     >
       <div className="w-20 h-20 opacity-80 group-hover:opacity-100 transition-opacity group-hover:scale-110 duration-200">
         <LottiePlayer animationData={uploadAnim} loop autoplay />

--- a/src/components/FramingControl.tsx
+++ b/src/components/FramingControl.tsx
@@ -2,6 +2,7 @@
 
 import { EditRecipe } from "@/lib/types";
 import { Maximize2, Crop } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 interface Props {
   recipe: EditRecipe;
@@ -19,14 +20,13 @@ export default function FramingControl({ recipe, onChange }: Props) {
             type="button"
             key={mode}
             onClick={() => onChange({ framing: mode })}
-            className={`
-              flex-1 flex flex-col items-center gap-2 py-4 rounded-lg border transition-all duration-150
-              hover:scale-[1.02] active:scale-[0.98]
-              ${active
+            className={cn(
+              "flex-1 flex flex-col items-center gap-2 py-4 rounded-lg border transition-all duration-150",
+              "hover:scale-[1.02] active:scale-[0.98]",
+              active
                 ? "border-film-500 bg-film-50 text-film-700"
                 : "border-[var(--border)] text-[var(--muted)] hover:border-film-300 bg-[var(--surface)]"
-              }
-            `}
+            )}
           >
             <Icon size={18} />
             <span className="sr-only">

--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -3,6 +3,7 @@
 import { PRESETS } from "@/lib/presets";
 import { EditRecipe } from "@/lib/types";
 import { Settings2 } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 interface Props {
   recipe: EditRecipe;
@@ -18,9 +19,10 @@ function RatioBox({ width, height, active }: { width: number; height: number; ac
 
   return (
     <div
-      className={`border-2 flex-shrink-0 transition-colors ${
+      className={cn(
+        "border-2 flex-shrink-0 transition-colors",
         active ? "border-film-600" : "border-[var(--muted)] opacity-60"
-      }`}
+      )}
       style={{ width: w, height: h }}
     />
   );
@@ -38,18 +40,20 @@ export default function PresetSelector({ recipe, onChange }: Props) {
               key={preset.id}
               onClick={() => onChange({ preset: preset.id })}
               title={`${preset.label} — ${preset.platform}`}
-              className={`
-                flex items-center gap-2.5 p-2.5 rounded-lg border text-left transition-all duration-150
-                hover:scale-[1.02] active:scale-[0.98]
-                ${active
+              className={cn(
+                "flex items-center gap-2.5 p-2.5 rounded-lg border text-left transition-all duration-150",
+                "hover:scale-[1.02] active:scale-[0.98]",
+                active
                   ? "border-film-500 bg-film-50"
                   : "border-[var(--border)] bg-[var(--surface)] hover:border-film-300 hover:bg-film-50/30"
-                }
-              `}
+              )}
             >
               <RatioBox width={preset.width} height={preset.height} active={active} />
               <div className="min-w-0 flex-1">
-                <p className={`text-xs font-heading font-bold leading-tight ${active ? "text-film-700" : "text-[var(--text)]"}`}>
+                <p className={cn(
+                  "text-xs font-heading font-bold leading-tight",
+                  active ? "text-film-700" : "text-[var(--text)]"
+                )}>
                   {preset.label}
                 </p>
                 <p className="text-[10px] text-[var(--muted)] leading-tight mt-0.5 truncate">
@@ -63,21 +67,26 @@ export default function PresetSelector({ recipe, onChange }: Props) {
         <button
           type="button"
           onClick={() => onChange({ preset: "custom" })}
-          className={`
-            flex items-center gap-2.5 p-2.5 rounded-lg border text-left transition-all duration-150
-            hover:scale-[1.02] active:scale-[0.98]
-            ${recipe.preset === "custom"
+          className={cn(
+            "flex items-center gap-2.5 p-2.5 rounded-lg border text-left transition-all duration-150",
+            "hover:scale-[1.02] active:scale-[0.98]",
+            recipe.preset === "custom"
               ? "border-film-500 bg-film-50"
               : "border-[var(--border)] bg-[var(--surface)] hover:border-film-300 hover:bg-film-50/30"
-            }
-          `}
+          )}
         >
           <Settings2
             size={20}
-            className={`shrink-0 ${recipe.preset === "custom" ? "text-film-600" : "text-[var(--muted)]"}`}
+            className={cn(
+              "shrink-0",
+              recipe.preset === "custom" ? "text-film-600" : "text-[var(--muted)]"
+            )}
           />
           <div className="min-w-0">
-            <p className={`text-xs font-heading font-bold ${recipe.preset === "custom" ? "text-film-700" : "text-[var(--text)]"}`}>
+            <p className={cn(
+              "text-xs font-heading font-bold",
+              recipe.preset === "custom" ? "text-film-700" : "text-[var(--text)]"
+            )}>
               Custom
             </p>
             <p className="text-[10px] text-[var(--muted)] mt-0.5">Set your own</p>

--- a/src/components/RotateControl.tsx
+++ b/src/components/RotateControl.tsx
@@ -2,6 +2,7 @@
 
 import { EditRecipe } from "@/lib/types";
 import { RotateCw } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 interface Props {
   recipe: EditRecipe;
@@ -20,14 +21,13 @@ export default function RotateControl({ recipe, onChange }: Props) {
             type="button"
             key={deg}
             onClick={() => onChange({ rotate: deg })}
-            className={`
-              flex-1 flex flex-col items-center gap-1.5 py-3 rounded-lg border text-xs transition-all duration-150
-              hover:scale-[1.03] active:scale-[0.97]
-              ${active
+            className={cn(
+              "flex-1 flex flex-col items-center gap-1.5 py-3 rounded-lg border text-xs transition-all duration-150",
+              "hover:scale-[1.03] active:scale-[0.97]",
+              active
                 ? "border-film-500 bg-film-50 text-film-700 font-heading font-semibold"
                 : "border-[var(--border)] text-[var(--muted)] hover:border-film-300 bg-[var(--surface)]"
-              }
-            `}
+            )}
           >
             <RotateCw size={15} style={{ transform: `rotate(${deg}deg)` }} className="transition-transform" />
             <span className="sr-only">Rotate video to {deg} degrees</span>

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -11,6 +11,7 @@ import AudioSpeedControl from "./AudioSpeedControl";
 import ExportSettings from "./ExportSettings";
 import ExportOverlay from "./ExportOverlay";
 import DownloadResult from "./DownloadResult";
+import { cn } from "@/lib/utils";
 import {
   Layers, Crop, Scissors, RotateCw, Volume2,
   SlidersHorizontal, Zap, AlertTriangle, Github
@@ -84,7 +85,10 @@ export default function VideoEditor() {
             </div>
 
             {file && (
-              <div className={`grid grid-cols-1 sm:grid-cols-2 gap-4 ${isProcessing ? "pointer-events-none opacity-50" : ""}`}>
+              <div className={cn(
+                "grid grid-cols-1 sm:grid-cols-2 gap-4",
+                isProcessing && "pointer-events-none opacity-50"
+              )}>
                 <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6">
                   <Section icon={<Scissors size={12} />} title="Trim" delay={50}>
                     <TrimControl recipe={recipe} onChange={updateRecipe} duration={duration} />
@@ -121,7 +125,10 @@ export default function VideoEditor() {
             )}
           </div>
 
-          <div className={`space-y-5 ${isProcessing ? "pointer-events-none opacity-50" : ""}`}>
+          <div className={cn(
+            "space-y-5",
+            isProcessing && "pointer-events-none opacity-50"
+          )}>
             <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6 animate-fade-in" style={{ animationDelay: "50ms" }}>
               <Section icon={<Layers size={12} />} title="Output size">
                 <PresetSelector recipe={recipe} onChange={updateRecipe} />
@@ -136,16 +143,15 @@ export default function VideoEditor() {
               type="button"
               onClick={handleExport}
               disabled={!file || isProcessing}
-              className={`
-                w-full flex items-center justify-center gap-3 py-5 rounded-xl
-                font-display text-2xl tracking-widest transition-all duration-200
-                ${file && !isProcessing
+              className={cn(
+                "w-full flex items-center justify-center gap-3 py-5 rounded-xl",
+                "font-display text-2xl tracking-widest transition-all duration-200",
+                file && !isProcessing
                   ? "bg-film-600 hover:bg-film-700 hover:scale-[1.01] text-white shadow-lg shadow-film-200 active:scale-[0.98] cursor-pointer"
                   : "bg-[var(--border)] text-[var(--muted)] cursor-not-allowed"
-                }
-              `}
+              )}
             >
-              <Zap size={20} className={file && !isProcessing ? "animate-pulse" : ""} />
+              <Zap size={20} className={cn(file && !isProcessing && "animate-pulse")} />
               {isProcessing ? "PROCESSING" : "EXPORT"}
             </button>
           </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
Closes #209

## Changes
- Created `src/lib/utils.ts` with `cn()` helper using clsx + tailwind-merge
- Replaced manual class string concatenations with `cn()` in:
  - PresetSelector.tsx
  - VideoEditor.tsx
  - AudioSpeedControl.tsx
  - FileUpload.tsx
  - FramingControl.tsx
  - RotateControl.tsx