### PR TITLE
Add public/robots.txt for SEO

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://your-domain.com/sitemap.xml
+


### PR DESCRIPTION
Adds a standard robots.txt file to the public/ directory to allow search engine crawling and proper indexing of the site.

This improves SEO for the project website.

Fixes #45