### PR TITLE
docs: add bot-based issue assignment guide to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ If you're ready to tackle some open issues, **[we've collected some good first i
 - [Development Setup](#development-setup)
 - [Project Structure](#project-structure)
 - [Finding Issues](#finding-issues)
+- [Claiming Issues](#-claiming-issues)
 - [Making Changes](#making-changes)
 - [Submitting a Pull Request](#submitting-a-pull-request)
 - [Code Style](#code-style)
@@ -230,9 +231,45 @@ We have **300+ open issues** across all skill levels:
 | ⚡ **Performance** | [`performance`](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3Aperformance) label |
 
 **Before claiming an issue:**
-1. Check if someone is already working on it (look at comments and assignees)
-2. Comment on the issue to let maintainers know you're working on it
-3. If it's been idle for 7+ days, feel free to take it over
+1. Check if it already has an assignee — if so, pick a different one
+2. Comment `/assign` on the issue to claim it instantly via our bot
+3. If an issue has been idle and unassigned for a while, it's fair game
+
+---
+
+## 🙋 Claiming Issues
+
+We use a bot to automatically manage issue assignments. Here's how it works:
+
+### Claiming an Issue
+Comment `/assign` on any open issue to claim it:
+- The bot will assign it to you instantly
+- You have **5 days** to make progress before it is automatically unassigned
+- You can only hold **5 issues** at a time across the repo
+
+### Unassigning Yourself
+If you can no longer work on an issue, comment `/unassign` to release it:
+- This frees it up for other contributors immediately
+- No hard feelings — we appreciate the honesty!
+
+### Assignment Rules
+- ✅ First person to comment `/assign` gets the issue
+- ✅ Only **one contributor** can be assigned per issue at a time
+- ✅ Maximum **5 issues** per contributor at once
+- ⚠️ You will get a warning after **2 days** of no activity
+- ⚠️ You will get a final warning after **4 days** of no activity
+- ❌ Issue is automatically unassigned after **5 days** of no activity
+
+### Inactivity Warnings
+The bot will ping you if your assigned issue has no activity:
+- **Day 2** — friendly reminder to update your progress
+- **Day 4** — final warning, 24 hours left before unassignment
+- **Day 5** — automatic unassignment, issue reopens for others
+
+### Tips
+- Leave a comment on your issue if you are stuck or need help — any comment resets the inactivity timer
+- Link your PR to the issue using `Fixes #issue_number` in your PR description
+- If you see an issue already assigned, please pick a different one
 
 ---
 
@@ -325,9 +362,8 @@ Reframe is an **official GirlScript Summer of Code 2026 project**!
 
 1. Browse issues labeled [`gssoc'26`](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3A%22gssoc%2726%22)
 2. Start with [`good first issue`](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3A%22gssoc%2726%22) if you're new to open source
-3. Comment on the issue with: "I'd like to work on this for GSSoC'26 — @magic-peach"
-4. Wait for a maintainer to assign the issue to you
-5. Submit your PR within **7 days** of being assigned
+3. Comment `/assign` on the issue — our bot will assign it to you instantly, no maintainer needed
+4. Submit your PR within **5 days** and remember to link it with `Fixes #issue_number`
 
 ### Tips for GSSoC Success
 


### PR DESCRIPTION
## Changes

Adds a **🙋 Claiming Issues** section to `CONTRIBUTING.md` explaining the assignment bot, and updates two places that had stale manual-assignment instructions.

### New section — Claiming Issues
- How to use `/assign` and `/unassign`
- 5-issue cap per contributor
- Inactivity timeline: Day 2 warning → Day 4 final warning → Day 5 auto-unassign
- Tips (any comment resets the timer, link PRs with `Fixes #N`)

### Updated — Finding Issues
- "Before claiming an issue" bullets now reference the bot instead of telling contributors to comment manually and wait

### Updated — GSSoC Getting Started
- Step 3: `/assign` replaces "comment and wait for a maintainer to assign"
- Step 4: timeline corrected from 7 days to 5 days (matches the bot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)