### PR TITLE
feat: add cancel export button to export overlay

### DIFF
--- a/src/components/ExportOverlay.tsx
+++ b/src/components/ExportOverlay.tsx
@@ -65,7 +65,7 @@ export default function ExportOverlay({ status, progress, onCancel }: Props) {
         aria-modal="true"
         tabIndex={-1}
         className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-white/95 backdrop-blur-sm"
-       >
+      >
         <div
           className="text-center space-y-6 max-w-xs px-6 animate-fade-in"
           aria-live="polite"
@@ -86,29 +86,29 @@ export default function ExportOverlay({ status, progress, onCancel }: Props) {
               aria-hidden="true"
             />
           </div>
-  
+
           <span className="sr-only">
             {status === "loading-engine"
               ? "Loading video engine..."
               : `Exporting: ${progress}%`}
           </span>
-  
+
           <div>
             <h2 className="font-heading font-bold text-xl tracking-tight text-[var(--text)]">
               {isLoading ? "Loading engine" : "Exporting"}
             </h2>
-  
+
             <p className="text-sm text-[var(--muted)] mt-1">
               {isLoading
                 ? "Setting up the video engine. This only happens once."
                 : "Processing your video locally."}
             </p>
-  
+
             <p className="text-xs font-heading font-semibold text-film-600 mt-2 uppercase tracking-wide">
               Do not close or refresh this tab
             </p>
           </div>
-  
+
           {status === "exporting" && (
             <div className="w-full space-y-2">
               <div className="h-1 w-full bg-film-100 rounded-full overflow-hidden">
@@ -122,14 +122,36 @@ export default function ExportOverlay({ status, progress, onCancel }: Props) {
                   style={{ width: `${progress}%` }}
                 />
               </div>
-  
+
               <p className="text-xs font-heading font-semibold text-[var(--muted)]">
                 {progress}%
               </p>
-  
-              <p className="text-gray-500 text-xs mt-4">
-                Press Escape to cancel
-              </p>
+
+              <div className="flex flex-col items-center gap-3 mt-4">
+
+                <button
+                  type="button"
+                  onClick={onCancel}
+                  className="
+      inline-flex items-center justify-center
+      rounded-lg
+      border border-red-200
+      bg-red-50
+      px-4 py-2
+      text-sm font-semibold text-red-600
+      transition-colors
+      hover:bg-red-100
+      active:scale-[0.98]
+    "
+                >
+                  Cancel Export
+                </button>
+
+
+
+              </div>
+
+
             </div>
           )}
         </div>

--- a/src/components/ExportOverlay.tsx
+++ b/src/components/ExportOverlay.tsx
@@ -9,7 +9,7 @@ import spinnerAnim from "@/lib/lottie/spinner.json";
 interface Props {
   status: ExportStatus;
   progress: number;
-  onCancel: () => void;
+  onCancel?: () => void;
 }
 
 export default function ExportOverlay({ status, progress, onCancel }: Props) {
@@ -37,7 +37,7 @@ export default function ExportOverlay({ status, progress, onCancel }: Props) {
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        onCancel();
+        onCancel?.();
       }
     };
 
@@ -106,21 +106,6 @@ export default function ExportOverlay({ status, progress, onCancel }: Props) {
               : `Exporting: ${progress}%`}
           </span>
 
-          <div>
-            <h2 className="font-heading font-bold text-xl tracking-tight text-[var(--text)]">
-              {isLoading ? "Loading engine" : "Exporting"}
-            </h2>
-
-            <p className="text-sm text-[var(--muted)] mt-1">
-              {isLoading
-                ? "Setting up the video engine. This only happens once."
-                : "Processing your video locally."}
-            </p>
-
-            <p className="text-xs font-heading font-semibold text-film-600 mt-2 uppercase tracking-wide">
-              Do not close or refresh this tab
-            </p>
-          </div>
 
           {status === "exporting" && (
             <div className="w-full space-y-2">
@@ -141,34 +126,32 @@ export default function ExportOverlay({ status, progress, onCancel }: Props) {
               </p>
 
               <div className="flex flex-col items-center gap-3 mt-4">
-
                 <button
                   type="button"
-                  onClick={onCancel}
+                  onClick={() => onCancel?.()}
                   className="
-      inline-flex items-center justify-center
-      rounded-lg
-      border border-red-200
-      bg-red-50
-      px-4 py-2
-      text-sm font-semibold text-red-600
-      transition-colors
-      hover:bg-red-100
-      active:scale-[0.98]
-    "
+          inline-flex items-center justify-center
+          rounded-lg
+          border border-red-200
+          bg-red-50
+          px-4 py-2
+          text-sm font-semibold text-red-600
+          transition-colors
+          hover:bg-red-100
+          active:scale-[0.98]
+        "
                 >
                   Cancel Export
                 </button>
 
-
-
+                <p className="text-gray-500 text-xs">
+                  Press Escape to cancel
+                </p>
               </div>
-
-
             </div>
           )}
         </div>
       </div>
-    </FocusTrap>
+    </FocusTrap >
   );
 }

--- a/src/components/ExportOverlay.tsx
+++ b/src/components/ExportOverlay.tsx
@@ -86,6 +86,19 @@ export default function ExportOverlay({ status, progress, onCancel }: Props) {
               aria-hidden="true"
             />
           </div>
+          <div>
+            <h2 className="font-heading font-bold text-xl tracking-tight text-[var(--text)]">
+              {isLoading ? "Loading engine" : "Exporting"}
+            </h2>
+            <p className="text-sm text-[var(--muted)] mt-1">
+              {isLoading
+                ? "Setting up the video engine. This only happens once."
+                : "Processing your video locally."}
+            </p>
+            <p className="text-xs font-heading font-semibold text-[var(--muted)] text-film-600 mt-2 uppercase tracking-wide">
+              Do not close or refresh this tab
+            </p>
+          </div>
 
           <span className="sr-only">
             {status === "loading-engine"


### PR DESCRIPTION
### Description

In the export overlay we introduce a button to cancle ongoing exports. 

This PR closes #86 

### Changes Made

1. Added a cancel export button in the ExportOverlay
2. Text on ExportOverlay was present but not visible so fixed that (see screenshot below)

### Testing

- [x] Tested export cancellation during active export
- [x] Verified Export States resets correctly
- [x] Run lint and typescript checks 

### Screenshots

Before 

<img width="1919" height="911" alt="image" src="https://github.com/user-attachments/assets/db3fc38b-79a8-4cee-8b72-b916e9291865" />

After

<img width="1919" height="921" alt="image" src="https://github.com/user-attachments/assets/504be76b-bf51-421f-872c-368e880f80f0" />


AI Usage: AI was used to write the commit message. No AI was used to write code or Description for this PR. 

#GSSOC26.