### PR TITLE
Add semantic landmarks to root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,13 +25,25 @@ const dmSans = DM_Sans({
 
 export const metadata: Metadata = {
   title: "Reframe — Resize, trim, and export videos in your browser",
-  description: "Free, open-source video editor that runs entirely in your browser. No login, no uploads, no ads. Resize for any platform, trim, rotate, adjust speed, and export.",
+  description:
+    "Free, open-source video editor that runs entirely in your browser. No login, no uploads, no ads. Resize for any platform, trim, rotate, adjust speed, and export.",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`${bebasNeue.variable} ${syne.variable} ${dmSans.variable}`}>
-      <body>{children}</body>
+    <html
+      lang="en"
+      className={`${bebasNeue.variable} ${syne.variable} ${dmSans.variable}`}
+    >
+      <body>
+        <header role="banner" />
+
+        <main role="main" id="main-content">
+          {children}
+        </main>
+
+        <footer role="contentinfo" />
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary

Added semantic HTML landmark elements to the root layout to improve accessibility for screen reader users.

## Changes

- Added `<header role="banner">`
- Added `<main role="main" id="main-content">`
- Added `<footer role="contentinfo">`
- Avoided adding a navigation landmark because no navigation element currently exists in the source

## Accessibility

This creates a clearer document structure so assistive technology users can navigate the page by landmarks.

## Closes

Closes #166 