### PR TITLE
feat: add 'Copy error' button with 2s confirmation for export errors …

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -1,5 +1,5 @@
 "use client";
-
+import { useState } from "react";
 import { useVideoEditor } from "@/hooks/useVideoEditor";
 import FileUpload from "./FileUpload";
 import VideoPreview from "./VideoPreview";
@@ -49,6 +49,7 @@ export default function VideoEditor() {
     result, error, updateRecipe,
     handleFileSelect, handleExport, cancelExport, reset, resetSettings,
   } = useVideoEditor();
+  const [copied, setCopied] = useState(false);
 
   
   const isProcessing = status === "loading-engine" || status === "exporting";
@@ -232,6 +233,18 @@ export default function VideoEditor() {
                   <p className="font-heading font-bold text-sm">Error</p>
                   <p className="text-film-600 text-xs mt-1">{error}</p>
                 </div>
+                <button
+                  onClick={() => {
+                    navigator.clipboard.writeText(error).then(() => {
+                      setCopied(true);
+                      setTimeout(() => setCopied(false), 2000);
+                    });
+                  }}
+                  className="px-3 py-1.5 bg-[var(--border)] border border-[var(--border)] rounded-lg text-xs font-semibold hover:opacity-80 transition-colors shrink-0 whitespace-nowrap"
+                  aria-label="Copy error message to clipboard"
+                >
+                  {copied ? "Copied!" : "Copy error"}
+                </button>
                 {!error.includes("Validation Failed") && (
                   <button
                     onClick={handleExport}


### PR DESCRIPTION
…(#72)

## Overview
Closes #72

This PR adds a "Copy error" button next to the export error message, making it easy for users to copy the error text to share as a bug report.

## Changes Made
- Added `useState` hook to track clipboard copy state.
- Added a **"Copy error"** button next to the error display in `VideoEditor.tsx`.
- Button uses `navigator.clipboard.writeText(error)` to copy the error text.
- Button text changes to **"Copied!"** for 2 seconds after clicking, then resets.
- Includes `aria-label` for screen reader accessibility.

## Acceptance Criteria Verified
- [x] 'Copy' button appears next to error message
- [x] Copies error text to clipboard
- [x] Button shows 'Copied!' confirmation for 2 seconds
- [x] Accessible with proper `aria-label`
