### PR TITLE
feat: add 'What is CRF?' tooltip to quality slider (#193)

### DIFF
--- a/src/components/ExportSettings.tsx
+++ b/src/components/ExportSettings.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { EditRecipe } from "@/lib/types";
-import { SlidersHorizontal } from "lucide-react";
+import { SlidersHorizontal, Info as InfoIcon } from "lucide-react";
 
 interface Props {
   recipe: EditRecipe;
@@ -20,6 +20,9 @@ export default function ExportSettings({ recipe, onChange }: Props) {
       <div className="flex items-center justify-between mb-2">
         <label htmlFor="quality-control" className="text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)] flex items-center gap-1">
           <SlidersHorizontal size={10} /> Quality
+          <span className="cursor-help" title="CRF (Constant Rate Factor): lower = higher quality, larger file. 18 = best quality, 30 = smallest file.">
+            <InfoIcon size={14} />
+          </span>
         </label>
         <span className="text-sm font-heading font-bold text-film-600">
           {label}


### PR DESCRIPTION
## Overview
Closes #193

This PR adds an info icon with a helpful tooltip next to the "Quality" label in the export settings. Since many users aren't familiar with Constant Rate Factor (CRF), this provides immediate, accessible context right where they need it.

## Changes Made
- Imported the `Info` icon from `lucide-react`.
- Added the info icon wrapped in a `<span title="...">` next to the `Quality` label.
- Included the explanation of how the CRF scale works (lower = better quality, 18 = best, 30 = smallest).
- Ensured the icon uses `cursor-help` for better UX.

## Acceptance Criteria Verified
- [x] Info icon next to quality label
- [x] Hover shows explanation tooltip
- [x] Accessible (uses native title attribute which is readable by screen readers)
