### PR TITLE
feat: add letterbox/crop preview overlay on video player (#104)

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -96,7 +96,7 @@ export default function VideoEditor() {
 
               {file && (
                 <div className="mt-4 animate-fade-in">
-                  <VideoPreview file={file} />
+                  <VideoPreview file={file} recipe={recipe} />
                 </div>
               )}
             </div>

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -1,17 +1,21 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { EditRecipe } from "@/lib/types";
+import { getPresetById } from "@/lib/presets";
 
 interface Props {
   file: File | null;
+  recipe?: EditRecipe;
 }
 
-export default function VideoPreview({ file }: Props) {
+export default function VideoPreview({ file, recipe }: Props) {
   const videoRef = useRef<HTMLVideoElement>(null);
 
   const lastId = useRef(0);
   const urlRef = useRef<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [showOverlay, setShowOverlay] = useState(false);
 
   // stable handler reference (avoids re-attaching logic unnecessarily)
   const onLoadedRef = useRef<(() => void) | null>(null);
@@ -67,6 +71,55 @@ export default function VideoPreview({ file }: Props) {
     };
   }, [file]);
 
+  /**
+   * Compute the overlay geometry for the selected preset + framing mode.
+   * The preview container always uses a 16:9 aspect-video box.
+   * We express widths/heights as percentage strings for CSS.
+   */
+  const overlay = (() => {
+    if (!recipe || !showOverlay) return null;
+
+    const preset = recipe.preset === "custom"
+      ? { width: recipe.customWidth, height: recipe.customHeight }
+      : getPresetById(recipe.preset);
+
+    if (!preset) return null;
+
+    // Preview container is 16:9
+    const containerW = 16;
+    const containerH = 9;
+    const containerRatio = containerW / containerH;   // 1.777…
+    const outputRatio = preset.width / preset.height;
+
+    if (recipe.framing === "fit") {
+      // Letterbox: the output video fits entirely inside 16:9, padded with bars.
+      if (outputRatio > containerRatio) {
+        // Wider output → pillarbox bars on top & bottom
+        const contentH = (containerRatio / outputRatio) * 100;
+        const barH = (100 - contentH) / 2;
+        return { mode: "fit", barTop: `${barH}%`, barBottom: `${barH}%`, barLeft: "0", barRight: "0" };
+      } else {
+        // Taller output → letterbox bars on left & right
+        const contentW = (outputRatio / containerRatio) * 100;
+        const barW = (100 - contentW) / 2;
+        return { mode: "fit", barTop: "0", barBottom: "0", barLeft: `${barW}%`, barRight: `${barW}%` };
+      }
+    } else {
+      // Fill / crop: the output fills the entire 16:9 preview — show a box representing what survives the crop.
+      if (outputRatio < containerRatio) {
+        // Output is taller → crops top & bottom
+        const visibleH = (outputRatio / containerRatio) * 100;
+        const cropH = (100 - visibleH) / 2;
+        return { mode: "fill", barTop: `${cropH}%`, barBottom: `${cropH}%`, barLeft: "0", barRight: "0" };
+      } else {
+        // Output is wider → crops left & right
+        const visibleW = (containerRatio / outputRatio) * 100;
+        const cropW = (100 - visibleW) / 2;
+        return { mode: "fill", barTop: "0", barBottom: "0", barLeft: `${cropW}%`, barRight: `${cropW}%` };
+      }
+    }
+  })();
+
   if (!file) return null;
 
   return (
@@ -87,6 +140,56 @@ export default function VideoPreview({ file }: Props) {
         onLoadedData={() => setIsLoading(false)}
         playsInline
       />
+
+      {/* Letterbox / Crop overlay */}
+      {overlay && (
+        <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
+          {overlay.mode === "fit" ? (
+            // Letterbox: semi-transparent bars outside the content area
+            <>
+              <div className="absolute left-0 right-0 top-0 bg-black/50" style={{ height: overlay.barTop }} />
+              <div className="absolute left-0 right-0 bottom-0 bg-black/50" style={{ height: overlay.barBottom }} />
+              <div className="absolute top-0 bottom-0 left-0 bg-black/50" style={{ width: overlay.barLeft }} />
+              <div className="absolute top-0 bottom-0 right-0 bg-black/50" style={{ width: overlay.barRight }} />
+            </>
+          ) : (
+            // Fill/crop: dashed border around the surviving area, dimmed outside
+            <>
+              <div className="absolute left-0 right-0 top-0 bg-red-900/50" style={{ height: overlay.barTop }} />
+              <div className="absolute left-0 right-0 bottom-0 bg-red-900/50" style={{ height: overlay.barBottom }} />
+              <div className="absolute top-0 bottom-0 left-0 bg-red-900/50" style={{ width: overlay.barLeft }} />
+              <div className="absolute top-0 bottom-0 right-0 bg-red-900/50" style={{ width: overlay.barRight }} />
+              <div
+                className="absolute border-2 border-dashed border-film-400"
+                style={{
+                  top: overlay.barTop,
+                  bottom: overlay.barBottom,
+                  left: overlay.barLeft,
+                  right: overlay.barRight,
+                }}
+              />
+            </>
+          )}
+        </div>
+      )}
+
+      {/* Toggle button */}
+      {recipe && !isLoading && (
+        <button
+          type="button"
+          onClick={() => setShowOverlay((v) => !v)}
+          className={`absolute bottom-10 right-2 px-2 py-1 text-[10px] font-heading font-bold uppercase tracking-wider rounded transition-colors z-10 pointer-events-auto ${
+            showOverlay
+              ? "bg-film-600 text-white"
+              : "bg-black/60 text-white/70 hover:bg-black/80"
+          }`}
+          aria-pressed={showOverlay}
+          aria-label={showOverlay ? "Hide framing overlay" : "Show framing overlay"}
+          title={showOverlay ? "Hide framing overlay" : "Show framing overlay"}
+        >
+          {showOverlay ? "Hide overlay" : "Show overlay"}
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Description
Adds a real-time visual framing overlay to the `VideoPreview` component that shows exactly how the exported video will be cropped or letterboxed based on the selected preset and framing mode.

- **Fit mode:** Renders semi-transparent black bars on the sides/top-bottom outside the content area (classic letterbox/pillarbox effect).
- **Fill mode:** Renders red-tinted regions over the areas that will be cropped, with a dashed border highlighting the surviving crop region.
- The overlay is **toggle-able** via a "Show overlay" button on the video to keep the UI clean by default.
- Updates **in real-time** as the user changes the preset or framing mode.
- `VideoEditor.tsx` now passes the current `recipe` to `VideoPreview` to enable live overlay updates.

## Related Issue
Closes #104

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] GSSoC contribution

## Participant Info
- GitHub username: @Rucha0901
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes
- [x] This PR is related to a valid issue

- [ ] I have read the contribution guidelines
- [ ] My changes follow the project structure
- [ ] I have tested my changes
- [ ] This PR is related to a valid issue