### PR TITLE
fix(video-preview): prevent race conditions and memory leaks on rapid file switching

### DIFF
--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -8,19 +8,60 @@ interface Props {
 
 export default function VideoPreview({ file }: Props) {
   const videoRef = useRef<HTMLVideoElement>(null);
+
+  const lastId = useRef(0);
   const urlRef = useRef<string | null>(null);
+
+  // stable handler reference (avoids re-attaching logic unnecessarily)
+  const onLoadedRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     if (!file) return;
 
-    // revoke previous object url to avoid memory leaks
-    if (urlRef.current) URL.revokeObjectURL(urlRef.current);
+    const id = ++lastId.current;
     const url = URL.createObjectURL(file);
+
+    // cleanup previous object URL safely
+    if (urlRef.current) {
+      URL.revokeObjectURL(urlRef.current);
+    }
     urlRef.current = url;
-    if (videoRef.current) videoRef.current.src = url;
+
+    const video = videoRef.current;
+    if (!video) return;
+
+    video.src = url;
+    video.load();
+
+    // define handler once per effect run
+    const handleLoaded = () => {
+      if (lastId.current !== id) return;
+      video.play().catch(() => {});
+    };
+
+    onLoadedRef.current = handleLoaded;
+
+    video.addEventListener("loadeddata", handleLoaded);
 
     return () => {
-      if (urlRef.current) URL.revokeObjectURL(urlRef.current);
+      // cleanup event listener safely
+      if (onLoadedRef.current) {
+        video.removeEventListener("loadeddata", onLoadedRef.current);
+        onLoadedRef.current = null;
+      }
+
+      // stop playback safely
+      if (video) {
+        video.pause();
+        video.removeAttribute("src");
+        video.load();
+      }
+
+      // revoke only if still current
+      if (urlRef.current === url) {
+        URL.revokeObjectURL(urlRef.current);
+        urlRef.current = null;
+      }
     };
   }, [file]);
 


### PR DESCRIPTION
### **Overview**

This PR improves the stability of VideoPreview.tsx by fixing race conditions and memory leaks that occur during rapid file switching. It ensures the video preview remains consistent and safe even when users quickly upload multiple files in succession.

### **Changes Made**

- Added request ID–based stale update prevention to handle rapid file switching safely
- Improved ObjectURL lifecycle management to prevent memory leaks
- Added safe handling of videoRef.current to avoid null or unmounted element errors
- Implemented proper cleanup for async loadeddata events to prevent stale playback
- Ensured only the latest uploaded file controls the video preview
- Added video state reset during cleanup to maintain consistent behavior