### PR TITLE
fix: implement Ctrl+O / Cmd+O keyboard shortcut to open file picker

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect} from "react";
 import { Film, FolderOpen } from "lucide-react";
 import LottiePlayer from "./LottiePlayer";
 import uploadAnim from "@/lib/lottie/upload.json";
@@ -29,6 +29,17 @@ export default function FileUpload({ onFileSelect, currentFile }: Props) {
 
   const [error, setError] = useState("");
   const [warning, setWarning] = useState("");
+  
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "o") {
+        e.preventDefault();
+        inputRef.current?.click();
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, []);
 
   const handleFile = (file: File) => {
     setError("");


### PR DESCRIPTION
## What
Implements the Ctrl+O / Cmd+O keyboard shortcut to open the file picker,
which was advertised in the UI but had no handler.

## Why
The drop zone and the "Change" button both show Ctrl+O / Cmd+O as a hint,
but pressing the shortcut did nothing. This is misleading, especially for
keyboard-reliant users.

## Changes
- `src/components/FileUpload.tsx` — added `useEffect` with a `keydown`
  listener that calls `inputRef.current?.click()` on Ctrl+O / Cmd+O

Fixes #557 

## Checklist
- [x] Code works in Chrome, Firefox, and Safari
- [x] No new TypeScript errors (`bunx tsc --noEmit`)
- [x] ESLint passes (`bun run lint`)
- [ ] UI changes tested on mobile — N/A (keyboard shortcut, not applicable on mobile)
- [ ] Accessibility: new interactive elements have ARIA labels — N/A (no new elements)
- [x] Issue number referenced in PR description