### PR TITLE
fix: remove duplicate footer copyright text

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -87,12 +87,7 @@ export default function RootLayout({
             <main role="main" id="main-content" tabIndex={-1}>
               {children}
             </main>
-            <footer
-              role="contentinfo"
-              className="px-6 py-4 text-sm text-[var(--muted)]"
-            >
-              <p>© 2026 Reframe</p>
-            </footer>
+            
           </ErrorBoundary>
         </ThemeProvider>
       </body>


### PR DESCRIPTION
## Changes Made

* Removed duplicate copyright footer text rendered below the main footer
* Kept only the intended footer section for cleaner UI consistency

## Issue Fixed

Fixes #491

## Tested On

* Localhost development server
* Desktop view

## Result

The duplicate copyright section no longer appears below the footer.

## Screenshots

### Before
<img width="1841" height="397" alt="before" src="https://github.com/user-attachments/assets/51afda0f-3239-4ee1-9fe6-c7433bcdfd67" />

### After
<img width="1519" height="277" alt="after" src="https://github.com/user-attachments/assets/e3f0809a-a151-4639-904c-813a4c1480b2" />

