### PR TITLE
feat: add Ctrl+O shortcut to open file picker

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Film, FolderOpen } from "lucide-react";
 import LottiePlayer from "./LottiePlayer";
 import uploadAnim from "@/lib/lottie/upload.json";
@@ -19,6 +19,18 @@ function fmt(bytes: number) {
 export default function FileUpload({ onFileSelect, currentFile }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [dragging, setDragging] = useState(false);
+
+  useEffect(() => {
+    const handleOpenShortcut = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "o") {
+        e.preventDefault();
+        inputRef.current?.click();
+      }
+    };
+
+    document.addEventListener("keydown", handleOpenShortcut);
+    return () => document.removeEventListener("keydown", handleOpenShortcut);
+  }, []);
 
   const handleFile = (file: File) => {
     if (!file.type.startsWith("video/")) return;
@@ -46,7 +58,7 @@ export default function FileUpload({ onFileSelect, currentFile }: Props) {
           onClick={() => inputRef.current?.click()}
           className="text-xs font-heading font-semibold text-film-600 hover:text-film-700 uppercase tracking-wide shrink-0 transition-colors"
         >
-          Change
+          Change <span className="text-[var(--muted)]">(Ctrl+O / Cmd+O)</span>
         </button>
         <input
           ref={inputRef}
@@ -87,6 +99,9 @@ export default function FileUpload({ onFileSelect, currentFile }: Props) {
         </p>
         <p className="text-sm text-[var(--muted)] mt-1">
           or click to browse
+        </p>
+        <p className="text-xs text-[var(--muted)] mt-2 font-heading">
+          Ctrl+O / Cmd+O
         </p>
       </div>
 


### PR DESCRIPTION
Closes magic-peach/reframe#217

## Summary
- Added Ctrl+O / Cmd+O keyboard shortcut to open the video file picker
- Prevented the browser default open-file behavior
- Documented the shortcut in the upload UI

## Testing
- Ran the app locally with `bun run dev`
- Verified `Ctrl+O` opens the file picker
- Verified selecting a video loads it in the editor
- Verified the shortcut is documented in the upload UI

## Screenshot
![Ctrl+O shortcut documented in upload area]
<img width="612" height="407" alt="Screenshot 2026-05-15 114321" src="https://github.com/user-attachments/assets/82205723-5f4d-43b9-8dcc-52a72b6b5b34" />

