### PR TITLE
fix: hide Star on GitHub button below 300px to prevent theme toggle overlap #471

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,8 +7,7 @@ export default function Home() {
         href="https://github.com/magic-peach/reframe"
         target="_blank"
         rel="noopener noreferrer"
-        className="fixed top-4 right-16 z-50 flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-[var(--border)] bg-[var(--surface)] text-[10px] font-heading font-semibold uppercase tracking-wider hover:bg-opacity-90 transition-all"
-      >
+        className="hidden min-[300px]:flex fixed top-4 right-16 z-50 items-center gap-1.5 px-3 py-1.5 rounded-lg border border-[var(--border)] bg-[var(--surface)] text-[10px] font-heading font-semibold uppercase tracking-wider hover:bg-opacity-90 transition-all"      >
         ⭐ Star on GitHub
       </a>
 


### PR DESCRIPTION
## Problem
The "Star on GitHub" button overlaps with the theme toggle at very narrow 
viewport widths (below ~300px), causing a broken UI appearance.

## Root Cause
Both elements use `fixed` positioning anchored to the right edge. At 
extremely compressed widths, the spacing between them collapses and 
they overlap.

## Fix
Hide the "Star on GitHub" button below 300px using Tailwind's arbitrary 
breakpoint `min-[300px]:flex`. No real device has a viewport this narrow 
(smallest phones are 360px+), so no real user is affected.

## Changes
- `src/app/page.tsx` — added `hidden min-[300px]:flex` to the button className

## Before 
<img width="212" height="72" alt="before" src="https://github.com/user-attachments/assets/fa2349c6-08a8-4864-8bc5-40603deadfe3" />

## After
<img width="273" height="72" alt="after" src="https://github.com/user-attachments/assets/ef9ace79-faf0-42fb-ab46-e2a7101138db" />


## Testing
Tested in Chrome DevTools responsive mode at:
- 224px — button hidden (no overlap) ✅
- 300px — button appears ✅  
- 375px (iPhone SE) — looks perfect ✅
- 1440px (desktop) — no change ✅

Fixes #471