### PR TITLE
Add custom favicon to app

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Reframe">
+  <rect width="32" height="32" rx="8" fill="#12100e"/>
+  <rect
+    x="6"
+    y="7"
+    width="20"
+    height="18"
+    rx="2.5"
+    fill="none"
+    stroke="#e63946"
+    stroke-width="1.75"
+  />
+  <circle cx="6.8" cy="11" r="0.85" fill="#e63946"/>
+  <circle cx="6.8" cy="16" r="0.85" fill="#e63946"/>
+  <circle cx="6.8" cy="21" r="0.85" fill="#e63946"/>
+  <circle cx="25.2" cy="11" r="0.85" fill="#e63946"/>
+  <circle cx="25.2" cy="16" r="0.85" fill="#e63946"/>
+  <circle cx="25.2" cy="21" r="0.85" fill="#e63946"/>
+  <path fill="#e63946" d="M14 11.5L21 16L14 20.5Z"/>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,6 +26,10 @@ const dmSans = DM_Sans({
 export const metadata: Metadata = {
   title: "Reframe — Resize, trim, and export videos in your browser",
   description: "Free, open-source video editor that runs entirely in your browser. No login, no uploads, no ads. Resize for any platform, trim, rotate, adjust speed, and export.",
+  icons: {
+    icon: [{ url: "/favicon.svg", type: "image/svg+xml" }],
+    shortcut: "/favicon.svg",
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
Fixes #55
### What was added

#### `public/favicon.svg`
- Added a custom SVG favicon matching the Reframe brand.
- Uses dark background `#12100e`.
- Uses accent color `#e63946`.
- Designed with a film/video inspired icon and play button for clarity even at small sizes.

#### `src/app/layout.tsx`
- Updated Next.js metadata icons configuration.
- Added favicon reference so it appears correctly in browser tabs.

<img width="296" height="51" alt="image" src="https://github.com/user-attachments/assets/466836ac-0acc-42f3-9834-6b89d106bc2a" />
<br>

```ts
icons: {
  icon: [{ url: "/favicon.svg", type: "image/svg+xml" }],
  shortcut: "/favicon.svg",
}



