### PR TITLE
ci: fix label automation — keyword bot + force Claude API calls

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,63 +1,89 @@
-name: 🏷️ Auto Labeler
+name: Auto Label
 
 on:
+  issues:
+    types: [opened]
   pull_request_target:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
 
 permissions:
+  issues: write
   pull-requests: write
+  contents: read
 
 jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - name: Auto-label based on changed files
+      - name: Apply keyword and size labels
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const pr = context.payload.pull_request;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const number = pr.number;
+            const isPR = context.eventName === 'pull_request_target';
 
-            if (pr.user.type === 'Bot') return;
+            const number = isPR
+              ? context.payload.pull_request.number
+              : context.payload.issue.number;
+            const title = isPR
+              ? context.payload.pull_request.title
+              : context.payload.issue.title;
+            const body = (isPR
+              ? context.payload.pull_request.body
+              : context.payload.issue.body) || '';
 
-            const { data: files } = await github.rest.pulls.listFiles({
-              owner, repo, pull_number: number, per_page: 100
-            });
-
-            const filenames = files.map(f => f.filename);
+            const text = `${title} ${body}`.toLowerCase();
             const labelsToAdd = new Set();
 
-            const patterns = [
-              [/^src\/lib\/ffmpeg/, 'ffmpeg'],
-              [/^src\/components\/.*/, 'ui/ux'],
-              [/^src\/lib\/.*/, 'enhancement'],
-              [/^src\/app\/.*\.css/, 'ui/ux'],
-              [/^\.github\/workflows\//, 'ci/cd'],
-              [/^\.github\//, 'ci/cd'],
-              [/^(README|CONTRIBUTING|CODE_OF_CONDUCT|LICENSE)/, 'documentation'],
-              [/\.(test|spec)\.(ts|tsx)$/, 'testing'],
-              [/^(package\.json|bun\.lock|yarn\.lock)$/, 'dependencies'],
-              [/^(vercel\.json|next\.config\.ts|tailwind\.config\.ts)$/, 'ci/cd'],
-              [/^public\//, 'documentation'],
-              [/^src\/hooks\//, 'enhancement'],
+            // Keyword → type label
+            const keywordMap = [
+              [/\bbug\b|\bfix(es|ed)?\b|\bbroken\b|\bcrash\b|\berror\b/, 'type:bug'],
+              [/\bfeature\b|\benhancement\b/, 'type:feature'],
+              [/\bdocs?\b|\bdocumentation\b|\breadme\b/, 'type:docs'],
+              [/\bsecurity\b|\bvulnerabilit|\bcve\b/, 'type:security'],
+              [/\bperformance\b|\boptimi[sz]e?\b|\bslow\b|\bspeed\b|\blatency\b/, 'type:performance'],
+              [/\bdesign\b|\bui\b|\bux\b|\bstyle\b|\bcsss?\b|\blayout\b/, 'type:design'],
+              [/\brefactor\b|\bclean.?up\b|\brestructure\b/, 'type:refactor'],
+              [/\btest(ing|s)?\b|\bspec\b|\bunit\b|\be2e\b/, 'type:testing'],
             ];
 
-            for (const [pattern, label] of patterns) {
-              if (filenames.some(f => pattern.test(f))) {
-                labelsToAdd.add(label);
-              }
+            for (const [pattern, label] of keywordMap) {
+              if (pattern.test(text)) labelsToAdd.add(label);
             }
 
-            if (labelsToAdd.size > 0) {
-              try {
-                await github.rest.issues.addLabels({
-                  owner, repo, issue_number: number,
-                  labels: Array.from(labelsToAdd)
+            // Line-count → level label (PRs only — issues have no diff)
+            if (isPR) {
+              let totalLines = 0;
+              let page = 1;
+              while (true) {
+                const { data: files } = await github.rest.pulls.listFiles({
+                  owner, repo, pull_number: number, per_page: 100, page
                 });
-              } catch (e) {
-                core.warning(`Failed to add labels: ${e?.message}`);
+                totalLines += files.reduce((sum, f) => sum + f.additions + f.deletions, 0);
+                if (files.length < 100) break;
+                page++;
               }
+
+              if (totalLines < 50) labelsToAdd.add('level:beginner');
+              else if (totalLines <= 200) labelsToAdd.add('level:intermediate');
+              else labelsToAdd.add('level:advanced');
+            }
+
+            if (labelsToAdd.size === 0) {
+              core.info('No labels matched. Skipping.');
+              return;
+            }
+
+            core.info(`Applying labels: ${Array.from(labelsToAdd).join(', ')}`);
+            try {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: number,
+                labels: Array.from(labelsToAdd)
+              });
+            } catch (e) {
+              core.warning(`Failed to add labels: ${e?.message}`);
             }

--- a/.github/workflows/claude-manager.yml
+++ b/.github/workflows/claude-manager.yml
@@ -86,10 +86,16 @@ jobs:
                - Acknowledges the specific problem they reported
                - Asks 1-2 targeted clarifying questions if the issue is vague or missing reproduction steps
                - Mentions a maintainer will review soon
-            3. Apply the correct GSSoC labels from CLAUDE.md:
-               - One level:* label (beginner/intermediate/advanced/critical)
-               - One or more type:* labels (bug/feature/docs/testing/security/performance/design/refactor/devops/accessibility)
-               - Add gssoc'26 if not already present
+            3. Apply the correct GSSoC labels. You MUST use the gh CLI to actually apply them —
+               do NOT mention labels in a comment instead of applying them. Run:
+                 gh issue edit ${{ github.event.issue.number }} \
+                   --add-label "label1,label2" \
+                   --repo ${{ github.repository }}
+               Choose labels from these lists:
+               - Exactly ONE level:* label → level:beginner / level:intermediate / level:advanced / level:critical
+               - One or more type:* labels → type:bug / type:feature / type:docs / type:testing /
+                 type:security / type:performance / type:design / type:refactor / type:devops / type:accessibility
+               - Always include gssoc'26
             4. Read all existing comments on the issue. If anyone said "I'd like to work on this",
                "can I be assigned?", "I want to take this", or similar — assign the issue to the
                FIRST person who made such a request. Only assign one person.


### PR DESCRIPTION
## Changes

### `auto-label.yml` — full rewrite
- **Now triggers on `issues: [opened]`** in addition to `pull_request_target` — issues were never labeled before
- **Keyword regex on title + body** applies `type:*` labels instantly (was file-path patterns only)
  - `bug/fix/broken/crash/error` → `type:bug`
  - `feature/enhancement` → `type:feature`
  - `docs/documentation/readme` → `type:docs`
  - `security/vulnerability/cve` → `type:security`
  - `performance/optimize/slow/speed/latency` → `type:performance`
  - `design/ui/ux/style/css/layout` → `type:design`
  - `refactor/cleanup/restructure` → `type:refactor`
  - `test/testing/spec/unit/e2e` → `type:testing`
- **PR line-count** (additions + deletions across all changed files) → `level:beginner` (<50) / `level:intermediate` (50–200) / `level:advanced` (>200)
- Calls `github.rest.issues.addLabels` directly

### `claude-manager.yml` — `claude-issue-triage` prompt
- Explicitly requires Claude to run `gh issue edit --add-label` — no more label recommendations posted as comments
- Lists all valid `level:*` and `type:*` label names inline

## Note
Labels must exist in the repo before `addLabels` can apply them. If any `type:*` or `level:*` labels are missing, create them under Settings → Labels first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)