### PR TITLE
fix memory leak issues and blob URL to prevent memory leaks(closes #5)

### DIFF
--- a/src/components/DownloadResult.tsx
+++ b/src/components/DownloadResult.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { ExportResult } from "@/lib/types";
 import { formatBytes } from "@/lib/ffmpeg";
 import { Download, RotateCcw } from "lucide-react";
@@ -13,6 +14,12 @@ interface Props {
 
 export default function DownloadResult({ result, onReset }: Props) {
   const filename = `reframe_${result.width}x${result.height}.${result.format}`;
+  // clears result without going through reset, revoke the URL
+    useEffect(() => {
+    return () => {
+      URL.revokeObjectURL(result.blobUrl);
+    };
+  }, [result.blobUrl]);
 
   return (
     <div className="p-5 bg-[var(--surface)] border border-[var(--border)] rounded-xl space-y-4">

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import { EditRecipe, ExportResult, ExportStatus, DEFAULT_RECIPE } from "@/lib/types";
 import { loadFFmpeg, exportVideo } from "@/lib/ffmpeg";
 
@@ -30,6 +30,19 @@ export function useVideoEditor() {
   const [result, setResult] = useState<ExportResult | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  // Track the active export blob URL so we can revoke it when it is replaced
+  // or when the hook unmounts — prevents the full video buffer from being held
+  // in memory indefinitely after each export.
+  const resultBlobRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resultBlobRef.current) {
+        URL.revokeObjectURL(resultBlobRef.current);
+      }
+    };
+  }, []);
+
   const updateRecipe = useCallback((patch: Partial<EditRecipe>) => {
     setRecipe((prev) => ({ ...prev, ...patch }));
   }, []);
@@ -58,6 +71,14 @@ export function useVideoEditor() {
       setStatus("exporting");
 
       const exportResult = await exportVideo(ffmpeg, file, recipe, setProgress);
+
+      // Revoke the previous blob URL before storing the new one so the old
+      // video buffer can be garbage-collected.
+      if (resultBlobRef.current) {
+        URL.revokeObjectURL(resultBlobRef.current);
+      }
+      resultBlobRef.current = exportResult.blobUrl;
+
       setResult(exportResult);
       setStatus("done");
     } catch (err) {
@@ -68,6 +89,11 @@ export function useVideoEditor() {
   }, [file, recipe]);
 
   const reset = useCallback(() => {
+    // Free the exported video buffer from memory before clearing state.
+    if (resultBlobRef.current) {
+      URL.revokeObjectURL(resultBlobRef.current);
+      resultBlobRef.current = null;
+    }
     setFile(null);
     setDuration(0);
     setRecipe(DEFAULT_RECIPE);


### PR DESCRIPTION
Closes #5

## Problem
Every exportVideo() call creates a blob URL via URL.createObjectURL()
that was never revoked. Exporting multiple videos pinned each full video
buffer in RAM until the tab was closed.

## Fix
Three escape paths are now closed:
- handleExport() — revokes previous URL before storing the new result
- reset() — revokes URL when user starts a fresh video
- useEffect cleanup — revokes on unmount as final safety net

DownloadResult also gets a useEffect cleanup as a backup.

## Files changed
- src/hooks/useVideoEditor.ts
- src/components/DownloadResult.tsx