### PR TITLE
feat: disable spellcheck on numeric inputs (#64)

### DIFF
--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -154,7 +154,7 @@ const handleHeightChange = useCallback((h: number) => {
               max={7680}
               step={2}
               value={recipe.customWidth}
-              
+              spellCheck={false}
               onChange={(e) => handleWidthChange(Number(e.target.value))}
               className="w-full text-sm px-3 py-1.5 border border-[var(--border)] rounded-md bg-[var(--bg)] font-heading focus:outline-none focus:ring-2 focus:ring-film-400 transition-shadow"
             />
@@ -190,6 +190,7 @@ const handleHeightChange = useCallback((h: number) => {
               max={7680}
               step={2}
               value={recipe.customHeight}
+              spellCheck={false}
               onChange={(e) => handleHeightChange(Number(e.target.value))}
               className="w-full text-sm px-3 py-1.5 border border-[var(--border)] rounded-md bg-[var(--bg)] font-heading focus:outline-none focus:ring-2 focus:ring-film-400 transition-shadow"
             />

--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -67,6 +67,7 @@ export default function TrimControl({ recipe, onChange, duration }: Props) {
             max={duration > 0 ? duration : undefined}
             step={0.1}
             value={recipe.trimStart}
+            spellCheck={false}
             onChange={(e) => handleStart(e.target.value)}
             className={`${inputClass} ${
               invalidStart ? "border-red-500" : "border-[var(--border)]"}`}
@@ -84,6 +85,7 @@ export default function TrimControl({ recipe, onChange, duration }: Props) {
             max={duration > 0 ? duration : undefined}
             step={0.1}
             value={recipe.trimEnd ?? ""}
+            spellCheck={false}
             onChange={(e) => handleEnd(e.target.value)}
             className={`${inputClass} ${
               invalidEnd ? "border-red-500" : "border-[var(--border)]"}`}


### PR DESCRIPTION
## Description
Added `spellCheck={false}` to all numeric input fields across the application to prevent the browser's native spell-check from interfering with number entry (which previously caused annoying red squiggly lines under valid numeric inputs). 

Affected inputs:
- Custom width (`PresetSelector.tsx`)
- Custom height (`PresetSelector.tsx`)
- Trim start (`TrimControl.tsx`)
- Trim end (`TrimControl.tsx`)

## Related Issue
Closes #64

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] GSSoC contribution

## Participant Info
- GitHub username: @Rucha0901
- Contribution level (Beginner/Intermediate/Advanced): Beginner

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes
- [x] This PR is related to a valid issue
