### PR TITLE
feat: add escape cancel for export overlay

### DIFF
--- a/src/components/ExportOverlay.tsx
+++ b/src/components/ExportOverlay.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { ExportStatus } from "@/lib/types";
 import LottiePlayer from "./LottiePlayer";
 import spinnerAnim from "@/lib/lottie/spinner.json";
@@ -7,13 +8,30 @@ import spinnerAnim from "@/lib/lottie/spinner.json";
 interface Props {
   status: ExportStatus;
   progress: number;
+  onCancel: () => void;
 }
 
-export default function ExportOverlay({ status, progress }: Props) {
+export default function ExportOverlay({ status, progress, onCancel }: Props) {
   const visible = status === "loading-engine" || status === "exporting";
-  if (!visible) return null;
-
   const isLoading = status === "loading-engine";
+
+  useEffect(() => {
+    if (!visible) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onCancel();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [visible, onCancel]);
+
+  if (!visible) return null;
 
   return (
     <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-white/95 backdrop-blur-sm">
@@ -47,6 +65,9 @@ export default function ExportOverlay({ status, progress }: Props) {
             </div>
             <p className="text-xs font-heading font-semibold text-[var(--muted)]">
               {progress}%
+            </p>
+            <p className="text-gray-500 text-xs mt-4">
+              Press Escape to cancel
             </p>
           </div>
         )}

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -46,14 +46,14 @@ export default function VideoEditor() {
   const {
     file, duration, recipe, status, progress,
     result, error, updateRecipe,
-    handleFileSelect, handleExport, reset,
+    handleFileSelect, handleExport, cancelExport, reset,
   } = useVideoEditor();
 
   const isProcessing = status === "loading-engine" || status === "exporting";
 
   return (
     <div className="min-h-screen relative flex flex-col" style={{ background: "var(--bg)" }}>
-      <ExportOverlay status={status} progress={progress} />
+      <ExportOverlay status={status} progress={progress} onCancel={cancelExport} />
 
       <div className="max-w-6xl mx-auto px-4 py-8 pb-6 flex-1 w-full">
 

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { EditRecipe, ExportResult, ExportStatus, DEFAULT_RECIPE } from "@/lib/types";
-import { loadFFmpeg, exportVideo } from "@/lib/ffmpeg";
+import { loadFFmpeg, exportVideo, terminateFFmpeg } from "@/lib/ffmpeg";
 
 const DEFAULT_TITLE = "Reframe — Resize, trim, and export videos in your browser";
 
@@ -31,6 +31,8 @@ export function useVideoEditor() {
   const [progress, setProgress] = useState(0);
   const [result, setResult] = useState<ExportResult | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const exportAbortControllerRef = useRef<AbortController | null>(null);
+  const exportCancelledRef = useRef(false);
 
   const updateRecipe = useCallback((patch: Partial<EditRecipe>) => {
     setRecipe((prev) => ({ ...prev, ...patch }));
@@ -50,22 +52,42 @@ export function useVideoEditor() {
   const handleExport = useCallback(async () => {
     if (!file) return;
 
+    const abortController = new AbortController();
+    exportAbortControllerRef.current = abortController;
+    exportCancelledRef.current = false;
+
     try {
       setStatus("loading-engine");
       setProgress(0);
       setError(null);
       setResult(null);
 
-      const ffmpeg = await loadFFmpeg();
+      const ffmpeg = await loadFFmpeg(abortController.signal);
+      if (exportCancelledRef.current) return;
+
       setStatus("exporting");
 
-      const exportResult = await exportVideo(ffmpeg, file, recipe, setProgress);
+      const exportResult = await exportVideo(
+        ffmpeg,
+        file,
+        recipe,
+        setProgress,
+        abortController.signal
+      );
+      if (exportCancelledRef.current) return;
+
       setResult(exportResult);
       setStatus("done");
     } catch (err) {
+      if (exportCancelledRef.current) return;
+
       console.error("export failed:", err);
       setError(err instanceof Error ? err.message : "something went wrong");
       setStatus("error");
+    } finally {
+      if (exportAbortControllerRef.current === abortController) {
+        exportAbortControllerRef.current = null;
+      }
     }
   }, [file, recipe]);
 
@@ -98,6 +120,17 @@ export function useVideoEditor() {
       document.removeEventListener("keydown", handleKeydown);
     };
   }, [file, status, handleExport]);
+
+  const cancelExport = useCallback(() => {
+    exportCancelledRef.current = true;
+    exportAbortControllerRef.current?.abort();
+    exportAbortControllerRef.current = null;
+    terminateFFmpeg();
+    setStatus("idle");
+    setProgress(0);
+    setError(null);
+  }, []);
+
   const reset = useCallback(() => {
     setFile(null);
     setDuration(0);
@@ -119,6 +152,7 @@ export function useVideoEditor() {
     updateRecipe,
     handleFileSelect,
     handleExport,
+    cancelExport,
     reset,
   };
 }

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -8,17 +8,31 @@ const CORE_BASE_URL =
 
 let ffmpegInstance: FFmpeg | null = null;
 
-export async function loadFFmpeg(): Promise<FFmpeg> {
-  if (ffmpegInstance) return ffmpegInstance;
+export async function loadFFmpeg(signal?: AbortSignal): Promise<FFmpeg> {
+  if (ffmpegInstance?.loaded) return ffmpegInstance;
 
-  const ffmpeg = new FFmpeg();
-  await ffmpeg.load({
-    coreURL: await toBlobURL(`${CORE_BASE_URL}/ffmpeg-core.js`, "text/javascript"),
-    wasmURL: await toBlobURL(`${CORE_BASE_URL}/ffmpeg-core.wasm`, "application/wasm"),
-  });
-
+  const ffmpeg = ffmpegInstance ?? new FFmpeg();
   ffmpegInstance = ffmpeg;
-  return ffmpeg;
+
+  try {
+    await ffmpeg.load({
+      coreURL: await toBlobURL(`${CORE_BASE_URL}/ffmpeg-core.js`, "text/javascript"),
+      wasmURL: await toBlobURL(`${CORE_BASE_URL}/ffmpeg-core.wasm`, "application/wasm"),
+    }, { signal });
+
+    return ffmpeg;
+  } catch (err) {
+    if (ffmpegInstance === ffmpeg) {
+      ffmpegInstance = null;
+    }
+
+    throw err;
+  }
+}
+
+export function terminateFFmpeg() {
+  ffmpegInstance?.terminate();
+  ffmpegInstance = null;
 }
 
 function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number): string {
@@ -75,7 +89,8 @@ export async function exportVideo(
   ffmpeg: FFmpeg,
   file: File,
   recipe: EditRecipe,
-  onProgress: (percent: number) => void
+  onProgress: (percent: number) => void,
+  signal?: AbortSignal
 ): Promise<ExportResult> {
   let targetW: number, targetH: number;
   if (recipe.preset === "custom") {
@@ -95,7 +110,7 @@ export async function exportVideo(
   const inputName = `input.${ext}`;
   const outputName = "output.mp4";
 
-  await ffmpeg.writeFile(inputName, await fetchFile(file));
+  await ffmpeg.writeFile(inputName, await fetchFile(file), { signal });
 
   ffmpeg.on("progress", ({ progress }) => {
     onProgress(Math.min(99, Math.round(progress * 100)));
@@ -129,7 +144,7 @@ export async function exportVideo(
 
   args.push(outputName);
 
-  const exitCode = await ffmpeg.exec(args);
+  const exitCode = await ffmpeg.exec(args, undefined, { signal });
 
   // fall back to webm if libx264 isnt available
   if (exitCode !== 0) {
@@ -144,13 +159,13 @@ export async function exportVideo(
       webmOutput,
     ];
 
-    const fallbackCode = await ffmpeg.exec(fallbackArgs);
+    const fallbackCode = await ffmpeg.exec(fallbackArgs, undefined, { signal });
     if (fallbackCode !== 0) throw new Error("Export failed");
 
-    const data = await ffmpeg.readFile(webmOutput);
+    const data = await ffmpeg.readFile(webmOutput, undefined, { signal });
     const blob = new Blob([new Uint8Array(data as Uint8Array)], { type: "video/webm" });
-    await ffmpeg.deleteFile(inputName);
-    await ffmpeg.deleteFile(webmOutput);
+    await ffmpeg.deleteFile(inputName, { signal });
+    await ffmpeg.deleteFile(webmOutput, { signal });
 
     onProgress(100);
     return {
@@ -162,10 +177,10 @@ export async function exportVideo(
     };
   }
 
-  const data = await ffmpeg.readFile(outputName);
+  const data = await ffmpeg.readFile(outputName, undefined, { signal });
   const blob = new Blob([new Uint8Array(data as Uint8Array)], { type: "video/mp4" });
-  await ffmpeg.deleteFile(inputName);
-  await ffmpeg.deleteFile(outputName);
+  await ffmpeg.deleteFile(inputName, { signal });
+  await ffmpeg.deleteFile(outputName, { signal });
 
   onProgress(100);
   return {


### PR DESCRIPTION
Closes #210

## Summary
- Added a "Press Escape to cancel" hint below the export progress bar
- Wired the Escape key to cancel the active export
- Aborts/terminates the active FFmpeg export and resets export state cleanly
- Fixed rebased build issues so the branch compiles successfully

## Testing
- Ran `npm.cmd run lint`
- Ran `npx.cmd tsc --noEmit`
- Ran `npm.cmd run build`
- Manually tested export overlay cancellation with Escape

## Screenshot
<img width="652" height="403" alt="Screenshot 2026-05-15 135647" src="https://github.com/user-attachments/assets/e4d22932-480c-41bd-a524-e1dc7b787f3c" />
