### PR TITLE
feat: add footer with copyright and github link (#62)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,13 @@ export default function Home() {
       <main id="main-content" tabIndex={-1}>
         <VideoEditor />
       </main>
+
+      <footer className="text-center text-gray-500 text-sm py-4">
+        <p>© 2025 Reframe. Open source under MIT License.</p>
+        <a href="https://github.com/magic-peach/reframe" target="_blank" rel="noopener noreferrer" className="hover:underline">
+          View on GitHub
+        </a>
+      </footer>
     </>
   );
 }


### PR DESCRIPTION
## Overview
Closes #62

This PR adds a simple footer to the main application page containing the required copyright information and a link to the project's GitHub repository.

## Changes Made
- Updated `src/app/page.tsx` to include a new `<footer>` element at the bottom of the page.
- Added copyright text `© 2025 Reframe. Open source under MIT License.`
- Added an accessible anchor tag linking to the GitHub repo with `target="_blank"` and `rel="noopener noreferrer"`.
- Added a `hover:underline` class to the link for better visual accessibility.

## Acceptance Criteria Verified
- [x] Footer visible at bottom of page
- [x] Links to GitHub repo
- [x] Accessible link with proper attributes (`rel="noopener noreferrer"`)
