### PR TITLE
fix: Consolidate DEFAULT_RECIPE and SPEED_STEPS to single source of truth

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -31,25 +31,6 @@ export type ExportStatus =
   | "done"
   | "error";
 
-export const SPEED_STEPS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 4] as const;
-
-export const DEFAULT_RECIPE: EditRecipe = {
-  preset: "vertical-9-16",
-  customWidth: 1920,
-  customHeight: 1080,
-  framing: "fit",
-  trimStart: 0,
-  trimEnd: null,
-  rotate: 0,
-  keepAudio: true,
-  speed: 1,
-  quality: 23,
-  format: "mp4",
-  brightness: 0,
-  contrast: 0,
-  saturation: 0,
-};
-
 export const MAX_FILE_SIZE =
   2 * 1024 * 1024 * 1024; // 2GB
 


### PR DESCRIPTION


## Description
Removed duplicate `DEFAULT_RECIPE` and `SPEED_STEPS` definitions from `src/lib/types.ts`. Consolidated all definitions to `src/lib/constants.ts` as the single authoritative source. This eliminates inconsistency where contrast and saturation defaults were incorrectly set to 0 instead of 1 in types.ts, preventing silent behavior drift across the app.

## Related Issue
Closes #507 

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] GSSoC contribution

## Participant Info
- GitHub username: Kunal241207
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes
- [x] This PR is related to a valid issue