### PR TITLE
docs: add automatic merge conflict resolution rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,14 @@ This file instructs Claude Code (and the Claude GitHub App) how to behave as an 
 
 When triggered on a pull request:
 
-1. Read the PR diff, title, description, and all CI check statuses.
-2. Check whether **ALL** checks have passed — including tests and the Vercel deployment check.
-3. Review the code for correctness, security issues, and adherence to the standards in this file.
+**Step 1 — Resolve merge conflicts first (if any).**
+Before reviewing code or checking CI, check whether the PR has merge conflicts. If it does, resolve them automatically as described in the Merge Conflict Resolution section below. Only proceed to steps 2–3 after the branch is clean.
+
+**Step 2 — Check CI.**
+Check whether **ALL** checks have passed — including tests and the Vercel deployment check.
+
+**Step 3 — Review the code.**
+Review for correctness, security issues, and adherence to the standards in this file.
 
 **If ALL checks pass AND the code looks good** → merge the PR immediately using a squash merge. Leave a short comment explaining what was merged and why it passed.
 
@@ -20,6 +25,50 @@ When triggered on a pull request:
 - A friendly but direct tone
 
 Never merge a PR if any CI check or Vercel deployment check is still pending or has failed.
+
+---
+
+## Merge Conflict Resolution
+
+When a PR has merge conflicts, resolve them automatically **before** doing anything else (before code review, before checking CI).
+
+### Steps:
+
+1. **Detect conflicts** — check the PR's mergeability via the GitHub API (`mergeable` field). If `mergeable: false`, proceed with resolution.
+
+2. **Clone and resolve locally:**
+   ```bash
+   git clone https://github.com/magic-peach/reframe.git
+   cd reframe
+   git fetch origin
+   git checkout <pr-branch>
+   git merge origin/main
+   # resolve conflicts (see rules below)
+   git add .
+   git commit -m "chore: resolve merge conflicts with main"
+   git push origin <pr-branch>
+   ```
+
+3. **Conflict resolution rules — apply these in order:**
+
+   - **`src/app/page.tsx`** — Always keep the `main` version exactly. This file has a known stable structure; contributor changes that add a `<main>` wrapper or duplicate JSX must be discarded in favour of main.
+   - **`bun.lock` / `package-lock.json`** — Keep `bun.lock` from `main`. Delete any `package-lock.json` the PR introduced.
+   - **`src/app/layout.tsx` metadata** — Keep all fields from `main`; merge in any *new* fields from the PR branch (e.g. new `openGraph` keys). If the PR duplicates an existing field, keep the `main` version of that field.
+   - **CSS variables in `src/app/globals.css`** — Keep `main`'s variable names (`--bg`, `--surface`, `--border`, `--text`, `--muted`). Discard any renames from the PR branch.
+   - **`.github/workflows/`** — Keep `main` versions of all workflow files. Only accept new workflow files from the PR if they don't conflict.
+   - **All other files** — Use standard semantic merge: keep both sets of changes if they don't logically conflict. If two edits touch the same line and both are meaningful, apply the PR's change on top of `main`'s version (i.e., prefer preserving contributor intent where safe).
+
+4. **Post a comment** on the PR after pushing the resolved branch, tagging the author:
+
+   > Hey @username! This PR had merge conflicts with `main` — I've resolved them automatically and pushed the result. Here's what was changed:
+   >
+   > - **`src/app/page.tsx`**: kept the `main` version (your `<main>` wrapper was removed — this file has a fixed structure)
+   > - **`bun.lock`**: regenerated from `main` (removed `package-lock.json`)
+   > - _(list each file and what decision was made)_
+   >
+   > CI has been re-triggered. If anything looks wrong, feel free to push additional changes.
+
+5. **Do not resolve conflicts that require domain judgement** — if two branches both meaningfully modify the same function body in `src/lib/ffmpeg.ts` or a complex component, do not guess. Instead post a comment asking the author to rebase manually and explain exactly which lines conflict.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a **Merge Conflict Resolution** section to `CLAUDE.md` that instructs the automated manager to resolve merge conflicts automatically before reviewing code or checking CI.

## What the new rule does

- Detects conflicts via the GitHub API (`mergeable: false`) before anything else
- Clones the branch, runs `git merge origin/main`, and applies file-specific resolution rules:
  - `page.tsx` → always keep `main` version
  - `bun.lock` / `package-lock.json` → keep `bun.lock`, delete `package-lock.json`
  - `layout.tsx` metadata → keep `main` fields, merge in new fields from PR
  - CSS variables → keep `main`'s variable names
  - Workflow files → keep `main` versions, accept new-only files
  - Everything else → semantic merge, prefer contributor intent where safe
- Pushes the resolved branch and posts a comment tagging the author with a per-file explanation
- Defers to the author if conflicts involve complex logic (FFmpeg internals, component business logic)

## Why

The most common failure mode for PRs in this repo is a stale branch conflicting with the `page.tsx` fix pushed to `main`. This rule automates the rebase so contributors don't have to do it manually for trivial conflicts.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)