### PR TITLE
fix: correct CRF quality label boundaries

### DIFF
--- a/src/components/ExportSettings.tsx
+++ b/src/components/ExportSettings.tsx
@@ -9,7 +9,11 @@ interface Props {
 }
 
 export default function ExportSettings({ recipe, onChange }: Props) {
-  const label = recipe.quality <= 20 ? "High" : recipe.quality <= 24 ? "Balanced" : "Small file";
+  const label = recipe.quality <= 21 
+    ? "High" 
+    : recipe.quality <= 25 
+    ? "Balanced" 
+    : "Small file";
 
   return (
     <div>


### PR DESCRIPTION
## Changes
- Fixed CRF quality label boundary logic
- Updated quality ranges:
  - 18–21 → High
  - 22–25 → Balanced
  - 26+ → Small file

## Testing
- Manually tested slider values:
  - 21 → High
  - 22 → Balanced
  - 25 → Balanced
  - 26 → Small fil

Closes #26 