### PR TITLE
feat: add video file type badge (#206)

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -88,9 +88,16 @@ export default function FileUpload({ onFileSelect, currentFile }: Props) {
       <Film size={18} className="text-film-600 shrink-0" />
 
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-[var(--text)] truncate">
-          {currentFile?.name}
-        </p>
+        <div className="flex items-center gap-2 mb-0.5">
+          <p className="text-sm font-medium text-[var(--text)] truncate">
+            {currentFile?.name}
+          </p>
+          {currentFile && (
+            <span className="px-2 py-0.5 bg-gray-700 text-white font-bold tracking-wider rounded text-[10px] uppercase">
+              {currentFile.name.includes('.') ? currentFile.name.split('.').pop() : 'VIDEO'}
+            </span>
+          )}
+        </div>
 
         <p className="text-xs text-[var(--muted)]">
           {formatBytes(currentFile?.size ?? 0)}


### PR DESCRIPTION
## Description
Added a video file type badge to the `FileUpload` component. Once a video is uploaded, its extension is dynamically parsed from the filename and displayed as an uppercase badge (e.g. `MP4`, `MOV`) next to the file name, improving user visibility. Fallback logic (`VIDEO`) is included if no extension is present.

## Related Issue
Closes #206

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] GSSoC contribution

## Participant Info
- GitHub username: @Rucha0901
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes
- [x] This PR is related to a valid issue

- [ ] I have read the contribution guidelines
- [ ] My changes follow the project structure
- [ ] I have tested my changes
- [ ] This PR is related to a valid issue