### PR TITLE
Fix #67: Add 500MB max file size limit

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -57,6 +57,11 @@ export default function FileUpload({
       return;
     }
 
+    if (file.size > 500 * 1024 * 1024) {
+      setError("File size exceeds 500MB limit. Please select a smaller video.");
+      return;
+    }
+
     // Hard limit
     if (file.size > MAX_FILE_SIZE) {
       setError(


### PR DESCRIPTION
### Problem Solved (Fixes #67)
The application previously allowed users to upload excessively large video files to the browser. Because all video processing is done locally via FFmpeg.wasm, uploading files larger than 500MB would frequently cause the browser tab to crash or freeze due to Out-Of-Memory (OOM) exceptions within the WebAssembly heap allocation.

### Technical Solution
I implemented a strict memory-safe threshold validation layer within the `handleFile` sequence of `FileUpload.tsx`. 

- **Pre-emptive Byte Evaluation**: Prior to extracting video metadata and invoking `URL.createObjectURL()`, the file's raw byte `size` property is evaluated against a strict 500MB (`500 * 1024 * 1024` bytes) threshold.
- **Pipeline Short-circuiting**: If the threshold is exceeded, the processing pipeline is immediately short-circuited and an explicit `setError` state is triggered.
- **Memory Mitigation**: This successfully mitigates critical performance bottlenecks and excessive memory pressure on the client's local machine, ensuring stable FFmpeg processing for supported file sizes.
