### PR TITLE
fix: prevent duplicate exports during active export

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,8 +12,10 @@ export default function Home() {
         ⭐ Star on GitHub
       </a>
       
+    <main>
       <VideoEditor />
+    </main>
     </>
   );
 }
- 
+    

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,9 +13,7 @@ export default function Home() {
       </a>
       
       <VideoEditor />
-    <main>
-      <VideoEditor />
-    </main>
     </>
   );
 }
+ 

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -107,6 +107,9 @@ export function useVideoEditor() {
 
   const handleExport = useCallback(async () => {
     if (!file) return;
+    if (status === "loading-engine" || status === "exporting") {
+      return;
+    }
 
     const abortController = new AbortController();
     exportAbortControllerRef.current = abortController;
@@ -164,7 +167,8 @@ export function useVideoEditor() {
         (e.ctrlKey || e.metaKey) &&
         e.key === "Enter" &&
         file &&
-        status === "idle"
+        status !== "loading-engine" &&
+        status !== "exporting"
       ) {
         handleExport();
       }


### PR DESCRIPTION
## Summary

This PR prevents duplicate exports from being triggered during an active export session.

## Changes Made

* Added a guard inside `handleExport` to prevent multiple simultaneous exports
* Disabled repeated export triggering during `loading-engine` and `exporting` states
* Updated keyboard shortcut handling (`Ctrl + Enter`) to respect active export states

## Testing

Tested the following scenarios:

* Rapid spam clicking on the export button
* Multiple `Ctrl + Enter` triggers during export
* Normal export completion flow
* Re-export after completion
* Production build verification using `bun run build`

This prevents duplicate export processes, unstable progress behavior, and unnecessary resource usage during active exports.

Closes #23

