### PR TITLE
feat: add confirmation dialog before resetting video (#112)

### DIFF
--- a/src/components/DownloadResult.tsx
+++ b/src/components/DownloadResult.tsx
@@ -26,6 +26,12 @@ export default function DownloadResult({ result, onReset }: Props) {
 
   const shareHref = `https://x.com/intent/tweet?text=${encodeURIComponent(SHARE_TWEET_TEXT)}`;
 
+  const handleReset = () => {
+    if (window.confirm("This will clear the current video and all settings. Continue?")) {
+      onReset();
+    }
+  };
+
   return (
     <div className="p-5 bg-[var(--surface)] border border-[var(--border)] rounded-xl space-y-4">
       <div className="flex items-center gap-4">
@@ -113,7 +119,7 @@ export default function DownloadResult({ result, onReset }: Props) {
           type="button"
           title="Reset and upload a new video"
           aria-label="Upload a new video"
-          onClick={onReset}
+          onClick={handleReset}
           className="flex items-center gap-2 px-4 py-3 border border-[var(--border)] text-[var(--muted)] text-sm rounded-lg hover:bg-[var(--bg)] transition-colors"
         >
           <RotateCcw size={14} />


### PR DESCRIPTION
## Description
Added a confirmation dialog to the **New** button in the `DownloadResult` component to prevent users from accidentally losing their video and all configured settings. Before the reset occurs, a browser-native `window.confirm` dialog appears with the message: *"This will clear the current video and all settings. Continue?"*. Users can press **Cancel** to dismiss and stay in the current state, or **OK** to proceed with the reset.

## Related Issue
Closes #112

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] GSSoC contribution

## Participant Info
- GitHub username: @Rucha0901
- Contribution level (Beginner/Intermediate/Advanced): Beginner

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes
- [x] This PR is related to a valid issue
