### PR TITLE
feat: add color filter presets 

### DIFF
--- a/src/components/ColorFilterControl.tsx
+++ b/src/components/ColorFilterControl.tsx
@@ -1,0 +1,42 @@
+import { EditRecipe } from "@/lib/types";
+
+interface Props {
+  recipe: EditRecipe;
+  onChange: (updates: Partial<EditRecipe>) => void;
+}
+
+const FILTERS = [
+  { id: "none", label: "None", css: "bg-gradient-to-tr from-rose-400 to-orange-300" },
+  { id: "grayscale", label: "Gray", css: "bg-gradient-to-tr from-gray-400 to-gray-500 grayscale" },
+  { id: "sepia", label: "Sepia", css: "bg-gradient-to-tr from-[#9e7452] to-[#cba37a] sepia" },
+  { id: "vintage", label: "Vintage", css: "bg-gradient-to-tr from-[#6b4c3a] to-[#d4b595] contrast-75 sepia-[.5]" },
+  { id: "cool", label: "Cool", css: "bg-gradient-to-tr from-cyan-400 to-blue-500" },
+  { id: "warm", label: "Warm", css: "bg-gradient-to-tr from-orange-400 to-red-400" },
+  { id: "high-contrast", label: "Contrast", css: "bg-gradient-to-tr from-zinc-800 to-zinc-900 contrast-125" },
+] as const;
+
+export default function ColorFilterControl({ recipe, onChange }: Props) {
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-4 gap-2">
+        {FILTERS.map((f) => (
+          <button
+            key={f.id}
+            type="button"
+            onClick={() => onChange({ colorFilter: f.id as EditRecipe["colorFilter"] })}
+            className={`flex flex-col items-center gap-1.5 p-1.5 rounded-lg border-2 transition-all ${
+              recipe.colorFilter === f.id
+                ? "border-film-600 bg-film-50 dark:bg-film-900/20"
+                : "border-transparent hover:bg-[var(--border)]"
+            }`}
+          >
+            <div className={`w-full aspect-video rounded-md shadow-inner ${f.css}`} />
+            <span className="text-[9px] font-heading font-semibold uppercase tracking-wider text-[var(--text)] text-center">
+              {f.label}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -16,10 +16,11 @@ import ExportSettings from "./ExportSettings";
 import ExportOverlay from "./ExportOverlay";
 import DownloadResult from "./DownloadResult";
 import ImageOverlay from "./ImageOverlay"
+import ColorFilterControl from "./ColorFilterControl";
 import { cn } from "@/lib/utils";
 import {
   Layers, Crop, Scissors, RotateCw, Volume2,
-  SlidersHorizontal, Zap, AlertTriangle, Github
+  SlidersHorizontal, Zap, AlertTriangle, Github, Palette
 } from "lucide-react";
 import OnboardingTour from "./OnboardingTour";
 
@@ -257,6 +258,9 @@ export default function VideoEditor() {
                   </Section>
                   <Section icon={<SlidersHorizontal size={12} />} title="Export quality" delay={200}>
                     <ExportSettings recipe={recipe} duration={duration} onChange={updateRecipe} />
+                  </Section>
+                  <Section icon={<Palette size={12} />} title="Color Filters" delay={210}>
+                    <ColorFilterControl recipe={recipe} onChange={updateRecipe} />
                   </Section>
                   <Section icon={<Layers size={12} />} title="Image overlay" delay={120}>
                     <ImageOverlay

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -17,6 +17,7 @@ export const DEFAULT_RECIPE: EditRecipe = {
   brightness: 0,
   contrast: 1,
   saturation: 1,
+  colorFilter: "none",
   stabilization: false,
   soundOnCompletion: false,
   normalizeAudio: false,

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -125,6 +125,28 @@ function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number):
     const pts = (1 / recipe.speed).toFixed(4);
     filters.push(`setpts=${pts}*PTS`);
   }
+
+  switch (recipe.colorFilter) {
+    case "grayscale":
+      filters.push("format=gray");
+      break;
+    case "sepia":
+      filters.push("colorchannelmixer=.393:.769:.189:0:.349:.686:.168:0:.272:.534:.131");
+      break;
+    case "vintage":
+      filters.push("curves=preset=vintage");
+      break;
+    case "cool":
+      filters.push("colorbalance=rs=-0.2:bs=0.2");
+      break;
+    case "warm":
+      filters.push("colorbalance=rs=0.2:bs=-0.2");
+      break;
+    case "high-contrast":
+      filters.push("eq=contrast=1.5");
+      break;
+  }
+
   filters.push(
     `eq=brightness=${recipe.brightness}:contrast=${recipe.contrast}:saturation=${recipe.saturation}`
   );

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,6 +15,7 @@ export interface EditRecipe {
   brightness: number;
   contrast: number;
   saturation: number;
+  colorFilter: "none" | "grayscale" | "sepia" | "vintage" | "cool" | "warm" | "high-contrast";
   soundOnCompletion: boolean;
 }
 
@@ -81,6 +82,7 @@ export const DEFAULT_RECIPE: EditRecipe = {
   brightness: 0,
   contrast: 0,
   saturation: 0,
+  colorFilter: "none",
   soundOnCompletion: false,
 };
 


### PR DESCRIPTION
### 🚀 Description
This PR introduces a new **Color Filters** control panel to the application, fulfilling all requirements outlined in the enhancement issue.

Users can now select from a visual grid of carefully mapped FFmpeg color filters, allowing them to apply stylistic visual effects before exporting. The `'None'` option is set as the default, and the interface uses semantic swatches to preview the effect.

### ✨ Changes Made
* **`src/components/ColorFilterControl.tsx`**: Created a new UI component rendering a responsive grid of filter swatches with active/hover states.
* **`src/components/VideoEditor.tsx`**: Integrated the new component into the editor layout alongside the export quality settings.
* **`src/lib/types.ts` & `constants.ts`**: Expanded the `EditRecipe` to include the new `colorFilter` property.
* **`src/lib/ffmpeg.ts`**: Implemented the precise FFmpeg filtergraph logic for each preset:
  * Grayscale: `format=gray`
  * Sepia: `colorchannelmixer` with exact color coefficients
  * Vintage: `curves=preset=vintage`
  * Cool: `colorbalance=rs=-0.2:bs=0.2`
  * Warm: `colorbalance=rs=0.2:bs=-0.2`
  * High-Contrast: `eq=contrast=1.5`

### 🔗 Related Issue
Closes #131 

### ✅ Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] UI/UX enhancement
