### PR TITLE
feat: add informational warning for audio when trim range is set

### DIFF
--- a/src/components/AudioSpeedControl.tsx
+++ b/src/components/AudioSpeedControl.tsx
@@ -119,7 +119,7 @@ useEffect(() => {
         <div className="flex items-start gap-2 p-3 bg-blue-50/50 border border-blue-100 rounded-lg animate-fade-in">
           <Info size={14} className="shrink-0 mt-0.5 text-blue-500" />
           <p className="text-[10px] text-blue-700 leading-tight">
-            Note: If audio doesn't start within the selected range, the output will be silent.
+            Note: If audio doesn&apos;t start within the selected range, the output will be silent.
           </p>
         </div>
       )}

--- a/src/components/AudioSpeedControl.tsx
+++ b/src/components/AudioSpeedControl.tsx
@@ -2,7 +2,7 @@
 import { useEffect } from "react";
 
 import { EditRecipe, SPEED_STEPS } from "@/lib/types";
-import { Volume2, VolumeX, Gauge } from "lucide-react";
+import { Volume2, VolumeX, Gauge, Info } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -114,6 +114,15 @@ useEffect(() => {
           ))}
         </div>
       </div>
+
+      {recipe.keepAudio && (recipe.trimStart > 0 || recipe.trimEnd !== null) && (
+        <div className="flex items-start gap-2 p-3 bg-blue-50/50 border border-blue-100 rounded-lg animate-fade-in">
+          <Info size={14} className="shrink-0 mt-0.5 text-blue-500" />
+          <p className="text-[10px] text-blue-700 leading-tight">
+            Note: If audio doesn't start within the selected range, the output will be silent.
+          </p>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
I have implemented the informational audio warning and committed it to the feature/warningwhentrimrangeexcludesallaudio branch.

What I Changed
Component: src/components/AudioSpeedControl.tsx
Logic: Added a conditional check that monitors both the keepAudio state and the trim settings (trimStart and trimEnd).
UI: Integrated a subtle, non-blocking alert box using Tailwind CSS and the Info icon from Lucide. This box appears only when audio is enabled and a trim is active.
Why
This change addresses a common point of confusion where users might trim a video to a section that contains no audio (e.g., trimming to the middle of a clip where the audio only starts later). By showing this informational note, we manage user expectations and prevent them from being surprised by a silent export.

Reference
Closes #95

UI Changes
Below is a screenshot of the informational warning appearing in the Audio & Speed section after a trim range was set:
<img width="772" height="811" alt="click_feedback_1778903169461" src="https://github.com/user-attachments/assets/b1f89fc0-7108-43d4-89ff-b38ec4072bb0" />
