### PR TITLE
fix: improve error messages to be more actionable (closes #63)

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -143,16 +143,21 @@ export function useVideoEditor() {
 
       setResult(exportResult);
       setStatus("done");
-    } catch (err) {
+    } } catch (err) {
       if (exportCancelledRef.current) return;
 
       console.error("export failed:", err);
       if (err instanceof FFmpegLoadError) {
         setError(err.message);
+      } else if (err instanceof Error && err.message.includes('network')) {
+        setError('Network error. Check your internet connection and try again.');
+      } else if (err instanceof Error && err.message.includes('codec')) {
+        setError('This video format is not supported. Try converting to MP4 first.');
       } else {
-        setError(err instanceof Error ? err.message : "something went wrong");
+        setError('Export failed. Please try again or use a different video.');
       }
       setStatus("error");
+    }
     } finally {
       if (exportAbortControllerRef.current === abortController) {
         exportAbortControllerRef.current = null;

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -143,7 +143,7 @@ export function useVideoEditor() {
 
       setResult(exportResult);
       setStatus("done");
-    } } catch (err) {
+     }  catch (err) {
       if (exportCancelledRef.current) return;
 
       console.error("export failed:", err);
@@ -158,7 +158,7 @@ export function useVideoEditor() {
       }
       setStatus("error");
     }
-    } finally {
+    finally {
       if (exportAbortControllerRef.current === abortController) {
         exportAbortControllerRef.current = null;
       }


### PR DESCRIPTION
Closes #63

The current error messages were just raw JavaScript errors which 
are confusing for users. I updated the catch block in useVideoEditor.ts 
to show clear messages based on the error type:

- Network issues now tell the user to check their connection
- Codec errors suggest converting to MP4
- Any other failure shows a simple retry message

Tested locally and the export flow works as expected.