### PR TITLE
fix: normalize error message capitalization

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -63,7 +63,7 @@ export function useVideoEditor() {
       setStatus("done");
     } catch (err) {
       console.error("export failed:", err);
-      setError(err instanceof Error ? err.message : "something went wrong");
+      setError(err instanceof Error ? err.message : "Something went wrong.");
       setStatus("error");
     }
   }, [file, recipe]);


### PR DESCRIPTION
What changed

Normalized error message in useVideoEditor.ts so all messages:

- Start with uppercase letters
- Are grammatically consistent
- End with proper punctuation

Why

This improves consistency and readability of error handling across the application.

Closes #226 