### PR TITLE
test: add unit tests for formatBytes utility function

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,11 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} **/
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.test.ts', '**/?(*.)+(spec|test).ts'],
+  transform: {
+    '^.+\.ts$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@ffmpeg/ffmpeg": "^0.12.10",
@@ -28,6 +30,9 @@
     "eslint-config-next": "^15.1.8",
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.12",
+    "ts-jest": "^29.1.2"
   }
 }

--- a/src/lib/__tests__/ffmpeg.test.ts
+++ b/src/lib/__tests__/ffmpeg.test.ts
@@ -1,0 +1,24 @@
+import { formatBytes } from '../ffmpeg';
+
+describe('formatBytes', () => {
+  it('should format bytes less than 1 MB as KB', () => {
+    expect(formatBytes(512)).toBe('0.5 KB');
+    expect(formatBytes(1024)).toBe('1.0 KB');
+    expect(formatBytes(1536)).toBe('1.5 KB');
+    expect(formatBytes(512 * 1024)).toBe('512.0 KB');
+  });
+
+  it('should format bytes greater than or equal to 1 MB as MB', () => {
+    expect(formatBytes(1024 * 1024)).toBe('1.0 MB');
+    expect(formatBytes(2 * 1024 * 1024)).toBe('2.0 MB');
+    expect(formatBytes(10.5 * 1024 * 1024)).toBe('10.5 MB');
+  });
+
+  it('should handle edge case of 0 bytes', () => {
+    expect(formatBytes(0)).toBe('0.0 KB');
+  });
+
+  it('should handle very large files', () => {
+    expect(formatBytes(1024 * 1024 * 1024)).toBe('1024.0 MB');
+  });
+});


### PR DESCRIPTION
## Summary\nAdded comprehensive unit tests for the formatBytes utility function along with Jest test setup.\n\n## Changes\n- Added src/lib/__tests__/ffmpeg.test.ts with 4 test cases\n- Created jest.config.js with ts-jest configuration\n- Updated package.json with test scripts and dev dependencies (jest, @types/jest, ts-jest)\n\n## Test Coverage\n- KB formatting for files < 1 MB\n- MB formatting for files >= 1 MB\n- Edge case: 0 bytes\n- Large file: 1 GB (1024 MB)\n\n## Related Issue\nCloses #231