### PR TITLE
feat: add retry export button for failed exports

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -122,10 +122,18 @@ export default function VideoEditor() {
                     className="flex items-start gap-3 p-4 bg-film-50 border border-film-200 rounded-xl text-film-800 text-sm animate-fade-in"
                   >
                 <AlertTriangle size={16} className="shrink-0 mt-0.5 text-film-500" />
-                <div>
+                <div className="flex-1">
                   <p className="font-heading font-bold text-sm">Error</p>
                   <p className="text-film-600 text-xs mt-1">{error}</p>
                 </div>
+                {!error.includes("Validation Failed") && (
+                  <button
+                    onClick={handleExport}
+                    className="px-3 py-1.5 bg-red-200 border border-film-200 rounded-lg text-xs font-semibold hover:bg-film-50 hover:border-film-300 transition-colors shrink-0 whitespace-nowrap"
+                  >
+                    Retry Export
+                  </button>
+                )}
               </div>
             )}
 


### PR DESCRIPTION
Added a "Retry Export" button that appears whenever an export fails (excluding file validation errors).

Why:
Previously, if a local FFmpeg render failed unexpectedly, the user was stuck on the error state and had to refresh the page or manually reset everything, losing all their settings. This button allows them to immediately re-attempt the export while preserving all of their existing adjustments.

Issue reference : Closes #94 

Testing : Temporarily threw a stimulated error
<img width="1185" height="138" alt="Screenshot 2026-05-15 184919" src="https://github.com/user-attachments/assets/0838bf06-3299-4d06-a0a7-980cfc01f06c" />
