### PR TITLE
fix:filename-as-title

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -4,6 +4,7 @@ import { useState, useCallback, useEffect } from "react";
 import { EditRecipe, ExportResult, ExportStatus, DEFAULT_RECIPE } from "@/lib/types";
 import { loadFFmpeg, exportVideo } from "@/lib/ffmpeg";
 
+const DEFAULT_TITLE = "Reframe — Resize, trim, and export videos in your browser";
 
 function getVideoDuration(file: File): Promise<number> {
   return new Promise((resolve) => {
@@ -67,24 +68,36 @@ export function useVideoEditor() {
       setStatus("error");
     }
   }, [file, recipe]);
+
   useEffect(() => {
-  const handleKeydown = (e: KeyboardEvent) => {
-    if (
-      (e.ctrlKey || e.metaKey) &&
-      e.key === "Enter" &&
-      file &&
-      status === "idle"
-    ) {
-      handleExport();
+    if (file) {
+      document.title = `Editing: ${file.name} | Reframe`;
+    } else {
+      document.title = DEFAULT_TITLE;
     }
-  };
+    return () => {
+      document.title = DEFAULT_TITLE;
+    };
+  }, [file]);
 
-  document.addEventListener("keydown", handleKeydown);
+  useEffect(() => {
+    const handleKeydown = (e: KeyboardEvent) => {
+      if (
+        (e.ctrlKey || e.metaKey) &&
+        e.key === "Enter" &&
+        file &&
+        status === "idle"
+      ) {
+        handleExport();
+      }
+    };
 
-  return () => {
-    document.removeEventListener("keydown", handleKeydown);
-  };
-}, [file, status, handleExport]);
+    document.addEventListener("keydown", handleKeydown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeydown);
+    };
+  }, [file, status, handleExport]);
   const reset = useCallback(() => {
     setFile(null);
     setDuration(0);


### PR DESCRIPTION
## Fixes #22 — Dynamic Browser Tab Title Based on Loaded Video

### Summary

This PR fixes the issue where the browser tab title always remained `Reframe`, even after loading a video file. The tab title now dynamically updates to reflect the currently loaded video, making it easier to distinguish between multiple open editor tabs.

### Changes Made

* Added `document.title` updates inside `src/hooks/useVideoEditor.ts`
* When a video is loaded:

  * Tab title becomes:

    ```text
    Editing: {filename} | Reframe
    ```
* When no video is loaded:

  * Title resets back to:

    ```text
    Reframe
    ```

### Example

Before:

```text
Reframe
```

After loading `demo.mp4`:

```text
Editing: demo.mp4 | Reframe
```

### Why This Fix?

Users working with multiple tabs and multiple videos could not identify which tab corresponded to which file because all tabs had the same static title.

This improves:

* multi-tab workflow usability
* navigation clarity
* overall UX

### Files Modified

* `src/hooks/useVideoEditor.ts`

### Testing

* Opened multiple tabs with different videos
* Verified each tab updates independently with the correct filename
* Confirmed title resets properly when no file is active

Closes #22