### PR TITLE
feat: add reset to default button for audio and speed controls

### DIFF
--- a/src/components/AudioSpeedControl.tsx
+++ b/src/components/AudioSpeedControl.tsx
@@ -12,37 +12,38 @@ interface Props {
 }
 
 export default function AudioSpeedControl({ recipe, onChange }: Props) {
-useEffect(() => {
-  const handler = (e: KeyboardEvent) => {
-    const target = e.target as HTMLElement;
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
 
-    if (
-      target.tagName === "INPUT" ||
-      target.tagName === "TEXTAREA" ||
-      target.isContentEditable
-    ) {
-      return;
-    }
+      if (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable
+      ) {
+        return;
+      }
 
-    if (
-      e.key.toLowerCase() === "m" &&
-      !e.ctrlKey &&
-      !e.metaKey
-    ) {
-      onChange({
-        keepAudio: !recipe.keepAudio,
-      });
-    }
-  };
+      if (
+        e.key.toLowerCase() === "m" &&
+        !e.ctrlKey &&
+        !e.metaKey
+      ) {
+        onChange({
+          keepAudio: !recipe.keepAudio,
+        });
+      }
+    };
 
-  document.addEventListener("keydown", handler);
-
-  return () => {
-    document.removeEventListener("keydown", handler);
-  };
-}, [recipe.keepAudio, onChange]);
+    document.addEventListener("keydown", handler);
+    
+    return () => {
+      document.removeEventListener("keydown", handler);
+    };
+  }, [recipe.keepAudio, onChange]);
 
   const speedIndex = SPEED_STEPS.indexOf(recipe.speed as (typeof SPEED_STEPS)[number]);
+  
   const getSpeedDescription = (speed: number) => {
     if (speed <= 0.5) return "Very Slow";
     if (speed < 1) return "Slow";
@@ -50,8 +51,23 @@ useEffect(() => {
     if (speed <= 1.5) return "Fast";
     return "Very Fast";
   };
+
+  const isModified = recipe.speed !== 1 || !recipe.keepAudio;
+
   return (
     <div className="space-y-4">
+      {isModified && (
+        <div className="flex justify-end animate-fade-in">
+          <button
+            type="button"
+            onClick={() => onChange({ speed: 1, keepAudio: true })}
+            className="text-[11px] font-heading font-semibold uppercase tracking-wider text-film-600 hover:text-film-700 hover:underline transition-all duration-150"
+          >
+            Reset to Default
+          </button>
+        </div>
+      )}
+
       <button
         type="button"
         onClick={() => onChange({ keepAudio: !recipe.keepAudio })}


### PR DESCRIPTION
Closes #515

Added a conditionally rendered "Reset to Default" button that reverts the playback speed to 1x and unmutes the video if either option is modified.

https://github.com/user-attachments/assets/19b46ce8-c6b8-4930-a713-6f6514fe7056

