### PR TITLE
feat: add video preview loading skeleton

### DIFF
--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface Props {
   file: File | null;
@@ -9,9 +9,12 @@ interface Props {
 export default function VideoPreview({ file }: Props) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const urlRef = useRef<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     if (!file) return;
+
+    setIsLoading(true);
 
     // revoke previous object url to avoid memory leaks
     if (urlRef.current) URL.revokeObjectURL(urlRef.current);
@@ -27,12 +30,21 @@ export default function VideoPreview({ file }: Props) {
   if (!file) return null;
 
   return (
-    <div className="w-full rounded-lg overflow-hidden bg-[#0a0a0a] aspect-video">
+    <div className="relative w-full rounded-lg overflow-hidden bg-[#0a0a0a] aspect-video">
+      {isLoading && (
+        <div
+          className="absolute inset-0 animate-pulse bg-gray-700 rounded-xl transition-opacity duration-300"
+          aria-label="Loading video preview"
+        />
+      )}
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <video
         ref={videoRef}
         controls
-        className="w-full h-full object-contain"
+        className={`w-full h-full object-contain transition-opacity duration-300 ${
+          isLoading ? "opacity-0" : "opacity-100"
+        }`}
+        onLoadedData={() => setIsLoading(false)}
         playsInline
       />
     </div>


### PR DESCRIPTION
## Summary

Closes #218

Added a loading skeleton to the video preview while the selected video is loading.

## Changes

- Added `isLoading` state in `VideoPreview.tsx`
- Showed a pulsing skeleton placeholder while the video loads
- Hid the skeleton using the video `onLoadedData` event
- Added a smooth opacity transition from skeleton to video

## Testing

- Ran `npm.cmd run lint`
- Ran `npx.cmd tsc --noEmit`
