### PR TITLE
fix: add inputMode numeric to width and height inputs

### DIFF
--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -150,7 +150,7 @@ const handleHeightChange = useCallback((h: number) => {
             <input
               id="custom-width"
               type="number"
-              inputmode="numeric"
+              inputMode="numeric"
               min={16}
               max={7680}
               step={2}
@@ -187,7 +187,7 @@ const handleHeightChange = useCallback((h: number) => {
             <input
               id="custom-height"
               type="number"
-              inputmode="numeric"
+              inputMode="numeric"
               min={16}
               max={7680}
               step={2}

--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -150,6 +150,7 @@ const handleHeightChange = useCallback((h: number) => {
             <input
               id="custom-width"
               type="number"
+              inputmode="numeric"
               min={16}
               max={7680}
               step={2}
@@ -186,6 +187,7 @@ const handleHeightChange = useCallback((h: number) => {
             <input
               id="custom-height"
               type="number"
+              inputmode="numeric"
               min={16}
               max={7680}
               step={2}


### PR DESCRIPTION
## Description
Added `inputMode="numeric"` to the custom width and custom height input fields in `PresetSelector.tsx` to improve mobile UX by triggering the numeric keyboard.

## Related Issue
Closes #51 

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: Srishti-Gupta74
- Contribution level (Beginner/Intermediate/Advanced): Beginner

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes
- [x] This PR is related to a valid issue