### PR TITLE
fix: revoke blob URLs to prevent memory leak on export failure and reset

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -54,6 +54,7 @@ export function useVideoEditor() {
       setStatus("loading-engine");
       setProgress(0);
       setError(null);
+      if (result?.blobUrl) URL.revokeObjectURL(result.blobUrl);
       setResult(null);
 
       const ffmpeg = await loadFFmpeg();
@@ -67,7 +68,7 @@ export function useVideoEditor() {
       setError(err instanceof Error ? err.message : "something went wrong");
       setStatus("error");
     }
-  }, [file, recipe]);
+  }, [file, recipe, result]);
 
   useEffect(() => {
     if (file) {
@@ -98,7 +99,8 @@ export function useVideoEditor() {
       document.removeEventListener("keydown", handleKeydown);
     };
   }, [file, status, handleExport]);
-  const reset = useCallback(() => {
+const reset = useCallback(() => {
+    if (result?.blobUrl) URL.revokeObjectURL(result.blobUrl);
     setFile(null);
     setDuration(0);
     setRecipe(DEFAULT_RECIPE);
@@ -106,7 +108,7 @@ export function useVideoEditor() {
     setProgress(0);
     setResult(null);
     setError(null);
-  }, []);
+  }, [result]);
 
   return {
     file,

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -145,7 +145,10 @@ export async function exportVideo(
     ];
 
     const fallbackCode = await ffmpeg.exec(fallbackArgs);
-    if (fallbackCode !== 0) throw new Error("Export failed");
+    if (fallbackCode !== 0) {
+      await ffmpeg.deleteFile(inputName);
+      throw new Error("Export failed");
+    }
 
     const data = await ffmpeg.readFile(webmOutput);
     const blob = new Blob([new Uint8Array(data as Uint8Array)], { type: "video/webm" });


### PR DESCRIPTION
Closes #7

### Description
Fixed memory leak where blob URLs were never revoked after export failure or reset.

### Related Issue
#7

### Type of Change
- [x] Bug fix

### What I did
- ffmpeg.ts: clean up input file before throwing when fallback export fails
- useVideoEditor.ts: revoke previous blob URL in reset() and before starting a new export in handleExport()
- Updated dependency arrays for both

No other files changed.

### Checklist
- [x] My changes follow the project's contribution guidelines
- [x] I have linked the related issue
- [x] No unrelated files changed