### PR TITLE
feat: add video format support hint to FileUpload component

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -92,10 +92,13 @@ export default function FileUpload({ onFileSelect, currentFile }: Props) {
       </div>
 
       <div className="flex items-center gap-2 px-4 py-2 bg-[var(--surface)] border border-[var(--border)] rounded-lg text-sm font-heading font-medium text-[var(--muted)]">
-        <FolderOpen size={14} />
+      <FolderOpen size={14} />
         MP4 / MOV / AVI / WebM
       </div>
-
+      <p className="text-xs text-gray-500">
+        Supports: MP4, MOV, AVI, MKV, WebM, and most video formats
+      </p>
+      
       <input
         ref={inputRef}
         type="file"


### PR DESCRIPTION
Closes #199

## Changes
- Added format support hint below the upload area in `FileUpload.tsx`
- Text reads: "Supports: MP4, MOV, AVI, MKV, WebM, and most video formats"