### PR TITLE
fix: improve export button visibility in light mode

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -51,7 +51,7 @@ export default function VideoEditor() {
   } = useVideoEditor();
   const [copied, setCopied] = useState(false);
 
-  
+
   const isProcessing = status === "loading-engine" || status === "exporting";
 
   return (
@@ -82,10 +82,10 @@ export default function VideoEditor() {
               <FileUpload onFileSelect={handleFileSelect} currentFile={file} />
 
               {!file && (
-              <div className="text-center text-gray-500 py-6">
-                <p>Upload a video to get started</p>
-                <p className="text-sm">Supports MP4, MOV, WebM and more</p>
-              </div>
+                <div className="text-center text-gray-500 py-6">
+                  <p>Upload a video to get started</p>
+                  <p className="text-sm">Supports MP4, MOV, WebM and more</p>
+                </div>
               )}
 
               {file && (
@@ -99,7 +99,7 @@ export default function VideoEditor() {
               <p className="text-yellow-400 text-sm">
                 ⚠️ Large file — processing may take several minutes
               </p>
-            )}      
+            )}
             {file && (
               <div className={cn(
                 "grid grid-cols-1 sm:grid-cols-2 gap-4",
@@ -115,102 +115,102 @@ export default function VideoEditor() {
                 </div>
                 <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6">
                   <Section icon={<Volume2 size={12} />} title="Audio & Speed" delay={150}>
-                  <Section
-  icon={<SlidersHorizontal size={12} />}
-  title="Adjustments"
-  delay={175}
->
-  <div className="space-y-5">
+                    <Section
+                      icon={<SlidersHorizontal size={12} />}
+                      title="Adjustments"
+                      delay={175}
+                    >
+                      <div className="space-y-5">
 
-    {/* Brightness */}
-    <div className="space-y-2">
-      <div className="flex items-center justify-between text-xs">
-        <span>Brightness</span>
+                        {/* Brightness */}
+                        <div className="space-y-2">
+                          <div className="flex items-center justify-between text-xs">
+                            <span>Brightness</span>
 
-        <button
-          type="button"
-          onClick={() => updateRecipe({ brightness: 0 })}
-          className="text-film-500 hover:underline"
-        >
-          Reset
-        </button>
-      </div>
+                            <button
+                              type="button"
+                              onClick={() => updateRecipe({ brightness: 0 })}
+                              className="text-film-500 hover:underline"
+                            >
+                              Reset
+                            </button>
+                          </div>
 
-      <input
-        type="range"
-        min="-1"
-        max="1"
-        step="0.1"
-        value={recipe.brightness}
-        onChange={(e) =>
-          updateRecipe({
-            brightness: Number(e.target.value),
-          })
-        }
-        className="w-full"
-      />
-    </div>
+                          <input
+                            type="range"
+                            min="-1"
+                            max="1"
+                            step="0.1"
+                            value={recipe.brightness}
+                            onChange={(e) =>
+                              updateRecipe({
+                                brightness: Number(e.target.value),
+                              })
+                            }
+                            className="w-full"
+                          />
+                        </div>
 
-    {/* Contrast */}
-    <div className="space-y-2">
-      <div className="flex items-center justify-between text-xs">
-        <span>Contrast</span>
+                        {/* Contrast */}
+                        <div className="space-y-2">
+                          <div className="flex items-center justify-between text-xs">
+                            <span>Contrast</span>
 
-        <button
-          type="button"
-          onClick={() => updateRecipe({ contrast: 1 })}
-          className="text-film-500 hover:underline"
-        >
-          Reset
-        </button>
-      </div>
+                            <button
+                              type="button"
+                              onClick={() => updateRecipe({ contrast: 1 })}
+                              className="text-film-500 hover:underline"
+                            >
+                              Reset
+                            </button>
+                          </div>
 
-      <input
-        type="range"
-        min="0"
-        max="2"
-        step="0.1"
-        value={recipe.contrast}
-        onChange={(e) =>
-          updateRecipe({
-            contrast: Number(e.target.value),
-          })
-        }
-        className="w-full"
-      />
-    </div>
+                          <input
+                            type="range"
+                            min="0"
+                            max="2"
+                            step="0.1"
+                            value={recipe.contrast}
+                            onChange={(e) =>
+                              updateRecipe({
+                                contrast: Number(e.target.value),
+                              })
+                            }
+                            className="w-full"
+                          />
+                        </div>
 
-    {/* Saturation */}
-    <div className="space-y-2">
-      <div className="flex items-center justify-between text-xs">
-        <span>Saturation</span>
+                        {/* Saturation */}
+                        <div className="space-y-2">
+                          <div className="flex items-center justify-between text-xs">
+                            <span>Saturation</span>
 
-        <button
-          type="button"
-          onClick={() => updateRecipe({ saturation: 1 })}
-          className="text-film-500 hover:underline"
-        >
-          Reset
-        </button>
-      </div>
+                            <button
+                              type="button"
+                              onClick={() => updateRecipe({ saturation: 1 })}
+                              className="text-film-500 hover:underline"
+                            >
+                              Reset
+                            </button>
+                          </div>
 
-      <input
-        type="range"
-        min="0"
-        max="3"
-        step="0.1"
-        value={recipe.saturation}
-        onChange={(e) =>
-          updateRecipe({
-            saturation: Number(e.target.value),
-          })
-        }
-        className="w-full"
-      />
-    </div>
+                          <input
+                            type="range"
+                            min="0"
+                            max="3"
+                            step="0.1"
+                            value={recipe.saturation}
+                            onChange={(e) =>
+                              updateRecipe({
+                                saturation: Number(e.target.value),
+                              })
+                            }
+                            className="w-full"
+                          />
+                        </div>
 
-  </div>
-</Section>
+                      </div>
+                    </Section>
                     <AudioSpeedControl recipe={recipe} onChange={updateRecipe} />
                   </Section>
                   <Section icon={<SlidersHorizontal size={12} />} title="Output format" delay={190}>
@@ -224,10 +224,10 @@ export default function VideoEditor() {
             )}
 
             {status === "error" && error && (
-                 <div
-                    role="status"
-                    className="flex items-start gap-3 p-4 bg-film-50 border border-film-200 rounded-xl text-film-800 text-sm animate-fade-in"
-                  >
+              <div
+                role="status"
+                className="flex items-start gap-3 p-4 bg-film-50 border border-film-200 rounded-xl text-film-800 text-sm animate-fade-in"
+              >
                 <AlertTriangle size={16} className="shrink-0 mt-0.5 text-film-500" />
                 <div className="flex-1">
                   <p className="font-heading font-bold text-sm">Error</p>
@@ -297,7 +297,7 @@ export default function VideoEditor() {
                 "w-full flex items-center justify-center gap-3 py-5 rounded-xl",
                 "font-display text-2xl tracking-widest transition-all duration-200",
                 file && !isProcessing
-                  ? "bg-film-600 hover:bg-film-700 hover:scale-[1.01] text-white shadow-lg shadow-film-200 active:scale-[0.98] cursor-pointer"
+                  ? "bg-film-600 hover:bg-film-700 hover:scale-[1.01] text-[var(--text)] shadow-lg shadow-film-200 active:scale-[0.98] cursor-pointer"
                   : "bg-[var(--border)] text-[var(--muted)] opacity-40 cursor-not-allowed"
               )}
             >


### PR DESCRIPTION
**Changes Made**

Updated the export button styling in src/components/VideoEditor.tsx by changing the text color from a fixed text-white value to the theme-aware text-[var(--text)].

**Before Update**
`? "bg-film-600 hover:bg-film-700 hover:scale-[1.01] text-white shadow-lg shadow-film-200 active:scale-[0.98] cursor-pointer"`

**Updated Code**
`? "bg-film-600 hover:bg-film-700 hover:scale-[1.01] text-[var(--text)] shadow-lg shadow-film-200 active:scale-[0.98] cursor-pointer"`

**Reason**
The export button text was difficult to see in light mode with a fixed white text color. Using text-[var(--text)] allows the text color to adapt to the current theme, improving visibility and maintaining better theme consistency.

**UI Changes**
Before Changes
<img width="494" height="151" alt="Screenshot 2026-05-16 211513" src="https://github.com/user-attachments/assets/079566ca-e5d9-4799-bc89-7a8a01b74acd" />

After Changes
<img width="380" height="100" alt="Screenshot 2026-05-17 001609" src="https://github.com/user-attachments/assets/4e5a0b1c-a2f1-48c9-8d24-33947b1ae582" />

Closes #483 