### PR TITLE
feat: add disabled state styling to Export button

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -146,12 +146,13 @@ export default function VideoEditor() {
               type="button"
               onClick={handleExport}
               disabled={!file || isProcessing}
+              title={!file ? "Select a video file to enable export" : ""}
               className={cn(
                 "w-full flex items-center justify-center gap-3 py-5 rounded-xl",
                 "font-display text-2xl tracking-widest transition-all duration-200",
                 file && !isProcessing
                   ? "bg-film-600 hover:bg-film-700 hover:scale-[1.01] text-white shadow-lg shadow-film-200 active:scale-[0.98] cursor-pointer"
-                  : "bg-[var(--border)] text-[var(--muted)] cursor-not-allowed"
+                  : "bg-[var(--border)] text-[var(--muted)] cursor-not-allowed opacity-60 grayscale"
               )}
             >
               <Zap size={20} className={cn(file && !isProcessing && "animate-pulse")} />


### PR DESCRIPTION
## Summary\nEnhanced the Export button's disabled state with improved visual feedback and accessibility.\n\n## Changes\n- Added opacity-60 and grayscale filter to disabled state\n- Added HTML title tooltip: 'Select a video file to enable export'\n- Improves UX by making it clearer why the button is disabled\n\n## Visual Changes\nBefore: Button had muted colors but lacked visual distinction\nAfter: Disabled button is now semi-transparent (opacity-60) and grayscale\n\n## Related Issue\nCloses #235