### PR TITLE
a11y: add aria-invalid and label associations to TrimControl and form fields (#541)

### DIFF
--- a/src/components/ExportSettings.tsx
+++ b/src/components/ExportSettings.tsx
@@ -59,6 +59,8 @@ export default function ExportSettings({ recipe, onChange }: Props) {
             type="checkbox"
             checked={recipe.stabilization}
             onChange={(e) =>onChange({ stabilization: e.target.checked })}
+            aria-label="Enable video stabilization"
+            aria-checked={recipe.stabilization}
             className="w-full accent-film-600 cursor-pointer"
           />
           {/* <span className="font-normal text-xs text-[var(--muted)] ml-1">deshake</span> */}

--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -68,6 +68,8 @@ export default function TrimControl({ recipe, onChange, duration }: Props) {
             step={0.1}
             value={recipe.trimStart}
             onChange={(e) => handleStart(e.target.value)}
+            aria-label="Trim start time in seconds"
+            aria-invalid={invalidStart}
             className={`${inputClass} ${
               invalidStart ? "border-red-500" : "border-[var(--border)]"}`}
             placeholder="0"
@@ -85,6 +87,8 @@ export default function TrimControl({ recipe, onChange, duration }: Props) {
             step={0.1}
             value={recipe.trimEnd ?? ""}
             onChange={(e) => handleEnd(e.target.value)}
+            aria-label="Trim end time in seconds"
+            aria-invalid={invalidEnd}
             className={`${inputClass} ${
               invalidEnd ? "border-red-500" : "border-[var(--border)]"}`}
             placeholder={duration > 0 ? `${duration.toFixed(1)}` : "full length"}

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -130,7 +130,7 @@ export default function VideoEditor() {
     {/* Brightness */}
     <div className="space-y-2">
       <div className="flex items-center justify-between text-xs">
-        <span>Brightness</span>
+        <label htmlFor="brightness-slider">Brightness</label>
 
         <button
           type="button"
@@ -142,6 +142,7 @@ export default function VideoEditor() {
       </div>
 
       <input
+        id="brightness-slider"
         type="range"
         min="-1"
         max="1"
@@ -152,6 +153,7 @@ export default function VideoEditor() {
             brightness: Number(e.target.value),
           })
         }
+        aria-label="Adjust brightness"
         className="w-full"
       />
     </div>
@@ -159,7 +161,7 @@ export default function VideoEditor() {
     {/* Contrast */}
     <div className="space-y-2">
       <div className="flex items-center justify-between text-xs">
-        <span>Contrast</span>
+        <label htmlFor="contrast-slider">Contrast</label>
 
         <button
           type="button"
@@ -171,6 +173,7 @@ export default function VideoEditor() {
       </div>
 
       <input
+        id="contrast-slider"
         type="range"
         min="0"
         max="2"
@@ -181,6 +184,7 @@ export default function VideoEditor() {
             contrast: Number(e.target.value),
           })
         }
+        aria-label="Adjust contrast"
         className="w-full"
       />
     </div>
@@ -188,7 +192,7 @@ export default function VideoEditor() {
     {/* Saturation */}
     <div className="space-y-2">
       <div className="flex items-center justify-between text-xs">
-        <span>Saturation</span>
+        <label htmlFor="saturation-slider">Saturation</label>
 
         <button
           type="button"
@@ -200,6 +204,7 @@ export default function VideoEditor() {
       </div>
 
       <input
+        id="saturation-slider"
         type="range"
         min="0"
         max="3"
@@ -210,6 +215,7 @@ export default function VideoEditor() {
             saturation: Number(e.target.value),
           })
         }
+        aria-label="Adjust saturation"
         className="w-full"
       />
     </div>


### PR DESCRIPTION
## Description
Improves screen reader accessibility across the application by adding missing semantic ARIA properties to custom sliders, checkboxes, and inputs.
- **`TrimControl.tsx`**: Added `aria-label` and explicitly mapped `aria-invalid={invalidStart}` / `aria-invalid={invalidEnd}` to correctly reflect the validation states.
- **`ExportSettings.tsx`**: Added `aria-label` and `aria-checked` to the stabilization toggle checkbox.
- **`VideoEditor.tsx`**: Added semantic `<label>` elements with `htmlFor` attributes linking directly to the Brightness, Contrast, and Saturation range inputs, alongside corresponding `aria-label` attributes.

## Related Issue
Closes #541

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: @AdityaM-IITH
- Contribution level (Beginner/Intermediate/Advanced): Beginner

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes
- [x] This PR is related to a valid issue
