### PR TITLE
fix: prevent body scroll when ExportOverlay is visible

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,6 +26,12 @@ const dmSans = DM_Sans({
 export const metadata: Metadata = {
   title: "Reframe — Resize, trim, and export videos in your browser",
   description: "Free, open-source video editor that runs entirely in your browser. No login, no uploads, no ads. Resize for any platform, trim, rotate, adjust speed, and export.",
+  openGraph: {
+    title: "Reframe — Free Browser Video Editor",
+    description: "Resize, trim, rotate and convert videos in your browser. No uploads. No login. No ads.",
+    type: "website",
+    url: "https://reframe.video",
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,13 +8,6 @@ import { ThemeToggle } from "@/components/ThemeToggle";
 export const metadata: Metadata = {
   title: "Reframe — Resize, trim, and export videos in your browser",
   description: "Free, open-source video editor that runs entirely in your browser. No login, no uploads, no ads. Resize for any platform, trim, rotate, adjust speed, and export.",
-<<<<<<< HEAD
-  openGraph: {
-    title: "Reframe — Free Browser Video Editor",
-    description: "Resize, trim, rotate and convert videos in your browser. No uploads. No login. No ads.",
-    type: "website",
-    url: "https://reframe.video",
-=======
    keywords: [
     "video editor",
     "browser video editor",
@@ -43,7 +36,6 @@ export const metadata: Metadata = {
   icons: {
     icon: [{ url: "/favicon.svg", type: "image/svg+xml" }],
     shortcut: "/favicon.svg",
->>>>>>> upstream/main
   },
 };
 

--- a/src/components/ExportOverlay.tsx
+++ b/src/components/ExportOverlay.tsx
@@ -1,11 +1,7 @@
 "use client";
-<<<<<<< HEAD
-import { useEffect } from "react";
-=======
 
 import FocusTrap from "focus-trap-react";
 import { useEffect, useRef, useCallback } from "react";
->>>>>>> upstream/main
 import { ExportStatus } from "@/lib/types";
 import LottiePlayer from "./LottiePlayer";
 import spinnerAnim from "@/lib/lottie/spinner.json";
@@ -18,42 +14,34 @@ interface Props {
 
 export default function ExportOverlay({ status, progress, onCancel }: Props) {
   const visible = status === "loading-engine" || status === "exporting";
-<<<<<<< HEAD
-  useEffect(() => {
-  if (visible) {
-    document.body.style.overflow = "hidden";
-  } else {
-    document.body.style.overflow = "";
-  }
-  return () => {
-    document.body.style.overflow = "";
-  };
-}, [visible]);
-  if (!visible) return null;
-
-=======
->>>>>>> upstream/main
-  const isLoading = status === "loading-engine";
-
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const focusAnchorRef = useRef<HTMLDivElement | null>(null);
-const handleKeyDown = useCallback((e: KeyboardEvent) => {
-  if (e.key === "Escape") {
-    onCancel?.();
-  }
-}, [onCancel]);
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      onCancel?.();
+    }
+  }, [onCancel]);
+
   useEffect(() => {
-  if (!visible) return;
+    if (visible) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [visible]);
 
-  window.addEventListener("keydown", handleKeyDown);
-
-  previousFocusRef.current =
-    document.activeElement as HTMLElement;
-
-  return () => {
-    window.removeEventListener("keydown", handleKeyDown);
-  };
-}, [visible, handleKeyDown]);
+  useEffect(() => {
+    if (!visible) return;
+    window.addEventListener("keydown", handleKeyDown);
+    previousFocusRef.current = document.activeElement as HTMLElement;
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [visible, handleKeyDown]);
 
   useEffect(() => {
     if (!visible && previousFocusRef.current) {
@@ -63,108 +51,4 @@ const handleKeyDown = useCallback((e: KeyboardEvent) => {
 
   if (!visible) return null;
 
-  return (
-    <FocusTrap
-      active={visible}
-      focusTrapOptions={{
-        escapeDeactivates: true,
-        clickOutsideDeactivates: false,
-        initialFocus: () => focusAnchorRef.current!,
-        fallbackFocus: () => focusAnchorRef.current!,
-      }}
-    >
-      <div
-        role="dialog"
-        aria-modal="true"
-        tabIndex={-1}
-        className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-white/95 backdrop-blur-sm"
-      >
-        <div
-          className="text-center space-y-6 max-w-xs px-6 animate-fade-in"
-          aria-live="polite"
-        >
-
-          <div
-            ref={focusAnchorRef}
-            tabIndex={-1}
-            className="sr-only"
-            aria-hidden="true"
-          />
-
-          <div className="mx-auto w-20 h-20">
-            <LottiePlayer
-              animationData={spinnerAnim}
-              loop
-              autoplay
-              aria-hidden="true"
-            />
-          </div>
-          <div>
-            <h2 className="font-heading font-bold text-xl tracking-tight text-[var(--text)]">
-              {isLoading ? "Loading engine" : "Exporting"}
-            </h2>
-            <p className="text-sm text-[var(--muted)] mt-1">
-              {isLoading
-                ? "Setting up the video engine. This only happens once."
-                : "Processing your video locally."}
-            </p>
-            <p className="text-xs font-heading font-semibold text-[var(--muted)] text-film-600 mt-2 uppercase tracking-wide">
-              Do not close or refresh this tab
-            </p>
-          </div>
-
-          <span className="sr-only">
-            {status === "loading-engine"
-              ? "Loading video engine..."
-              : `Exporting: ${progress}%`}
-          </span>
-
-
-          {status === "exporting" && (
-            <div className="w-full space-y-2">
-              <div className="h-1 w-full bg-film-100 rounded-full overflow-hidden">
-                <div
-                  role="progressbar"
-                  aria-valuenow={progress}
-                  aria-valuemin={0}
-                  aria-valuemax={100}
-                  aria-label="Export progress"
-                  className="h-full bg-film-600 rounded-full transition-all duration-300"
-                  style={{ width: `${progress}%` }}
-                />
-              </div>
-
-              <p className="text-xs font-heading font-semibold text-[var(--muted)]">
-                {progress}%
-              </p>
-
-              <div className="flex flex-col items-center gap-3 mt-4">
-                <button
-                  type="button"
-                  onClick={() => onCancel?.()}
-                  className="
-          inline-flex items-center justify-center
-          rounded-lg
-          border border-red-200
-          bg-red-50
-          px-4 py-2
-          text-sm font-semibold text-red-600
-          transition-colors
-          hover:bg-red-100
-          active:scale-[0.98]
-        "
-                >
-                  Cancel Export
-                </button>
-
-                <p className="text-gray-500 text-xs">
-                  Press Escape to cancel
-                </p>
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
-    </FocusTrap >
-  );
-}
+  const isLoading = status === "loading-engine";

--- a/src/components/ExportOverlay.tsx
+++ b/src/components/ExportOverlay.tsx
@@ -1,5 +1,5 @@
 "use client";
-
+import { useEffect } from "react";
 import { ExportStatus } from "@/lib/types";
 import LottiePlayer from "./LottiePlayer";
 import spinnerAnim from "@/lib/lottie/spinner.json";
@@ -11,6 +11,16 @@ interface Props {
 
 export default function ExportOverlay({ status, progress }: Props) {
   const visible = status === "loading-engine" || status === "exporting";
+  useEffect(() => {
+  if (visible) {
+    document.body.style.overflow = "hidden";
+  } else {
+    document.body.style.overflow = "";
+  }
+  return () => {
+    document.body.style.overflow = "";
+  };
+}, [visible]);
   if (!visible) return null;
 
   const isLoading = status === "loading-engine";

--- a/src/components/ExportOverlay.tsx
+++ b/src/components/ExportOverlay.tsx
@@ -52,3 +52,91 @@ export default function ExportOverlay({ status, progress, onCancel }: Props) {
   if (!visible) return null;
 
   const isLoading = status === "loading-engine";
+
+  return (
+    <FocusTrap
+      active={visible}
+      focusTrapOptions={{
+        escapeDeactivates: true,
+        clickOutsideDeactivates: false,
+        initialFocus: () => focusAnchorRef.current!,
+        fallbackFocus: () => focusAnchorRef.current!,
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        tabIndex={-1}
+        className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-white/95 backdrop-blur-sm"
+      >
+        <div
+          className="text-center space-y-6 max-w-xs px-6 animate-fade-in"
+          aria-live="polite"
+        >
+          <div
+            ref={focusAnchorRef}
+            tabIndex={-1}
+            className="sr-only"
+            aria-hidden="true"
+          />
+          <div className="mx-auto w-20 h-20">
+            <LottiePlayer
+              animationData={spinnerAnim}
+              loop
+              autoplay
+              aria-hidden="true"
+            />
+          </div>
+          <div>
+            <h2 className="font-heading font-bold text-xl tracking-tight text-[var(--text)]">
+              {isLoading ? "Loading engine" : "Exporting"}
+            </h2>
+            <p className="text-sm text-[var(--muted)] mt-1">
+              {isLoading
+                ? "Setting up the video engine. This only happens once."
+                : "Processing your video locally."}
+            </p>
+            <p className="text-xs font-heading font-semibold text-[var(--muted)] text-film-600 mt-2 uppercase tracking-wide">
+              Do not close or refresh this tab
+            </p>
+          </div>
+          <span className="sr-only">
+            {status === "loading-engine"
+              ? "Loading video engine..."
+              : `Exporting: ${progress}%`}
+          </span>
+          {status === "exporting" && (
+            <div className="w-full space-y-2">
+              <div className="h-1 w-full bg-film-100 rounded-full overflow-hidden">
+                <div
+                  role="progressbar"
+                  aria-valuenow={progress}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-label="Export progress"
+                  className="h-full bg-film-600 rounded-full transition-all duration-300"
+                  style={{ width: `${progress}%` }}
+                />
+              </div>
+              <p className="text-xs font-heading font-semibold text-[var(--muted)]">
+                {progress}%
+              </p>
+              <div className="flex flex-col items-center gap-3 mt-4">
+                <button
+                  type="button"
+                  onClick={() => onCancel?.()}
+                  className="inline-flex items-center justify-center rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm font-semibold text-red-600 transition-colors hover:bg-red-100 active:scale-[0.98]"
+                >
+                  Cancel Export
+                </button>
+                <p className="text-gray-500 text-xs">
+                  Press Escape to cancel
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </FocusTrap>
+  );
+}


### PR DESCRIPTION
Closes #13

Changes Made:
- Added useEffect to lock body scroll when overlay is visible
- Restores scroll on unmount