### PR TITLE
a11y: standardize minimum text scale to 14px to pass WCAG validation rules

### DIFF
--- a/src/components/AudioSpeedControl.tsx
+++ b/src/components/AudioSpeedControl.tsx
@@ -61,7 +61,7 @@ export default function AudioSpeedControl({ recipe, onChange }: Props) {
           <button
             type="button"
             onClick={() => onChange({ speed: 1, keepAudio: true })}
-            className="text-[11px] font-heading font-semibold uppercase tracking-wider text-film-600 hover:text-film-700 hover:underline transition-all duration-150"
+            className="text-sm font-heading font-semibold uppercase tracking-wider text-film-600 hover:text-film-700 hover:underline transition-all duration-150"
           >
             Reset to Default
           </button>
@@ -95,7 +95,7 @@ export default function AudioSpeedControl({ recipe, onChange }: Props) {
           <label
             id="speed-label"
             htmlFor="speed-control"
-            className="text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)] flex items-center gap-1"
+            className="text-sm font-heading font-semibold uppercase tracking-wider text-[var(--muted)] flex items-center gap-2"
           >
             <Gauge size={10} /> Speed
           </label>
@@ -104,7 +104,7 @@ export default function AudioSpeedControl({ recipe, onChange }: Props) {
             <span className="text-sm font-heading font-bold text-film-600 block">
               {recipe.speed}x
             </span>
-            <span id="speed-description" className="text-[10px] text-[var(--muted)]">
+            <span id="speed-description" className="text-sm text-[var(--muted)]">
               {getSpeedDescription(recipe.speed)}
             </span>
           </div>
@@ -127,7 +127,7 @@ export default function AudioSpeedControl({ recipe, onChange }: Props) {
           {SPEED_STEPS.map((s) => (
             <span
               key={s}
-              className="text-[9px] text-[var(--muted)] truncate text-center min-w-0 px-[1px]"
+              className="text-sm text-[var(--muted)] truncate text-center min-w-0 px-[1px]"
             >
               {s}x
             </span>
@@ -136,7 +136,7 @@ export default function AudioSpeedControl({ recipe, onChange }: Props) {
       </div>
 
       {recipe.keepAudio && (recipe.trimStart !== 0 || recipe.trimEnd !== null) && (
-        <div className="mt-2 p-2 bg-amber-50 border border-amber-200 rounded text-[10px] text-amber-700 leading-tight flex items-start gap-2 animate-fade-in">
+        <div className="mt-3 p-3 bg-amber-50 border border-amber-200 rounded text-sm text-amber-700 leading-relaxed flex items-start gap-2 animate-fade-in">
           <AlertTriangle size={12} className="shrink-0 mt-0.5" />
           <p>
             Note: If audio doesn&apos;t start within the selected range, the output will be silent.

--- a/src/components/ExportSettings.tsx
+++ b/src/components/ExportSettings.tsx
@@ -20,7 +20,7 @@ export default function ExportSettings({ recipe, onChange }: Props) {
   <>
     <div>
       <div className="flex items-center justify-between mb-2">
-        <label htmlFor="quality-control" className="text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)] flex items-center gap-1">
+        <label htmlFor="quality-control" className="text-sm font-heading font-semibold uppercase tracking-wider text-[var(--muted)] flex items-center gap-2">
           <SlidersHorizontal size={10} /> Quality
           <span className="cursor-help" title="CRF (Constant Rate Factor): lower = higher quality, larger file. 18 = best quality, 30 = smallest file.">
             <InfoIcon size={14} />
@@ -28,7 +28,7 @@ export default function ExportSettings({ recipe, onChange }: Props) {
         </label>
         <span className="text-sm font-heading font-bold text-film-600">
           {label}
-          <span className="font-normal text-xs text-[var(--muted)] ml-1">CRF {recipe.quality}</span>
+          <span className="font-normal text-sm text-[var(--muted)] ml-2">CRF {recipe.quality}</span>
         </span>
       </div>
       <input
@@ -45,13 +45,13 @@ export default function ExportSettings({ recipe, onChange }: Props) {
         className="w-full accent-film-600 cursor-pointer"
       />
       <div id="quality-description" className="flex justify-between mt-1">
-        <span className="text-[10px] text-[var(--muted)]">Best quality</span>
-        <span className="text-[10px] text-[var(--muted)]">Smallest file</span>
+        <span className="text-sm text-[var(--muted)]">Best quality</span>
+        <span className="text-sm text-[var(--muted)]">Smallest file</span>
       </div>
     </div>
     <div>
       <div className="flex items-center justify-between mb-2">
-        <label htmlFor="stabilization-toggle" className="text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)] flex items-center gap-1">
+        <label htmlFor="stabilization-toggle" className="text-sm font-heading font-semibold uppercase tracking-wider text-[var(--muted)] flex items-center gap-2">
           <SlidersHorizontal size={10} /> Stabilization
         </label>
          <span className="flex text-sm font-heading font-bold text-film-600">
@@ -64,12 +64,12 @@ export default function ExportSettings({ recipe, onChange }: Props) {
             aria-checked={recipe.stabilization}
             className="w-full accent-film-600 cursor-pointer"
           />
-          {/* <span className="font-normal text-xs text-[var(--muted)] ml-1">deshake</span> */}
+          {/* <span className="font-normal text-sm text-[var(--muted)] ml-2">deshake</span> */}
         </span>
       </div>
 
       <div className="flex justify-end">
-        <span className={cn("text-[13px]", recipe.stabilization ? "text-red-700" : "text-[var(--muted)]")}>Note: significantly increases processing time.</span>
+        <span className={cn("text-sm", recipe.stabilization ? "text-red-700" : "text-[var(--muted)]")}>Note: significantly increases processing time.</span>
       </div>
     </div>
   </>

--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -57,7 +57,7 @@ export default function TrimControl({ recipe, onChange, duration }: Props) {
     <div className="space-y-2">
       <div className="flex gap-3">
         <div className="flex-1">
-          <label htmlFor="trim-start" className="text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)] block mb-1.5">
+          <label htmlFor="trim-start" className="text-sm font-heading font-semibold uppercase tracking-wider text-[var(--muted)] block mb-2">
             Start (sec)
           </label>
           <input
@@ -77,7 +77,7 @@ export default function TrimControl({ recipe, onChange, duration }: Props) {
           />
         </div>
         <div className="flex-1">
-          <label htmlFor="trim-end" className="text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)] block mb-1.5">
+          <label htmlFor="trim-end" className="text-sm font-heading font-semibold uppercase tracking-wider text-[var(--muted)] block mb-2">
             End (sec)
           </label>
           <input
@@ -98,7 +98,7 @@ export default function TrimControl({ recipe, onChange, duration }: Props) {
         </div>
       </div>
       {duration > 0 && (
-        <p className="text-[10px] text-[var(--muted)] font-heading">
+        <p className="text-sm text-[var(--muted)] font-heading mt-1">
           Duration: {duration.toFixed(1)}s
         </p>
       )}

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -33,7 +33,7 @@ function Section({ icon, title, children, delay = 0 }: SectionProps) {
     >
       <div className="flex items-center gap-2">
         <span className="text-film-500 opacity-80">{icon}</span>
-        <h3 className="text-[10px] font-heading font-bold uppercase tracking-widest text-[var(--muted)]">
+        <h3 className="text-sm font-heading font-bold uppercase tracking-widest text-[var(--muted)]">
           {title}
         </h3>
         <div className="flex-1 h-px bg-[var(--border)]" />
@@ -81,13 +81,13 @@ export default function VideoEditor() {
             <h1 className="font-display text-6xl leading-none tracking-widest2 text-[var(--text)]">
               REFRAME
             </h1>
-            <p className="font-heading text-xs text-[var(--muted)] mt-1 uppercase tracking-widest">
+            <p className="font-heading text-sm text-[var(--muted)] mt-1 uppercase tracking-widest">
               Your video, any format
             </p>
           </div>
-          <div className="hidden sm:flex items-center gap-2 text-[10px] font-heading font-semibold uppercase tracking-widest text-[var(--muted)] pb-1">
+          <div className="hidden sm:flex items-center gap-2 text-sm font-heading font-semibold uppercase tracking-widest text-[var(--muted)] pb-1">
             <span className="w-1.5 h-1.5 rounded-full bg-green-400 inline-block animate-pulse" />
-            No login. No ads. 100% private — your video never leaves your device.
+            No login. No ads. 100% private - your video never leaves your device.
           </div>
         </header>
 
@@ -113,7 +113,7 @@ export default function VideoEditor() {
 
             {file && file.size > 100 * 1024 * 1024 && (
               <p className="text-[var(--warning)] text-sm">
-                ⚠️ Large file — processing may take several minutes
+                ⚠️ Large file - processing may take several minutes
               </p>
             )}      
             {file && (
@@ -140,7 +140,7 @@ export default function VideoEditor() {
 
     {/* Brightness */}
     <div className="space-y-2">
-      <div className="flex items-center justify-between text-xs">
+      <div className="flex items-center justify-between text-sm">
         <label htmlFor="brightness-slider">Brightness</label>
 
         <button
@@ -171,7 +171,7 @@ export default function VideoEditor() {
 
     {/* Contrast */}
     <div className="space-y-2">
-      <div className="flex items-center justify-between text-xs">
+      <div className="flex items-center justify-between text-sm">
         <label htmlFor="contrast-slider">Contrast</label>
 
         <button
@@ -202,7 +202,7 @@ export default function VideoEditor() {
 
     {/* Saturation */}
     <div className="space-y-2">
-      <div className="flex items-center justify-between text-xs">
+      <div className="flex items-center justify-between text-sm">
         <label htmlFor="saturation-slider">Saturation</label>
 
         <button
@@ -253,7 +253,7 @@ export default function VideoEditor() {
                 <AlertTriangle size={16} className="shrink-0 mt-0.5 text-film-500" />
                 <div className="flex-1">
                   <p className="font-heading font-bold text-sm">Error</p>
-                  <p className="text-film-600 text-xs mt-1">{error}</p>
+                  <p className="text-film-600 text-sm mt-1">{error}</p>
                 </div>
                 <button
                   type="button"
@@ -263,7 +263,7 @@ export default function VideoEditor() {
                       setTimeout(() => setCopied(false), 2000);
                     });
                   }}
-                  className="px-3 py-1.5 bg-[var(--border)] border border-[var(--border)] rounded-lg text-xs font-semibold hover:opacity-80 transition-colors shrink-0 whitespace-nowrap"
+                  className="px-3 py-1.5 bg-[var(--border)] border border-[var(--border)] rounded-lg text-sm font-semibold hover:opacity-80 transition-colors shrink-0 whitespace-nowrap"
                   aria-label="Copy error message to clipboard"
                 >
                   {copied ? "Copied!" : "Copy error"}
@@ -272,7 +272,7 @@ export default function VideoEditor() {
                   <button
                     type="button"
                     onClick={handleExport}
-                    className="px-3 py-1.5 bg-[var(--error-bg)] border border-[var(--error-border)] rounded-lg text-xs font-semibold hover:bg-[var(--error-hover)] hover:border-[var(--error)] text-[var(--text)] transition-colors shrink-0 whitespace-nowrap"
+                    className="px-3 py-1.5 bg-[var(--error-bg)] border border-[var(--error-border)] rounded-lg text-sm font-semibold hover:bg-[var(--error-hover)] hover:border-[var(--error)] text-[var(--text)] transition-colors shrink-0 whitespace-nowrap"
                   >
                     Retry Export
                   </button>
@@ -304,7 +304,7 @@ export default function VideoEditor() {
                 <button
                   type="button"
                   onClick={resetSettings}
-                  className="text-[9px] font-heading font-bold uppercase tracking-widest text-[var(--muted)] hover:text-film-600 transition-all opacity-60 hover:opacity-100"
+                  className="text-sm font-heading font-bold uppercase tracking-widest text-[var(--muted)] hover:text-film-600 transition-all opacity-60 hover:opacity-100"
                 >
                   Reset all settings
                 </button>


### PR DESCRIPTION
Closes #158

## Description
This PR addresses WCAG text readability violations by standardizing the minimum font size scale across all interactive control panels to 14px (`text-sm`). 

- Replaced non-compliant micro-font classes (`text-xs`, `text-[10px]`, `text-[9px]`, `text-[11px]`) across the editor modules (VideoEditor, TrimControl, AudioSpeedControl, ExportSettings).
- Adjusted surrounding flex gaps, label margins (`mb-1.5` -> `mb-2`), and padding variables to dynamically absorb the typography scale increase without causing layout overflows or fracturing the compact Bento grid UI.
- Purged conflicting typography dash formatting inside variables and text nodes to maintain a clean aesthetic base.

## Related Issue
Closes #158

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: @AdityaM-IITH
- Contribution level (Beginner/Intermediate/Advanced): Beginner

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes
- [x] This PR is related to a valid issue
