### PR TITLE
feat: add character count and validation to filename input (#204)

### DIFF
--- a/src/components/DownloadResult.tsx
+++ b/src/components/DownloadResult.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import { useState } from "react";
 import { ExportResult } from "@/lib/types";
 import { formatBytes } from "@/lib/ffmpeg";
-import { Download, RotateCcw, Share2 } from "lucide-react";
+import { Download, RotateCcw, Share2, AlertCircle } from "lucide-react";
 import LottiePlayer from "./LottiePlayer";
 import successAnim from "@/lib/lottie/success.json";
+import { cn } from "@/lib/utils";
 
 const SHARE_TWEET_TEXT =
   "I just edited my video with @reframevideo — free browser-based video editor! Check it out: https://github.com/magic-peach/reframe";
@@ -15,7 +17,13 @@ interface Props {
 }
 
 export default function DownloadResult({ result, onReset }: Props) {
-  const filename = `reframe_${result.width}x${result.height}.${result.format}`;
+  const defaultName = `reframe_${result.width}x${result.height}`;
+  const [name, setName] = useState(defaultName);
+
+  const invalidCharRegex = /[<>:"/\\|?*]/;
+  const isValid = !invalidCharRegex.test(name) && name.trim().length > 0;
+  const filename = `${name.trim() || "untitled"}.${result.format}`;
+
   const shareHref = `https://x.com/intent/tweet?text=${encodeURIComponent(SHARE_TWEET_TEXT)}`;
 
   return (
@@ -44,11 +52,53 @@ export default function DownloadResult({ result, onReset }: Props) {
         </div>
       </div>
 
-      <div className="flex flex-wrap gap-2">
+      <div className="space-y-1.5 pt-2">
+        <div className="flex justify-between items-center text-xs px-1">
+          <label htmlFor="filename-input" className="text-[var(--muted)] font-heading font-semibold uppercase tracking-wider">
+            Filename
+          </label>
+          <span className={cn("transition-colors", name.length >= 100 ? "text-red-500 font-medium" : "text-[var(--muted)]")}>
+            {100 - name.length} chars remaining
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            id="filename-input"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            maxLength={100}
+            className={cn(
+              "flex-1 px-3 py-2.5 bg-[var(--bg)] border rounded-lg text-sm transition-colors text-[var(--text)] placeholder:text-[var(--muted)]",
+              !isValid && name.length > 0 ? "border-red-500 focus:outline-red-500 focus:ring-1 focus:ring-red-500" : "border-[var(--border)] focus:outline-film-500"
+            )}
+            placeholder="Enter filename"
+          />
+          <span className="text-sm text-[var(--muted)] shrink-0 font-medium bg-[var(--bg)] px-3 py-2.5 border border-[var(--border)] rounded-lg">
+            .{result.format}
+          </span>
+        </div>
+        {!isValid && name.length > 0 && (
+          <p className="text-xs text-red-500 px-1 flex items-center gap-1.5 mt-1 animate-fade-in">
+            <AlertCircle size={12} />
+            Filename contains invalid characters (\ / : * ? " &lt; &gt; |)
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-wrap gap-2 pt-2">
         <a
-          href={result.blobUrl}
-          download={filename}
-          className="flex-1 min-w-[10rem] flex items-center justify-center gap-2 py-3 bg-film-600 hover:bg-film-700 text-white text-sm font-heading font-bold uppercase tracking-wide rounded-lg transition-all hover:scale-[1.01] active:scale-[0.99]"
+          href={isValid ? result.blobUrl : undefined}
+          download={isValid ? filename : undefined}
+          className={cn(
+            "flex-1 min-w-[10rem] flex items-center justify-center gap-2 py-3 text-white text-sm font-heading font-bold uppercase tracking-wide rounded-lg transition-all",
+            isValid 
+              ? "bg-film-600 hover:bg-film-700 hover:scale-[1.01] active:scale-[0.99] cursor-pointer" 
+              : "bg-film-600/50 cursor-not-allowed"
+          )}
+          onClick={(e) => {
+            if (!isValid) e.preventDefault();
+          }}
         >
           <Download size={15} />
           Download {result.format.toUpperCase()}

--- a/src/components/DownloadResult.tsx
+++ b/src/components/DownloadResult.tsx
@@ -81,7 +81,7 @@ export default function DownloadResult({ result, onReset }: Props) {
         {!isValid && name.length > 0 && (
           <p className="text-xs text-red-500 px-1 flex items-center gap-1.5 mt-1 animate-fade-in">
             <AlertCircle size={12} />
-            Filename contains invalid characters (\ / : * ? " &lt; &gt; |)
+            Filename contains invalid characters (\ / : * ? &quot; &lt; &gt; |)
           </p>
         )}
       </div>

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -158,7 +158,7 @@ export function useVideoEditor() {
         exportAbortControllerRef.current = null;
       }
     }
-  }, [file, recipe, result]);
+  }, [file, recipe, result, status]);
 
   useEffect(() => {
     if (file) {


### PR DESCRIPTION
## Overview
Closes #204.

This PR implements a real-time character count and validation for the custom filename input in the `DownloadResult` component. This ensures users can't download files with invalid OS characters or excessively long filenames.

## Changes Made
- Added a filename text input replacing the previously hardcoded filename logic.
- **Validation**: Added a regex check (`/[<>:"/\\|?*]/`) to detect invalid characters in real-time.
- **UI Enhancements**:
  - Displays remaining characters (100 character max length enforced).
  - Turns input borders and the remaining character count red when limits or invalid characters are detected.
  - Shows an inline error message immediately when invalid characters are typed.
  - Prevents downloading (button visual state reflects disabled state and `href` clears) until the filename is corrected.
