### PR TITLE
fix: issue #221 - Add validation feedback color to trim inputs

### DIFF
--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { EditRecipe } from "@/lib/types";
+import { useState } from "react";
 
 interface Props {
   recipe: EditRecipe;
@@ -9,24 +10,47 @@ interface Props {
 }
 
 export default function TrimControl({ recipe, onChange, duration }: Props) {
+  const [invalidStart, setStart]=useState(false);
+  const [invalidEnd, setEnd]=useState(false);
+
   const handleStart = (val: string) => {
     const n = parseFloat(val);
-    if (isNaN(n) || n < 0) return;
-    if (duration > 0 && n >= duration - 0.001) return;
-    if (recipe.trimEnd !== null && n >= recipe.trimEnd - 0.001) return;
+    if (isNaN(n) || n < 0){
+      setStart(true);
+      return;
+    }
+    if (duration > 0 && n >= duration){
+      setStart(true);
+      return;
+    }
+    if (recipe.trimEnd !== null && n >= recipe.trimEnd){
+      setStart(true);
+      return;
+    };
+    setStart(false);
     onChange({ trimStart: n });
   };
 
   const handleEnd = (val: string) => {
-    if (val === "") { onChange({ trimEnd: null }); return; }
+    if (val === "") { setEnd(false);
+      onChange({ trimEnd: null }); return; }
     const n = parseFloat(val);
-    if (isNaN(n) || n <= 0 || n <= recipe.trimStart - 0.001) return;
-    if (duration > 0 && n > duration + 0.001) return;
+    if (isNaN(n) || n <= 0 || n <= recipe.trimStart){
+      setEnd(true);
+      return;
+    }
+    if (duration > 0 && n > duration){
+      setEnd(true);
+      return;
+    }
+    setEnd(false);
     onChange({ trimEnd: n });
   };
+  
+
 
   const inputClass =
-    "w-full min-h-[44px] text-sm px-3 py-2 border border-[var(--border)] rounded-md bg-[var(--bg)] font-heading focus:outline-none focus:ring-2 focus:ring-film-400 text-[var(--text)] transition-shadow";
+    "w-full text-sm px-3 py-2 border border-[var(--border)] rounded-md bg-[var(--bg)] font-heading focus:outline-none focus:ring-2 focus:ring-film-400 text-[var(--text)] transition-shadow";
 
   return (
     <div className="space-y-2">
@@ -43,7 +67,8 @@ export default function TrimControl({ recipe, onChange, duration }: Props) {
             step={0.1}
             value={recipe.trimStart}
             onChange={(e) => handleStart(e.target.value)}
-            className={inputClass}
+            className={`${inputClass} ${
+              invalidStart ? "border-red-500" : "border-[var(--border)]"}`}
             placeholder="0"
           />
         </div>
@@ -59,7 +84,8 @@ export default function TrimControl({ recipe, onChange, duration }: Props) {
             step={0.1}
             value={recipe.trimEnd ?? ""}
             onChange={(e) => handleEnd(e.target.value)}
-            className={inputClass}
+            className={`${inputClass} ${
+              invalidEnd ? "border-red-500" : "border-[var(--border)]"}`}
             placeholder={duration > 0 ? `${duration.toFixed(1)}` : "full length"}
           />
         </div>


### PR DESCRIPTION
## What already existed

- The users were not allowed to enter start trim value greater than or equal to end trim value and even negative values. 
- The handleStart( ) and handleEnd( ) functions silently ignored the above functionalities using simple return statement.

## Changes made

-The above human errors are notified to users by showing a red colored border around start and end input fields when invalid.
-The UI is made interactive by the above change using useState hook in React.js and ternary operator .

## Acceptance Criteria

[x] Red border on invalid trim values
[x] Border returns to normal when valid

## Type of fix

[x] Bug fix

## Future enhancements

-The error can be displayed as a warning text message for the user to understand the error easily.