### PR TITLE
add tooltip and aria-label to New button

### DIFF
--- a/src/components/DownloadResult.tsx
+++ b/src/components/DownloadResult.tsx
@@ -51,6 +51,8 @@ export default function DownloadResult({ result, onReset }: Props) {
         </a>
         <button
           type="button"
+          title="Reset and upload a new video"
+          aria-label="Upload a new video"
           onClick={onReset}
           className="flex items-center gap-2 px-4 py-3 border border-[var(--border)] text-[var(--muted)] text-sm rounded-lg hover:bg-[var(--bg)] transition-colors"
         >


### PR DESCRIPTION
Fixed #85 by adding a descriptive tooltip and aria-label to the "New" button in DownloadResult.tsx

Changes:
-Added title="Reset and upload a new video" for the hover tooltip.
-Added aria-label="Upload a new video" for screen reader accessibility.

<img width="1889" height="918" alt="Screenshot 2026-05-14 150644" src="https://github.com/user-attachments/assets/4f534d24-a3c7-4c0e-b026-0d8e454e79c2" />
