### PR TITLE
feat: add SRI verification for FFmpeg CDN resources

### DIFF
--- a/scripts/generate-sri.ts
+++ b/scripts/generate-sri.ts
@@ -1,0 +1,15 @@
+import { createHash } from "crypto";
+
+const urls = [
+    "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd/ffmpeg-core.js",
+    "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd/ffmpeg-core.wasm",
+    "https://cdn.jsdelivr.net/npm/@ffmpeg/core-mt@0.12.10/dist/umd/ffmpeg-core.js",
+    "https://cdn.jsdelivr.net/npm/@ffmpeg/core-mt@0.12.10/dist/umd/ffmpeg-core.wasm",
+  ];
+
+for (const url of urls) {
+  const res = await fetch(url);
+  const buf = await res.arrayBuffer();
+  const hash = createHash("sha384").update(Buffer.from(buf)).digest("base64");
+  console.log(`"${url}": "sha384-${hash}"`);
+}

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -1,10 +1,31 @@
 import { FFmpeg } from "@ffmpeg/ffmpeg";
-import { fetchFile, toBlobURL } from "@ffmpeg/util";
+import { fetchFile } from "@ffmpeg/util";
 import { EditRecipe, ExportResult } from "./types";
 import { getPresetById } from "./presets";
 import { simd } from "wasm-feature-detect";
 
 const CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd";
+const SRI_HASHES: Record<string, string> = {
+  "ffmpeg-core.js":   "sha384-sKfkiFtvUk+vexk+0EUhEh366190/4WpgUAsUvaxEfyg7+E1Zt5Y5hrsU808g8Q9",
+  "ffmpeg-core.wasm": "sha384-U1VDhkPYrM3wTCT4/vjSpSsKqG/UjljYrYCI4hBSJ02svbCkxuCi6U6u/peg5vpW",
+};
+
+async function fetchWithIntegrity(url:string,mimeType:string):Promise<string> {
+
+  const key = url.split("/").pop()!;
+  
+  const integrity = SRI_HASHES[key];
+  
+
+  if (!integrity) {
+    throw new Error(`[SRI] No hash found for: ${key}`);
+  }
+
+  const res = await fetch(url,{ integrity,credentials:"omit"});
+  const blob = new Blob([await res.arrayBuffer()],{type:mimeType});
+  return URL.createObjectURL(blob);
+  
+}
 
 let ffmpegInstance: FFmpeg | null = null;
 
@@ -40,16 +61,11 @@ export async function loadFFmpeg(signal?: AbortSignal,
   try {
 
     ffmpeg.on("progress", handleProgress);
-    // Check if the user's browser supports WebAssembly SIMD
-    const isSimdSupported = await simd();
-
-    // Dynamically set the core filename
-    const coreName = isSimdSupported ? "ffmpeg-core-simd" : "ffmpeg-core";
 
     // Load FFmpeg using the dynamic URLs + the new signal parameter
     await ffmpeg.load({
-      coreURL: await toBlobURL(`${CORE_BASE_URL}/${coreName}.js`, "text/javascript"),
-      wasmURL: await toBlobURL(`${CORE_BASE_URL}/${coreName}.wasm`, "application/wasm"),
+      coreURL: await fetchWithIntegrity(`${CORE_BASE_URL}/ffmpeg-core.js`, "text/javascript"),
+      wasmURL: await fetchWithIntegrity(`${CORE_BASE_URL}/ffmpeg-core.wasm`, "application/wasm"),
     }, { signal });
     onProgress?.(100);
     return ffmpeg;
@@ -308,4 +324,4 @@ export async function exportVideo(
       }
     }
   }
-}
+}


### PR DESCRIPTION
## Description
Added Subresource Integrity (SRI) verification for FFmpeg CDN resources loaded from jsDelivr. Replaced `toBlobURL` with a custom `fetchWithIntegrity` helper that passes the `integrity` option to `fetch`, so the browser verifies the SHA-384 hash of each file before executing it. Also removed the broken SIMD path that referenced `ffmpeg-core-simd` files which don't exist on `@ffmpeg/core`, and added a `scripts/generate-sri.ts` utility to regenerate hashes when FFmpeg is upgraded.

## Related Issue
Closes #138

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: 
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes
- [x] This PR is related to a valid issue