### PR TITLE
feat: add reset settings functionality and button

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -46,7 +46,7 @@ export default function VideoEditor() {
   const {
     file, duration, recipe, status, progress,
     result, error, updateRecipe,
-    handleFileSelect, handleExport, cancelExport, reset,
+    handleFileSelect, handleExport, cancelExport, reset, resetSettings,
   } = useVideoEditor();
 
   
@@ -258,6 +258,16 @@ export default function VideoEditor() {
               <Section icon={<Crop size={12} />} title="Framing" delay={100}>
                 <FramingControl recipe={recipe} onChange={updateRecipe} />
               </Section>
+
+              <div className="pt-2 flex justify-end">
+                <button
+                  type="button"
+                  onClick={resetSettings}
+                  className="text-[9px] font-heading font-bold uppercase tracking-widest text-[var(--muted)] hover:text-film-600 transition-all opacity-60 hover:opacity-100"
+                >
+                  Reset all settings
+                </button>
+              </div>
             </div>
 
             <button

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -188,6 +188,10 @@ export function useVideoEditor() {
     setError(null);
   }, []);
 
+  const resetSettings = useCallback(() => {
+    setRecipe(DEFAULT_RECIPE);
+  }, []);
+
   const reset = useCallback(() => {
     setFile(null);
     setDuration(0);
@@ -226,5 +230,6 @@ export function useVideoEditor() {
     handleExport,
     cancelExport,
     reset,
+    resetSettings,
   };
 }


### PR DESCRIPTION
## Overview
This PR implements a "Reset settings" feature that allows users to quickly revert all video adjustments (presets, trim, rotate, speed, and quality) to their default values without needing to re-upload the video.

## Changes
- **Hook Update**: Added `resetSettings` to `useVideoEditor.ts` which resets the `recipe` state to `DEFAULT_RECIPE`.
- **UI Enhancement**: Added a subtle "Reset all settings" button in the right-hand sidebar of `VideoEditor.tsx`.
- **UX Improvement**: Ensured the button is non-intrusive and only accessible when a video is loaded and not currently exporting.

## Acceptance Criteria
- [x] "Reset settings" button is available in the controls area.
- [x] Video remains loaded after reset.
- [x] All settings return to `DEFAULT_RECIPE` values (Fit framing, Vertical 9:16, 0 rotation, etc.).
- [x] Button design is subtle and matches the overall aesthetics.

## Related Issue
Closes #219 