### PR TITLE
feat: Add mobile-only scroll to top button(#196)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import ErrorBoundary from "@/components/ErrorBoundary";
 import "./globals.css";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { ThemeToggle } from "@/components/ThemeToggle";
+import ScrollToTop from "@/components/ScrollToTop";
 
 export const metadata: Metadata = {
   title: "Reframe — Resize, trim, and export videos in your browser",
@@ -87,7 +88,7 @@ export default function RootLayout({
             <main role="main" id="main-content" tabIndex={-1}>
               {children}
             </main>
-            
+            <ScrollToTop />
           </ErrorBoundary>
         </ThemeProvider>
       </body>

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function ScrollToTop() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsVisible(window.scrollY > 300);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <button
+      onClick={scrollToTop}
+      aria-label="Scroll to top"
+      className="
+        fixed bottom-5 right-5 z-50
+        h-12 w-12 rounded-full
+        bg-black text-white shadow-lg
+        flex items-center justify-center
+        md:hidden
+      "
+    >
+      ↑
+    </button>
+  );
+}


### PR DESCRIPTION
## What I Changed

* Added a reusable `ScrollToTop` component
* Added a floating "Back to Top" button for mobile devices
* Button becomes visible after scrolling more than 300px
* Added smooth scroll-to-top functionality
* Hidden the button on desktop screens using responsive classes
* Added accessibility support with `aria-label`

## Why

This improves navigation on long mobile pages by allowing users to quickly return to the top of the page.

## Screenshots

<img width="1238" height="885" alt="image" src="https://github.com/user-attachments/assets/9266844e-2e4c-4c92-b1da-e26dee27acb0" />
<img width="1221" height="865" alt="image" src="https://github.com/user-attachments/assets/0916dec9-ca91-4df7-892a-81fdc72f8029" />


## Issue Reference

Closes #196

## Type of Contribution

- [x] Bug fix
- [x] New feature
- [x] GSSoC  contribution

## Participant Info

- GitHub username: siri-004
- Contribution level: Beginner

---

## Checklist

- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes
- [x] This PR is related to a valid issue
