### PR TITLE
feat: add keyboard shortcut for export

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { EditRecipe, ExportResult, ExportStatus, DEFAULT_RECIPE } from "@/lib/types";
 import { loadFFmpeg, exportVideo } from "@/lib/ffmpeg";
+
 
 function getVideoDuration(file: File): Promise<number> {
   return new Promise((resolve) => {
@@ -66,7 +67,24 @@ export function useVideoEditor() {
       setStatus("error");
     }
   }, [file, recipe]);
+  useEffect(() => {
+  const handleKeydown = (e: KeyboardEvent) => {
+    if (
+      (e.ctrlKey || e.metaKey) &&
+      e.key === "Enter" &&
+      file &&
+      status === "idle"
+    ) {
+      handleExport();
+    }
+  };
 
+  document.addEventListener("keydown", handleKeydown);
+
+  return () => {
+    document.removeEventListener("keydown", handleKeydown);
+  };
+}, [file, status, handleExport]);
   const reset = useCallback(() => {
     setFile(null);
     setDuration(0);


### PR DESCRIPTION
## Description

Implemented a keyboard shortcut to improve the export workflow and enhance user productivity.

## Changes Made

* Added `Ctrl + Enter` / `Cmd + Enter` shortcut support for triggering video export
* Ensured the shortcut only works when a file is loaded
* Prevented export triggering during an active export process
* Added proper event listener cleanup using `useEffect`

## Result

This enhancement improves accessibility and provides a faster workflow experience for keyboard users.

Closes #84 