### PR TITLE
fix: add input validation for all EditRecipe fields before export

### DIFF
--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -83,6 +83,11 @@ const handleHeightChange = useCallback((h: number) => {
     onChange({ preset: presetId });
     setSearch("");
   }, [onChange]);
+  
+  function clampInputValue(value: number, min = 16, max = 7680) {
+    if (isNaN(value)) return min;
+    return Math.max(min, Math.min(max, value));
+  }
 
   return (
     <div className="space-y-3">
@@ -187,6 +192,10 @@ const handleHeightChange = useCallback((h: number) => {
               value={recipe.customWidth}
               spellCheck={false}
               onChange={(e) => handleWidthChange(Number(e.target.value))}
+              onBlur={(e) => {
+                  const value = clampInputValue(Number(e.target.value));
+                  onChange({ customWidth: value });
+                }}
               className="w-full text-sm px-3 py-1.5 border border-[var(--border)] rounded-md bg-[var(--bg)] font-heading focus:outline-none focus:ring-2 focus:ring-film-400 transition-shadow"
             />
             {recipe.customWidth % 2 !== 0 && (
@@ -224,6 +233,10 @@ const handleHeightChange = useCallback((h: number) => {
               value={recipe.customHeight}
               spellCheck={false}
               onChange={(e) => handleHeightChange(Number(e.target.value))}
+              onBlur={(e) => {
+                  const value = clampInputValue(Number(e.target.value));
+                  onChange({ customHeight: value });
+                }}
               className="w-full text-sm px-3 py-1.5 border border-[var(--border)] rounded-md bg-[var(--bg)] font-heading focus:outline-none focus:ring-2 focus:ring-film-400 transition-shadow"
             />
             {recipe.customHeight % 2 !== 0 && (

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useEffect, useRef } from "react";
 import { EditRecipe, ExportResult, ExportStatus, MAX_FILE_SIZE } from "@/lib/types";
-import { DEFAULT_RECIPE } from "@/lib/constants";
+import { DEFAULT_RECIPE, SPEED_STEPS } from "@/lib/constants";
 import { loadFFmpeg, exportVideo, terminateFFmpeg, FFmpegLoadError } from "@/lib/ffmpeg";
 
 const DEFAULT_TITLE = "Reframe — Resize, trim, and export videos in your browser";
@@ -58,6 +58,58 @@ function verifyMagicBytes(file: File): Promise<boolean> {
     reader.onerror = () => resolve(false);
     reader.readAsArrayBuffer(file.slice(0, 12));
   });
+}
+
+function validateRecipe(recipe: EditRecipe, duration: number ): string | null {
+  const validations: Array<[boolean, string]> = [
+    [
+      recipe.trimStart < 0,
+      "Trim start time cannot be less than 0 seconds.",
+    ],
+    [
+      recipe.trimEnd !== null && recipe.trimEnd > duration,
+      `Trim end time cannot exceed the video duration (${Math.floor(duration)}s).`,
+    ],
+    [
+      recipe.trimStart >= (recipe.trimEnd ?? duration),
+      "Trim start time must be earlier than the end time.",
+    ],
+    [
+      recipe.preset === "custom" && (recipe.customWidth < 16 || recipe.customWidth > 7680),
+      "Width must be between 16px and 7680px.",
+    ],
+    [
+      recipe.preset === "custom" && (recipe.customHeight < 16 || recipe.customHeight > 7680),
+      "Height must be between 16px and 7680px.",
+    ],
+    [
+      !(SPEED_STEPS as readonly number[]).includes(recipe.speed),
+      "Please select a valid playback speed.",
+    ],
+    [
+      recipe.quality < 18 || recipe.quality > 30,
+      "Quality must be between 18 and 30.",
+    ],
+    [
+      recipe.brightness < -1 || recipe.brightness > 1,
+      "Brightness must be between -1 and 1.",
+    ],
+
+    [
+      recipe.contrast < 0 || recipe.contrast > 2,
+      "Contrast must be between 0 and 2.",
+    ],
+
+    [
+      recipe.saturation < 0 || recipe.saturation > 3,
+      "Saturation must be between 0 and 3.",
+    ],
+  ];
+
+  return (
+    validations.find(([condition]) => condition)?.[1] ??
+    null
+  );
 }
 
 export function useVideoEditor() {
@@ -173,6 +225,13 @@ export function useVideoEditor() {
       return;
     }
 
+    const validationError = validateRecipe(recipe, duration);
+    if (validationError) {
+      setError(validationError);
+      setStatus("error");
+      return;
+    }
+
     const abortController = new AbortController();
     exportAbortControllerRef.current = abortController;
     exportCancelledRef.current = false;
@@ -220,7 +279,7 @@ export function useVideoEditor() {
         exportAbortControllerRef.current = null;
       }
     }
-  }, [file, recipe, result, status]);
+  }, [file, recipe, result, status, duration]);
 
   useEffect(() => {
     if (file) {


### PR DESCRIPTION
# Changes

- Added validation for all EditRecipe fields before passing them to FFmpeg to prevent unexpected behavior.
- Added UI validation for custom height and width inputs to improve user experience.

Closes #143 

- [x] Code works in Chrome, Firefox, and Safari
- [x] No new TypeScript errors (`bunx tsc --noEmit`)
- [x] ESLint passes (`bun run lint`)
- [ ] UI changes tested on mobile (use browser DevTools) - No UI Changes
- [ ] Accessibility: new interactive elements have ARIA labels - No UI Changes
- [x] Issue number referenced in PR description