### PR TITLE
feat: add high contrast accessibility theme

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -62,7 +62,7 @@ body {
 }
 
 :focus-visible {
-  outline: 2px solid #e63946;
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
   border-radius: 4px;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,6 +26,25 @@
   --accent-hover: #2563eb;
 }
 
+/* ── High contrast mode tokens ── */
+[data-theme="high-contrast"] {
+  --bg: #000000;
+  --surface: #000000;
+  --border: #FFFFFF;
+
+  --text: #FFFFFF;
+  --muted: #FFFFFF;
+
+  --accent: #FFFF00;
+  --accent-hover: #FFFF00;
+
+  --error: #FF6666;
+  --success: #66FF66;
+
+  --film-600: #FF6666;
+  --film-400: #66FF66;
+}
+
 /* ── Base styles ── */
 body {
   background-color: var(--bg);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -62,6 +62,14 @@ export default function RootLayout({
                   } else {
                     document.documentElement.classList.remove('dark');
                   }
+                  if (stored === 'high-contrast') {
+                    document.documentElement.setAttribute(
+                      'data-theme',
+                      'high-contrast'
+                    );
+                  } else {
+                    document.documentElement.removeAttribute('data-theme');
+                  }  
                 } catch (e) {}
               })();
             `,

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -26,10 +26,17 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   // The inline <script> in layout.tsx already applied the class to <html>;
   // we just sync React state here so the toggle button shows the right icon.
   useEffect(() => {
+    try {
     const stored = localStorage.getItem("theme") as Theme | null;
     if (stored === "light" || stored === "dark" || stored === "high-contrast") {
       setThemeState(stored);
     } else {
+      const prefersDark = window.matchMedia(
+        "(prefers-color-scheme: dark)"
+      ).matches;
+      setThemeState(prefersDark ? "dark" : "light");
+    }
+    } catch {
       const prefersDark = window.matchMedia(
         "(prefers-color-scheme: dark)"
       ).matches;

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -9,7 +9,7 @@ import {
   type ReactNode,
 } from "react";
 
-type Theme = "light" | "dark";
+type Theme = "light" | "dark" | "high-contrast";
 
 interface ThemeContextValue {
   theme: Theme;
@@ -27,7 +27,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   // we just sync React state here so the toggle button shows the right icon.
   useEffect(() => {
     const stored = localStorage.getItem("theme") as Theme | null;
-    if (stored === "light" || stored === "dark") {
+    if (stored === "light" || stored === "dark" || stored === "high-contrast") {
       setThemeState(stored);
     } else {
       const prefersDark = window.matchMedia(
@@ -55,6 +55,14 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       } else {
         document.documentElement.classList.remove("dark");
       }
+      if (next === "high-contrast") {
+      document.documentElement.setAttribute(
+        "data-theme",
+        "high-contrast"
+      );
+      } else {
+      document.documentElement.removeAttribute("data-theme");
+      }
       if (persist) {
         localStorage.setItem("theme", next);
       }
@@ -63,7 +71,13 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   );
 
   const toggleTheme = useCallback(() => {
-    applyTheme(theme === "dark" ? "light" : "dark");
+    applyTheme(
+      theme === "light"
+        ? "dark"
+        : theme === "dark"
+        ? "high-contrast"
+        : "light"
+    ); 
   }, [theme, applyTheme]);
 
   const setTheme = useCallback(

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -40,8 +40,8 @@ export function ThemeToggle() {
         transition-colors duration-200
       "
     >
-      {/* Sun icon — shown in dark mode */}
-      {theme === "dark" ? (
+      {/* Sun icon — shown in light mode */}
+      {theme === "light" ? (
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
@@ -57,7 +57,7 @@ export function ThemeToggle() {
           <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
         </svg>
       ) : (
-        /* Moon icon — shown in light mode */
+       /* Moon icon — shown in dark/high contrast mode */
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -12,12 +12,22 @@ export function ThemeToggle() {
 
   return (
     <button
-      type="button"
-      onClick={toggleTheme}
-      aria-label={
-        theme === "dark" ? "Switch to light mode" : "Switch to dark mode"
-      }
-      title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+       type="button"
+       onClick={toggleTheme}
+       aria-label={
+         theme === "light"
+           ? "Switch to dark mode"
+           : theme === "dark"
+           ? "Switch to high contrast mode"
+           : "Switch to light mode"
+      } 
+       title={
+         theme === "light"
+           ? "Switch to dark mode"
+           : theme === "dark"
+           ? "Switch to high contrast mode"
+           : "Switch to light mode"
+     }
       className="
         relative flex items-center justify-center
         w-9 h-9 rounded-full


### PR DESCRIPTION
## Description
Implemented a high contrast accessibility theme for visually impaired users using CSS custom properties and data-theme="high-contrast" support.

Changes Made

1. Added high-contrast theme support to the existing theme system
2. Added WCAG-style high contrast color tokens
3. Implemented data-theme="high-contrast" on <html>
4. Added high contrast theme persistence using localStorage
5. Extended theme toggle functionality to support high contrast mode
6. Updated accessibility labels for theme switching
7. Preserved existing light/dark architecture with minimal changes

## Related Issue
 Fixes #161  

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: diptipradeep
- Contribution level (Beginner/Intermediate/Advanced):Beginner and Intermediate

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes
- [x] This PR is related to a valid issue