### PR TITLE
fix(ui): format trim times as MM:SS instead of raw seconds

### DIFF
--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -2,6 +2,12 @@
 
 import { EditRecipe } from "@/lib/types";
 
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = (seconds % 60).toFixed(1);
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(4, "0")}`;
+}
+
 interface Props {
   recipe: EditRecipe;
   onChange: (patch: Partial<EditRecipe>) => void;
@@ -33,7 +39,7 @@ export default function TrimControl({ recipe, onChange, duration }: Props) {
       <div className="flex gap-3">
         <div className="flex-1">
           <label className="text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)] block mb-1.5">
-            Start (sec)
+            Start {duration > 0 ? formatTime(recipe.trimStart) : ""}
           </label>
           <input
             type="number"
@@ -44,11 +50,12 @@ export default function TrimControl({ recipe, onChange, duration }: Props) {
             onChange={(e) => handleStart(e.target.value)}
             className={inputClass}
             placeholder="0"
+            aria-label="Trim start time in seconds"
           />
         </div>
         <div className="flex-1">
           <label className="text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)] block mb-1.5">
-            End (sec)
+            End {recipe.trimEnd !== null ? formatTime(recipe.trimEnd) : ""}
           </label>
           <input
             type="number"
@@ -59,12 +66,13 @@ export default function TrimControl({ recipe, onChange, duration }: Props) {
             onChange={(e) => handleEnd(e.target.value)}
             className={inputClass}
             placeholder={duration > 0 ? `${duration.toFixed(1)}` : "full length"}
+            aria-label="Trim end time in seconds"
           />
         </div>
       </div>
       {duration > 0 && (
         <p className="text-[10px] text-[var(--muted)] font-heading">
-          Duration: {duration.toFixed(1)}s
+          Duration: {formatTime(duration)}
         </p>
       )}
     </div>


### PR DESCRIPTION
## Summary

Fixes #78 — Format trim times as MM:SS instead of raw seconds in TrimControl component.

## Root Cause

`TrimControl.tsx` displayed trim start/end times and video duration as raw decimal seconds (e.g., `65.5s`). While functional, this format is unintuitive for users accustomed to MM:SS time displays common in video editors.

## Fix

Added a `formatTime` helper function that converts seconds to `MM:SS.d` format, then updated:
- **Start label**: shows formatted time (e.g., `Start 00:10.0`)
- **End label**: shows formatted time (e.g., `End 01:30.5`)  
- **Duration footer**: shows formatted time (e.g., `Duration: 02:05.5`)
- **Input fields**: remain numeric for direct editing
- **Accessibility**: added `aria-label` attributes to both time inputs

## Changes

| File | Changes |
|------|---------|
| `src/components/TrimControl.tsx` | +11 -3 |

## Testing

- [x] Duration of 65.5s displays as `01:05.5`
- [x] Duration of 125.0s displays as `02:05.0`
- [x] Start label shows formatted time with zero-padded minutes
- [x] End label shows formatted time when trimEnd is set
- [x] Input fields still accept numeric values for editing
- [x] No TypeScript errors