### PR TITLE
feat: add thumbnail strip for video frame navigation

### DIFF
--- a/src/components/ThumbnailStrip.tsx
+++ b/src/components/ThumbnailStrip.tsx
@@ -1,0 +1,397 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+
+interface Thumbnail {
+  time: number;
+  dataUrl: string;
+}
+
+interface ThumbnailStripProps {
+  videoSrc: string | null;
+  duration: number;
+  currentTime: number;
+  trimStart?: number;
+  trimEnd?: number;
+  onSeek: (time: number) => void;
+  intervalSeconds?: number;
+}
+
+export default function ThumbnailStrip({
+  videoSrc,
+  duration,
+  currentTime,
+  trimStart = 0,
+  trimEnd,
+  onSeek,
+  intervalSeconds = 5,
+}: ThumbnailStripProps) {
+  const [thumbnails, setThumbnails] = useState<Thumbnail[]>([]);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+  const stripRef = useRef<HTMLDivElement>(null);
+  const offscreenVideoRef = useRef<HTMLVideoElement | null>(null);
+  const abortRef = useRef(false);
+
+  const effectiveTrimEnd = trimEnd ?? duration;
+
+  const generateThumbnails = useCallback(async () => {
+    if (!videoSrc || duration <= 0) return;
+
+    abortRef.current = false;
+    setIsGenerating(true);
+    setThumbnails([]);
+    setProgress(0);
+
+    const video = document.createElement("video");
+    video.src = videoSrc;
+    video.crossOrigin = "anonymous";
+    video.muted = true;
+    video.preload = "auto";
+    offscreenVideoRef.current = video;
+
+    await new Promise<void>((resolve, reject) => {
+      video.onloadedmetadata = () => resolve();
+      video.onerror = () => reject(new Error("Video load failed"));
+      video.load();
+    });
+
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const thumbW = 160;
+    const thumbH = 90;
+    canvas.width = thumbW;
+    canvas.height = thumbH;
+
+    const times: number[] = [];
+    for (let t = 0; t <= duration; t += intervalSeconds) {
+      times.push(Math.min(t, duration - 0.1));
+    }
+    if (times[times.length - 1] < duration - 0.5) {
+      times.push(duration - 0.1);
+    }
+
+    const captured: Thumbnail[] = [];
+
+    for (let i = 0; i < times.length; i++) {
+      if (abortRef.current) break;
+
+      const time = times[i];
+      await new Promise<void>((resolve) => {
+        const onSeeked = () => {
+          video.removeEventListener("seeked", onSeeked);
+          ctx.drawImage(video, 0, 0, thumbW, thumbH);
+          captured.push({ time, dataUrl: canvas.toDataURL("image/jpeg", 0.7) });
+          setThumbnails([...captured]);
+          setProgress(Math.round(((i + 1) / times.length) * 100));
+          resolve();
+        };
+        video.addEventListener("seeked", onSeeked);
+        video.currentTime = time;
+      });
+    }
+
+    video.src = "";
+    offscreenVideoRef.current = null;
+    setIsGenerating(false);
+  }, [videoSrc, duration, intervalSeconds]);
+
+  useEffect(() => {
+    if (videoSrc && duration > 0) {
+      generateThumbnails();
+    }
+    return () => {
+      abortRef.current = true;
+    };
+  }, [generateThumbnails]);
+
+  const formatTime = (seconds: number) => {
+    const m = Math.floor(seconds / 60);
+    const s = Math.floor(seconds % 60);
+    return `${m}:${s.toString().padStart(2, "0")}`;
+  };
+
+  const activeIndex = thumbnails.findIndex(
+    (t, i) =>
+      currentTime >= t.time &&
+      (i === thumbnails.length - 1 || currentTime < thumbnails[i + 1].time)
+  );
+
+  if (!videoSrc) return null;
+
+  return (
+    <div className="thumbnail-strip-wrapper">
+      <div className="strip-header">
+        <span className="strip-label">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <rect x="0.5" y="0.5" width="11" height="11" rx="1.5" stroke="currentColor" />
+            <rect x="3" y="2.5" width="1.5" height="7" rx="0.5" fill="currentColor" />
+            <rect x="7.5" y="2.5" width="1.5" height="7" rx="0.5" fill="currentColor" />
+          </svg>
+          Frames
+        </span>
+        {isGenerating && (
+          <span className="strip-progress">
+            <span
+              className="progress-bar"
+              style={{ width: `${progress}%` }}
+            />
+            <span className="progress-text">{progress}%</span>
+          </span>
+        )}
+        {!isGenerating && thumbnails.length > 0 && (
+          <span className="strip-meta">
+            {thumbnails.length} frames · every {intervalSeconds}s
+          </span>
+        )}
+      </div>
+
+      <div className="strip-scroll-area" ref={stripRef}>
+        {thumbnails.length === 0 && isGenerating && (
+          <div className="strip-skeleton">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div key={i} className="skeleton-thumb" style={{ animationDelay: `${i * 80}ms` }} />
+            ))}
+          </div>
+        )}
+
+        {thumbnails.length > 0 && (
+          <div className="strip-inner">
+            {thumbnails.map((thumb, i) => {
+              const isActive = i === activeIndex;
+              const inTrimRange =
+                thumb.time >= trimStart && thumb.time <= effectiveTrimEnd;
+              const isHovered = hoveredIndex === i;
+
+              return (
+                <button
+                  key={thumb.time}
+                  className={`thumb-btn ${isActive ? "active" : ""} ${
+                    !inTrimRange ? "out-of-range" : ""
+                  } ${isHovered ? "hovered" : ""}`}
+                  onClick={() => onSeek(thumb.time)}
+                  onMouseEnter={() => setHoveredIndex(i)}
+                  onMouseLeave={() => setHoveredIndex(null)}
+                  title={`Seek to ${formatTime(thumb.time)}`}
+                >
+                  <img
+                    src={thumb.dataUrl}
+                    alt={`Frame at ${formatTime(thumb.time)}`}
+                    draggable={false}
+                  />
+                  <span className="thumb-time">{formatTime(thumb.time)}</span>
+                  {isActive && <span className="active-indicator" />}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      <style>{`
+        .thumbnail-strip-wrapper {
+          width: 100%;
+          background: #0d0d0f;
+          border: 1px solid #1e1e24;
+          border-radius: 10px;
+          overflow: hidden;
+          font-family: 'SF Mono', 'Fira Code', monospace;
+        }
+
+        .strip-header {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+          padding: 8px 14px;
+          background: #111115;
+          border-bottom: 1px solid #1e1e24;
+        }
+
+        .strip-label {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          font-size: 10px;
+          font-weight: 600;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          color: #5a5a72;
+        }
+
+        .strip-progress {
+          position: relative;
+          flex: 1;
+          height: 3px;
+          background: #1e1e24;
+          border-radius: 2px;
+          overflow: hidden;
+          display: flex;
+          align-items: center;
+        }
+
+        .progress-bar {
+          position: absolute;
+          left: 0;
+          top: 0;
+          height: 100%;
+          background: linear-gradient(90deg, #4f6ef7, #a78bfa);
+          border-radius: 2px;
+          transition: width 0.2s ease;
+        }
+
+        .progress-text {
+          position: absolute;
+          right: -28px;
+          font-size: 9px;
+          color: #5a5a72;
+          white-space: nowrap;
+        }
+
+        .strip-meta {
+          margin-left: auto;
+          font-size: 10px;
+          color: #3a3a50;
+        }
+
+        .strip-scroll-area {
+          overflow-x: auto;
+          overflow-y: hidden;
+          padding: 10px 10px 6px;
+          scrollbar-width: thin;
+          scrollbar-color: #2a2a35 transparent;
+        }
+
+        .strip-scroll-area::-webkit-scrollbar {
+          height: 4px;
+        }
+
+        .strip-scroll-area::-webkit-scrollbar-track {
+          background: transparent;
+        }
+
+        .strip-scroll-area::-webkit-scrollbar-thumb {
+          background: #2a2a35;
+          border-radius: 2px;
+        }
+
+        .strip-skeleton {
+          display: flex;
+          gap: 6px;
+        }
+
+        .skeleton-thumb {
+          width: 106px;
+          height: 60px;
+          border-radius: 6px;
+          background: linear-gradient(90deg, #111115 25%, #1a1a22 50%, #111115 75%);
+          background-size: 200% 100%;
+          animation: shimmer 1.4s infinite;
+          flex-shrink: 0;
+        }
+
+        @keyframes shimmer {
+          0% { background-position: 200% 0; }
+          100% { background-position: -200% 0; }
+        }
+
+        .strip-inner {
+          display: flex;
+          gap: 6px;
+          align-items: flex-end;
+        }
+
+        .thumb-btn {
+          position: relative;
+          padding: 0;
+          border: none;
+          background: none;
+          cursor: pointer;
+          border-radius: 6px;
+          overflow: hidden;
+          flex-shrink: 0;
+          width: 106px;
+          height: 60px;
+          transition: transform 0.15s ease, box-shadow 0.15s ease;
+          outline: 2px solid transparent;
+          outline-offset: 1px;
+        }
+
+        .thumb-btn img {
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
+          display: block;
+          border-radius: 6px;
+          filter: brightness(0.85);
+          transition: filter 0.15s ease;
+        }
+
+        .thumb-btn:hover img,
+        .thumb-btn.hovered img {
+          filter: brightness(1.05);
+        }
+
+        .thumb-btn:hover,
+        .thumb-btn.hovered {
+          transform: translateY(-3px) scale(1.04);
+          box-shadow: 0 8px 24px rgba(0,0,0,0.6);
+          outline-color: rgba(79, 110, 247, 0.5);
+          z-index: 2;
+        }
+
+        .thumb-btn.active {
+          outline-color: #4f6ef7;
+          box-shadow: 0 0 0 2px #4f6ef7, 0 8px 20px rgba(79,110,247,0.3);
+          z-index: 3;
+        }
+
+        .thumb-btn.active img {
+          filter: brightness(1.1);
+        }
+
+        .thumb-btn.out-of-range img {
+          filter: brightness(0.35) saturate(0.2);
+        }
+
+        .thumb-time {
+          position: absolute;
+          bottom: 0;
+          left: 0;
+          right: 0;
+          padding: 3px 4px 3px;
+          background: linear-gradient(transparent, rgba(0,0,0,0.85));
+          font-size: 9px;
+          color: rgba(255,255,255,0.75);
+          text-align: center;
+          letter-spacing: 0.04em;
+          pointer-events: none;
+          border-radius: 0 0 6px 6px;
+        }
+
+        .thumb-btn.active .thumb-time {
+          color: #a5b4fc;
+        }
+
+        .active-indicator {
+          position: absolute;
+          top: 4px;
+          right: 4px;
+          width: 6px;
+          height: 6px;
+          border-radius: 50%;
+          background: #4f6ef7;
+          box-shadow: 0 0 6px #4f6ef7;
+          animation: pulse-dot 1.5s ease-in-out infinite;
+        }
+
+        @keyframes pulse-dot {
+          0%, 100% { opacity: 1; transform: scale(1); }
+          50% { opacity: 0.5; transform: scale(0.7); }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -3,6 +3,7 @@
 import { useVideoEditor } from "@/hooks/useVideoEditor";
 import FileUpload from "./FileUpload";
 import VideoPreview from "./VideoPreview";
+import ThumbnailStrip from "./ThumbnailStrip";  
 import PresetSelector from "./PresetSelector";
 import FramingControl from "./FramingControl";
 import TrimControl from "./TrimControl";
@@ -44,13 +45,17 @@ function Section({ icon, title, children, delay = 0 }: SectionProps) {
 
 export default function VideoEditor() {
   const {
-    file, duration, recipe, status, progress,
-    result, error, updateRecipe,
-    handleFileSelect, handleExport, cancelExport, reset,
-  } = useVideoEditor();
-
+  file, duration, recipe, status, progress,
+  result, error, updateRecipe,
+  handleFileSelect, handleExport, cancelExport, reset, resetSettings,
+  videoRef,
+  seekTo,
+} = useVideoEditor();
   const isProcessing = status === "loading-engine" || status === "exporting";
 
+  // build a stable object url string for ThumbnailStrip
+  const videoSrc = file ? URL.createObjectURL(file) : null;   // ← ADD this
+ 
   return (
     <div className="min-h-screen relative flex flex-col" style={{ background: "var(--bg)" }}>
       <ExportOverlay status={status} progress={progress} onCancel={cancelExport} />
@@ -87,7 +92,18 @@ export default function VideoEditor() {
 
               {file && (
                 <div className="mt-4 animate-fade-in">
-                  <VideoPreview file={file} />
+                  <VideoPreview file={file} videoRef={videoRef} />
+
+                  <div className="mt-3">
+                    <ThumbnailStrip
+                      videoSrc={videoSrc}
+                      duration={duration}
+                      currentTime={videoRef.current?.currentTime ?? 0}
+                      trimStart={recipe.trimStart ?? 0}
+                      trimEnd={recipe.trimEnd ?? duration}
+                      onSeek={seekTo}
+                    />
+                  </div>  
                 </div>
               )}
             </div>

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import { useMemo, useEffect } from "react";
 import { useVideoEditor } from "@/hooks/useVideoEditor";
 import FileUpload from "./FileUpload";
 import VideoPreview from "./VideoPreview";
-import ThumbnailStrip from "./ThumbnailStrip";  
+import ThumbnailStrip from "./ThumbnailStrip";
 import PresetSelector from "./PresetSelector";
 import FramingControl from "./FramingControl";
 import TrimControl from "./TrimControl";
@@ -45,17 +46,26 @@ function Section({ icon, title, children, delay = 0 }: SectionProps) {
 
 export default function VideoEditor() {
   const {
-  file, duration, recipe, status, progress,
-  result, error, updateRecipe,
-  handleFileSelect, handleExport, cancelExport, reset, resetSettings,
-  videoRef,
-  seekTo,
-} = useVideoEditor();
+    file, duration, recipe, status, progress,
+    result, error, updateRecipe,
+    handleFileSelect, handleExport, cancelExport, reset,
+    videoRef,
+    seekTo,
+  } = useVideoEditor();
+
   const isProcessing = status === "loading-engine" || status === "exporting";
 
-  // build a stable object url string for ThumbnailStrip
-  const videoSrc = file ? URL.createObjectURL(file) : null;   // ← ADD this
- 
+  const videoSrc = useMemo(
+    () => (file ? URL.createObjectURL(file) : null),
+    [file]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (videoSrc) URL.revokeObjectURL(videoSrc);
+    };
+  }, [videoSrc]);
+
   return (
     <div className="min-h-screen relative flex flex-col" style={{ background: "var(--bg)" }}>
       <ExportOverlay status={status} progress={progress} onCancel={cancelExport} />
@@ -84,10 +94,10 @@ export default function VideoEditor() {
               <FileUpload onFileSelect={handleFileSelect} currentFile={file} />
 
               {!file && (
-              <div className="text-center text-gray-500 py-6">
-                <p>Upload a video to get started</p>
-                <p className="text-sm">Supports MP4, MOV, WebM and more</p>
-              </div>
+                <div className="text-center text-gray-500 py-6">
+                  <p>Upload a video to get started</p>
+                  <p className="text-sm">Supports MP4, MOV, WebM and more</p>
+                </div>
               )}
 
               {file && (
@@ -103,7 +113,7 @@ export default function VideoEditor() {
                       trimEnd={recipe.trimEnd ?? duration}
                       onSeek={seekTo}
                     />
-                  </div>  
+                  </div>
                 </div>
               )}
             </div>
@@ -133,10 +143,10 @@ export default function VideoEditor() {
             )}
 
             {status === "error" && error && (
-                 <div
-                    role="status"
-                    className="flex items-start gap-3 p-4 bg-film-50 border border-film-200 rounded-xl text-film-800 text-sm animate-fade-in"
-                  >
+              <div
+                role="status"
+                className="flex items-start gap-3 p-4 bg-film-50 border border-film-200 rounded-xl text-film-800 text-sm animate-fade-in"
+              >
                 <AlertTriangle size={16} className="shrink-0 mt-0.5 text-film-500" />
                 <div>
                   <p className="font-heading font-bold text-sm">Error</p>
@@ -190,9 +200,9 @@ export default function VideoEditor() {
           <p className="text-[11px] font-heading text-[var(--muted)] tracking-wide">
             2026 Reframe. Free, open source, no login required.
           </p>
-<p className="text-[10px] text-[var(--muted)]">
-  All video processing happens locally in your browser using FFmpeg.wasm.
-</p>
+          <p className="text-[10px] text-[var(--muted)]">
+            All video processing happens locally in your browser using FFmpeg.wasm.
+          </p>
           <a
             href="https://github.com/magic-peach/reframe"
             target="_blank"

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -7,18 +7,16 @@ interface Props {
   videoRef: RefObject<HTMLVideoElement | null>;
 }
 
-export default function VideoPreview({ file ,videoRef }: Props) {
-  
+export default function VideoPreview({ file, videoRef }: Props) {
   const urlRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!file) return;
 
-    // revoke previous object url to avoid memory leaks
     if (urlRef.current) URL.revokeObjectURL(urlRef.current);
     const url = URL.createObjectURL(file);
     urlRef.current = url;
-    if (videoRef.current) videoRef.current.src = url;  
+    if (videoRef.current) videoRef.current.src = url;
 
     return () => {
       if (urlRef.current) URL.revokeObjectURL(urlRef.current);

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, RefObject } from "react";
 
 interface Props {
   file: File | null;
+  videoRef: RefObject<HTMLVideoElement | null>;
 }
 
-export default function VideoPreview({ file }: Props) {
-  const videoRef = useRef<HTMLVideoElement>(null);
+export default function VideoPreview({ file ,videoRef }: Props) {
+  
   const urlRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -17,12 +18,12 @@ export default function VideoPreview({ file }: Props) {
     if (urlRef.current) URL.revokeObjectURL(urlRef.current);
     const url = URL.createObjectURL(file);
     urlRef.current = url;
-    if (videoRef.current) videoRef.current.src = url;
+    if (videoRef.current) videoRef.current.src = url;  
 
     return () => {
       if (urlRef.current) URL.revokeObjectURL(urlRef.current);
     };
-  }, [file]);
+  }, [file, videoRef]);
 
   if (!file) return null;
 

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -6,6 +6,7 @@ import { loadFFmpeg, exportVideo, terminateFFmpeg } from "@/lib/ffmpeg";
 
 const DEFAULT_TITLE = "Reframe — Resize, trim, and export videos in your browser";
 
+
 function getVideoDuration(file: File): Promise<number> {
   return new Promise((resolve, reject) => {
     const video = document.createElement("video");
@@ -58,6 +59,7 @@ export function useVideoEditor() {
   const [error, setError] = useState<string | null>(null);
   const exportAbortControllerRef = useRef<AbortController | null>(null);
   const exportCancelledRef = useRef(false);
+  const videoRef = useRef<HTMLVideoElement>(null);
 
   const updateRecipe = useCallback((patch: Partial<EditRecipe>) => {
     setRecipe((prev) => ({ ...prev, ...patch }));
@@ -212,6 +214,12 @@ export function useVideoEditor() {
     return () => clearInterval(interval);
   }, [status]);
 
+  const seekTo = useCallback((time: number) => {
+  if (videoRef.current) {
+    videoRef.current.currentTime = time;
+  }
+}, []);
+
   return {
     file,
     duration,
@@ -220,6 +228,8 @@ export function useVideoEditor() {
     progress,
     result,
     error,
+    videoRef,   
+  seekTo, 
     updateRecipe,
     handleFileSelect,
     handleExport,

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -6,7 +6,6 @@ import { loadFFmpeg, exportVideo, terminateFFmpeg } from "@/lib/ffmpeg";
 
 const DEFAULT_TITLE = "Reframe — Resize, trim, and export videos in your browser";
 
-
 function getVideoDuration(file: File): Promise<number> {
   return new Promise((resolve, reject) => {
     const video = document.createElement("video");
@@ -36,11 +35,8 @@ function verifyMagicBytes(file: File): Promise<boolean> {
       const hex = Array.from(arr).map(b => b.toString(16).padStart(2, '0')).join('').toUpperCase();
       const ascii = String.fromCharCode(...arr);
 
-      // WebM / MKV
       if (hex.startsWith('1A45DFA3')) resolve(true);
-      // AVI
       else if (hex.startsWith('52494646')) resolve(true);
-      // MP4 / MOV (checks for 'ftyp' in first 12 bytes)
       else if (ascii.substring(0, 12).includes('ftyp')) resolve(true);
       else resolve(false);
     };
@@ -71,7 +67,6 @@ export function useVideoEditor() {
     setError(null);
     setFile(null);
 
-    // LAYER 1: Extension check
     const validExtensions = ['.mp4', '.mov', '.avi', '.webm', '.mkv'];
     const name = selectedFile.name.toLowerCase();
     const hasValidExtension = validExtensions.some(ext => name.endsWith(ext));
@@ -81,14 +76,12 @@ export function useVideoEditor() {
       return;
     }
 
-    // LAYER 2: MIME type check
     if (!selectedFile.type.startsWith("video/")) {
       setError(`Layer 2 Validation Failed: Invalid MIME type. Expected video/*, got ${selectedFile.type || 'unknown'}`);
       setStatus("error");
       return;
     }
 
-    // LAYER 3: Magic Bytes Verification
     const isVideo = await verifyMagicBytes(selectedFile);
     if (!isVideo) {
       setError("Layer 3 Validation Failed: Invalid file content. The file's magic bytes do not match known video formats.");
@@ -173,7 +166,6 @@ export function useVideoEditor() {
     };
 
     document.addEventListener("keydown", handleKeydown);
-
     return () => {
       document.removeEventListener("keydown", handleKeydown);
     };
@@ -199,7 +191,6 @@ export function useVideoEditor() {
     setError(null);
   }, []);
 
-  // Development-only memory monitoring during export
   useEffect(() => {
     if (process.env.NODE_ENV !== "development") return;
     if (status !== "exporting") return;
@@ -215,10 +206,10 @@ export function useVideoEditor() {
   }, [status]);
 
   const seekTo = useCallback((time: number) => {
-  if (videoRef.current) {
-    videoRef.current.currentTime = time;
-  }
-}, []);
+    if (videoRef.current) {
+      videoRef.current.currentTime = time;
+    }
+  }, []);
 
   return {
     file,
@@ -228,8 +219,8 @@ export function useVideoEditor() {
     progress,
     result,
     error,
-    videoRef,   
-  seekTo, 
+    videoRef,
+    seekTo,
     updateRecipe,
     handleFileSelect,
     handleExport,


### PR DESCRIPTION
## What
Adds a scrollable thumbnail strip below the video preview that captures 
frames at regular intervals and allows click-to-seek navigation.

## Changes
- `ThumbnailStrip.tsx`  - new component, captures frames via canvas at 
  every 5s, displays as scrollable strip with shimmer loading state
- `useVideoEditor.ts`  - exposes `videoRef` and `seekTo`
- `VideoPreview.tsx`  - accepts `videoRef` as prop instead of owning it locally
- `VideoEditor.tsx`  - wires everything together

## Behaviour
- Thumbnails generate automatically on video upload
- Clicking any frame seeks the player to that timestamp
- Frames outside trim range are visually dimmed
- Active frame gets a blue outline tracking playback position
- 
<img width="1366" height="768" alt="Screenshot (326)" src="https://github.com/user-attachments/assets/9aa597e6-8ffe-49cf-88e8-f261d7dea1b4" />

## 
Closes #127 
