### PR TITLE
fix: add -b:v 0 to VP9 WebM export for true constant quality mode

### DIFF
--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -209,6 +209,7 @@ export async function exportVideo(
     if (recipe.format === "webm") {
       args.push(
         "-c:v", "libvpx-vp9",
+        "-b:v", "0",
         "-crf", String(recipe.quality)
       );
       if (recipe.keepAudio) {
@@ -247,6 +248,7 @@ export async function exportVideo(
         ...(vf ? ["-vf", vf] : []),
         ...(recipe.keepAudio ? (af ? ["-af", af] : []) : ["-an"]),
         "-c:v", "libvpx-vp9",
+        "-b:v", "0",
         "-crf", String(recipe.quality),
         ...(recipe.keepAudio ? ["-c:a", "libopus"] : []),
         fallbackOutputName,


### PR DESCRIPTION
## What
Adds `-b:v 0` to the libvpx-vp9 FFmpeg arguments for WebM export (both
the primary path and the fallback path).

## Why
VP9 requires both `-b:v 0` and `-crf <value>` to run in constant-quality
mode. Without `-b:v 0`, the encoder uses constrained VBR mode, where CRF
is only a soft hint — the quality slider has inconsistent effect on output.

## Changes
- `src/lib/ffmpeg.ts` — added `"-b:v", "0"` to the primary WebM export args
- `src/lib/ffmpeg.ts` — added `"-b:v", "0"` to the fallback WebM export args

## Reference
https://developers.google.com/media/vp9/settings/vod/#constant_quality

Fixes #556 

## Checklist
- [x] Code works in Chrome, Firefox, and Safari
- [x] No new TypeScript errors (`bunx tsc --noEmit`)
- [x] ESLint passes (`bun run lint`)
- [ ] UI changes tested on mobile (use browser DevTools)
- [ ] Accessibility: new interactive elements have ARIA labels
- [x] Issue number referenced in PR description