### PR TITLE
fix: handle Escape key in export overlay

### DIFF
--- a/src/components/ExportOverlay.tsx
+++ b/src/components/ExportOverlay.tsx
@@ -24,16 +24,17 @@ const handleKeyDown = useCallback((e: KeyboardEvent) => {
   }
 }, [onCancel]);
   useEffect(() => {
-    if (visible) {
-      window.addEventListener("keydown", handleKeyDown);
-      previousFocusRef.current =
-        document.activeElement as HTMLElement;
-    }
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-    
-  }, [visible]);
+  if (!visible) return;
+
+  window.addEventListener("keydown", handleKeyDown);
+
+  previousFocusRef.current =
+    document.activeElement as HTMLElement;
+
+  return () => {
+    window.removeEventListener("keydown", handleKeyDown);
+  };
+}, [visible, handleKeyDown]);
 
   useEffect(() => {
     if (!visible && previousFocusRef.current) {

--- a/src/components/ExportOverlay.tsx
+++ b/src/components/ExportOverlay.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import FocusTrap from "focus-trap-react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useCallback } from "react";
 import { ExportStatus } from "@/lib/types";
 import LottiePlayer from "./LottiePlayer";
 import spinnerAnim from "@/lib/lottie/spinner.json";
@@ -18,12 +18,21 @@ export default function ExportOverlay({ status, progress, onCancel }: Props) {
 
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const focusAnchorRef = useRef<HTMLDivElement | null>(null);
-
+const handleKeyDown = useCallback((e: KeyboardEvent) => {
+  if (e.key === "Escape") {
+    onCancel();
+  }
+}, [onCancel]);
   useEffect(() => {
     if (visible) {
+      window.addEventListener("keydown", handleKeyDown);
       previousFocusRef.current =
         document.activeElement as HTMLElement;
     }
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+    
   }, [visible]);
 
   useEffect(() => {


### PR DESCRIPTION
Fixes Escape key handling in ExportOverlay component.

### Changes made
- Added keyboard event listener for Escape key
- Triggered `onCancel()` when Escape is pressed
- Added cleanup using `removeEventListener`

Closes #79