### PR TITLE
Add inputMode=numeric to width/height inputs

### DIFF
--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -93,6 +93,7 @@ export default function PresetSelector({ recipe, onChange }: Props) {
             </label>
             <input
               type="number"
+              inputMode="numeric"
               min={16}
               max={7680}
               step={2}
@@ -108,6 +109,7 @@ export default function PresetSelector({ recipe, onChange }: Props) {
             </label>
             <input
               type="number"
+              inputMode="numeric"
               min={16}
               max={7680}
               step={2}


### PR DESCRIPTION
Improves mobile accessibility by adding inputMode=numeric to the custom width and height number inputs in PresetSelector. This tells mobile browsers to show a numeric keypad when focused.

Fixes #51