### PR TITLE
refactor: standardize Tailwind colors to use theme CSS variables in V…

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,6 +13,11 @@
   --accent-hover: #1d4ed8;
   --film-600: #e63946;
   --film-400: #ff6b6b;
+  --warning: #f59e0b;
+  --error: #ef4444;
+  --error-bg: #fee2e2;
+  --error-border: #fca5a5;
+  --error-hover: #fecaca;
 }
 
 /* ── Dark mode tokens ── */
@@ -24,6 +29,11 @@
   --muted: #94a3b8;
   --accent: #3b82f6;
   --accent-hover: #2563eb;
+  --warning: #fbbf24;
+  --error: #f87171;
+  --error-bg: #7f1d1d;
+  --error-border: #991b1b;
+  --error-hover: #991b1b;
 }
 
 /* ── Base styles ── */

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -87,7 +87,7 @@ export default function VideoEditor() {
               <FileUpload onFileSelect={handleFileSelect} currentFile={file} />
 
               {!file && (
-              <div className="text-center text-gray-500 py-6">
+              <div className="text-center text-[var(--muted)] py-6">
                 <p>Upload a video to get started</p>
                 <p className="text-sm">Supports MP4, MOV, WebM and more</p>
               </div>
@@ -101,7 +101,7 @@ export default function VideoEditor() {
             </div>
 
             {file && file.size > 100 * 1024 * 1024 && (
-              <p className="text-yellow-400 text-sm">
+              <p className="text-[var(--warning)] text-sm">
                 ⚠️ Large file — processing may take several minutes
               </p>
             )}      
@@ -255,7 +255,7 @@ export default function VideoEditor() {
                   <button
                     type="button"
                     onClick={handleExport}
-                    className="px-3 py-1.5 bg-red-200 border border-film-200 rounded-lg text-xs font-semibold hover:bg-film-50 hover:border-film-300 transition-colors shrink-0 whitespace-nowrap"
+                    className="px-3 py-1.5 bg-[var(--error-bg)] border border-[var(--error-border)] rounded-lg text-xs font-semibold hover:bg-[var(--error-hover)] hover:border-[var(--error)] text-[var(--text)] transition-colors shrink-0 whitespace-nowrap"
                   >
                     Retry Export
                   </button>


### PR DESCRIPTION
…ideoEditor


#481 



## Description
This PR addresses the UI inconsistencies in `src/components/VideoEditor.tsx` by replacing hardcoded Tailwind utility colors with the project's custom theme variables. This ensures the component respects global light/dark theme toggling and provides a cohesive visual experience.

## Changes Made
- **Global Theme Variables (`src/app/globals.css`)**: 
  - Added new semantic variables for warnings and errors (`--warning`, `--error`, `--error-bg`, `--error-border`, `--error-hover`) to both `:root` (light) and `.dark` blocks.
- **Upload Placeholder (`src/components/VideoEditor.tsx`)**: 
  - Replaced `text-gray-500` with `text-[var(--muted)]`.
- **Large File Warning (`src/components/VideoEditor.tsx`)**: 
  - Replaced `text-yellow-400` with `text-[var(--warning)]`.
- **Retry Export Button (`src/components/VideoEditor.tsx`)**: 
  - Refactored hardcoded colors (`bg-red-200`, `hover:bg-film-50`, `border-film-200`) into consistent semantic theme variables (`bg-[var(--error-bg)]`, `border-[var(--error-border)]`, `hover:bg-[var(--error-hover)]`).

## Verification
- Verified that the new text colors adapt correctly between light and dark modes.
- Ensured the "Retry Export" button on error states falls back smoothly on the newly added theme variables without breaking layout or aesthetics.


