### PR TITLE
perf: add preconnect and dns-prefetch for FFmpeg CDN in layout.tsx

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,6 +31,10 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={`${bebasNeue.variable} ${syne.variable} ${dmSans.variable}`}>
+      <head>
+        <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+        <link rel="dns-prefetch" href="https://cdn.jsdelivr.net" />
+      </head>
       <body>
         <header>
           <h1>Reframe</h1>


### PR DESCRIPTION
Closes #54

### What I did
Added preconnect and dns-prefetch link hints for the FFmpeg CDN (cdn.jsdelivr.net) in layout.tsx. This pre-establishes the connection before a user clicks Export, reducing latency when downloading FFmpeg WASM for the first time.

### Changes
- Added link rel="preconnect" for cdn.jsdelivr.net
- Added link rel="dns-prefetch" as fallback

No other files changed.