### PR TITLE
feat: add smooth scroll to export result (#110)

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useVideoEditor } from "@/hooks/useVideoEditor";
 import FileUpload from "./FileUpload";
 import VideoPreview from "./VideoPreview";
@@ -50,6 +50,17 @@ export default function VideoEditor() {
     handleFileSelect, handleExport, cancelExport, reset, resetSettings,
   } = useVideoEditor();
   const [copied, setCopied] = useState(false);
+  const downloadRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (status === "done" && downloadRef.current) {
+      const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+      downloadRef.current.scrollIntoView({
+        behavior: prefersReducedMotion ? "instant" : "smooth",
+        block: "center",
+      });
+    }
+  }, [status]);
 
   
   const isProcessing = status === "loading-engine" || status === "exporting";
@@ -263,7 +274,7 @@ export default function VideoEditor() {
             )}
 
             {status === "done" && result && (
-              <div role="status" className="animate-fade-in">
+              <div role="status" className="animate-fade-in" ref={downloadRef}>
                 <DownloadResult result={result} onReset={reset} />
               </div>
             )}


### PR DESCRIPTION
## Description
Added smooth scrolling functionality to automatically navigate the user to the `DownloadResult` component once an export completes.
- Attaches a `useRef` to the result container in `VideoEditor.tsx`.
- Utilizes `useEffect` to trigger a `scrollIntoView` call dynamically when the export status flips to `'done'`.
- Includes accessibility support: dynamically checks `prefers-reduced-motion` to fall back to `instant` scrolling if the user has disabled animations at the OS/browser level.

## Related Issue
Closes #110

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] GSSoC contribution

## Participant Info
- GitHub username: @Rucha0901
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes
- [x] This PR is related to a valid issue
