### PR TITLE
test: add comprehensive vitest suite for formatBytes utility (#231)

### DIFF
--- a/src/lib/tests/utils.test.ts
+++ b/src/lib/tests/utils.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { formatBytes } from "../utils";
+
+describe("formatBytes", () => {
+  it("returns '0 Bytes' for zero input", () => {
+    expect(formatBytes(0)).toBe("0 Bytes");
+  });
+
+  it("formats values below 1 KB as Bytes", () => {
+    expect(formatBytes(512)).toBe("512 Bytes");
+    expect(formatBytes(1)).toBe("1 Bytes");
+  });
+
+  it("formats kilobytes", () => {
+    expect(formatBytes(1024)).toBe("1 KB");
+    expect(formatBytes(1536)).toBe("1.5 KB");
+  });
+
+  it("formats megabytes", () => {
+    expect(formatBytes(1048576)).toBe("1 MB");
+    expect(formatBytes(1572864)).toBe("1.5 MB");
+  });
+
+  it("formats gigabytes", () => {
+    expect(formatBytes(1073741824)).toBe("1 GB");
+  });
+
+  it("formats terabytes", () => {
+    expect(formatBytes(1099511627776)).toBe("1 TB");
+  });
+
+  it("respects custom decimal precision", () => {
+    expect(formatBytes(1536, 2)).toBe("1.5 KB");
+    expect(formatBytes(1048576, 0)).toBe("1 MB");
+    expect(formatBytes(123456789, 2)).toBe("117.74 MB");
+  });
+
+  it("clamps negative decimals to zero", () => {
+    expect(formatBytes(1536, -1)).toBe("2 KB");
+  });
+});


### PR DESCRIPTION
## Description
Adds comprehensive Vitest unit testing coverage for the `formatBytes` utility function located in `src/lib/utils.ts`.
- Added 8 separate test assertions covering byte scale boundaries (KB through TB), zero-byte input, custom decimal precision, and negative decimal edge cases.
- `utils.ts` lacked test coverage, and since `formatBytes` is actively used in file size validation warnings, this ensures deterministic UI behavior.

## Related Issue
Closes #231

## Type of Contribution
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: @AdityaM-IITH
- Contribution level (Beginner/Intermediate/Advanced): Beginner

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes
- [x] This PR is related to a valid issue
