### PR TITLE
fix: normalize error message capitalization

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -64,7 +64,7 @@ export function useVideoEditor() {
       setStatus("done");
     } catch (err) {
       console.error("export failed:", err);
-      setError(err instanceof Error ? err.message : "something went wrong");
+      setError(err instanceof Error ? err.message : "Something went wrong");
       setStatus("error");
     }
   }, [file, recipe]);


### PR DESCRIPTION
## Summary\nStandardized error message capitalization for consistency.\n\n## Changes\n- 'something went wrong' → 'Something went wrong'\n\n## Related Issue\nCloses #226