### PR TITLE
feat: add bug report issue template (#42)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Create a report to help us improve Reframe
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+**Bug description**
+A clear and concise description of what the bug is.
+
+**Steps to reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Upload video '...'
+3. Click on '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+A clear and concise description of what actually happened.
+
+**Browser and OS info**
+ - OS: [e.g. Windows 11, macOS 14]
+ - Browser: [e.g. Chrome, Firefox, Safari]
+ - Version: [e.g. 122]
+
+**Video format (if relevant)**
+ - Input video format: [e.g. MP4, WebM, MOV]
+ - Export preset used: [e.g. Instagram Reels, 1080p, Custom]
+ - File size: [e.g. 15MB]
+
+**Screenshots/screen recording**
+If applicable, add screenshots or a screen recording to help explain your problem.


### PR DESCRIPTION
## Overview
Closes #42

This PR creates a structured GitHub issue template (`bug_report.md`) to ensure future bug reports are consistent and include all the necessary technical information to debug video editor issues efficiently.

## Changes Made
- Added `.github/ISSUE_TEMPLATE/bug_report.md`
- Included standard GitHub frontmatter (`name`, `about`, `title`, `labels`)
- Added all requested fields: Bug description, Steps to reproduce, Expected/Actual behavior, Browser/OS info, Video format, and Screenshots.

## Acceptance Criteria Verified
- [x] Bug report template file created
- [x] Template has proper GitHub frontmatter (name, about, labels, assignees)
- [x] All relevant fields included (Description, Steps, Expected/Actual behavior, Browser/OS, Video format, Screenshots)
