### PR TITLE
feat: add export summary above export button

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -17,6 +17,7 @@ import ExportSettings from "./ExportSettings";
 import ExportOverlay from "./ExportOverlay";
 import DownloadResult from "./DownloadResult";
 import ImageOverlay from "./ImageOverlay"
+import { getPresetById } from "@/lib/presets";
 
 import { cn } from "@/lib/utils";
 import {
@@ -283,6 +284,22 @@ export default function VideoEditor() {
     () => (file ? URL.createObjectURL(file) : null),
     [file]
   );
+
+  const exportSummary = useMemo(() => {
+    const preset = getPresetById(recipe.preset);
+    const width = recipe.preset === "custom" ? recipe.customWidth : (preset?.width ?? recipe.customWidth);
+    const height = recipe.preset === "custom" ? recipe.customHeight : (preset?.height ?? recipe.customHeight);
+
+    const framingLabel = recipe.framing === "fit" ? "Fit" : "Fill";
+    const speedLabel = `${recipe.speed}× speed`;
+    const qualityLabel = recipe.quality <= 21
+      ? "High"
+      : recipe.quality <= 25
+      ? "Balanced"
+      : "Small file";
+
+    return `Exporting to ${width}×${height} ${recipe.format.toUpperCase()} • ${framingLabel} • ${speedLabel} • Quality: ${qualityLabel}`;
+  }, [recipe]);
 
   useEffect(() => {
     return () => {
@@ -656,6 +673,12 @@ export default function VideoEditor() {
             </div>
 
             <KeyboardShortcutsPanel />
+
+            {file && (
+              <p className="rounded-xl border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-xs text-[var(--muted)] leading-relaxed">
+                {exportSummary}
+              </p>
+            )}
 
             <button
               id="export-button"


### PR DESCRIPTION
## Related Issue
Closes #223 
## Overview
Added a concise one-line export summary above the Export button showing:
* resolution
* format
* framing mode
* speed
* quality
Example:
Exporting to 5120×1080 MP4 • Fit • 1× speed • Quality: Balanced
## Changes Made
* Generated export summary string from current recipe/state
* Displayed summary above Export button
* Ensured summary updates in real-time when settings change
* Improved styling to keep the summary concise and readable in a single line
## Validation
* Summary visible above Export button
* Updates correctly when export settings change
* Passed ESLint checks
* Passed production build successfully
## Program
Contribution made under GSSoC 2026.

## Screenshots
<img width="953" height="443" alt="Screenshot 2026-05-14 152636" src="https://github.com/user-attachments/assets/196f0e6d-dfbc-4cf2-bfc8-af3671d09a7d" />

<img width="954" height="441" alt="Screenshot 2026-05-14 152603" src="https://github.com/user-attachments/assets/21b3c864-58c4-4253-b3fa-283353bb0a0c" />


