### PR TITLE
Add Share on X button to DownloadResult

### DIFF
--- a/src/components/DownloadResult.tsx
+++ b/src/components/DownloadResult.tsx
@@ -2,9 +2,12 @@
 
 import { ExportResult } from "@/lib/types";
 import { formatBytes } from "@/lib/ffmpeg";
-import { Download, RotateCcw } from "lucide-react";
+import { Download, RotateCcw, Share2 } from "lucide-react";
 import LottiePlayer from "./LottiePlayer";
 import successAnim from "@/lib/lottie/success.json";
+
+const SHARE_TWEET_TEXT =
+  "I just edited my video with @reframevideo — free browser-based video editor! Check it out: https://github.com/magic-peach/reframe";
 
 interface Props {
   result: ExportResult;
@@ -13,6 +16,7 @@ interface Props {
 
 export default function DownloadResult({ result, onReset }: Props) {
   const filename = `reframe_${result.width}x${result.height}.${result.format}`;
+  const shareHref = `https://x.com/intent/tweet?text=${encodeURIComponent(SHARE_TWEET_TEXT)}`;
 
   return (
     <div className="p-5 bg-[var(--surface)] border border-[var(--border)] rounded-xl space-y-4">
@@ -37,11 +41,11 @@ export default function DownloadResult({ result, onReset }: Props) {
         </div>
       </div>
 
-      <div className="flex gap-2">
+      <div className="flex flex-wrap gap-2">
         <a
           href={result.blobUrl}
           download={filename}
-          className="flex-1 flex items-center justify-center gap-2 py-3 bg-film-600 hover:bg-film-700 text-white text-sm font-heading font-bold uppercase tracking-wide rounded-lg transition-all hover:scale-[1.01] active:scale-[0.99]"
+          className="flex-1 min-w-[10rem] flex items-center justify-center gap-2 py-3 bg-film-600 hover:bg-film-700 text-white text-sm font-heading font-bold uppercase tracking-wide rounded-lg transition-all hover:scale-[1.01] active:scale-[0.99]"
         >
           <Download size={15} />
           Download {result.format.toUpperCase()}
@@ -53,6 +57,16 @@ export default function DownloadResult({ result, onReset }: Props) {
           <RotateCcw size={14} />
           New
         </button>
+        <a
+          href={shareHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Share on X (opens in a new tab)"
+          className="flex-1 min-w-[10rem] flex items-center justify-center gap-2 py-3 border border-[var(--border)] text-[var(--text)] text-sm font-heading font-bold uppercase tracking-wide rounded-lg hover:bg-[var(--bg)] transition-colors"
+        >
+          <Share2 size={15} aria-hidden="true" />
+          Share on X
+        </a>
       </div>
     </div>
   );


### PR DESCRIPTION
* Added a new “Share on X” button in `src/components/DownloadResult.tsx`
* Imported and used the `Share2` icon from `lucide-react`
* Added pre-filled tweet text with project link and mention
* Generated Twitter/X share URL using `encodeURIComponent`
* Added accessibility support with `aria-label`
* Used `target="_blank"` and `rel="noopener noreferrer"` for secure external navigation
* Updated button layout with responsive `flex-wrap` styling
* Matched the new button styling with existing UI components

Closes #190



<img width="732" height="245" alt="image" src="https://github.com/user-attachments/assets/392ec0c9-ff5a-4a1f-a8ee-c37aa9f6649a" />

