### PR TITLE
feat: show export progress percentage in browser tab title

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -223,7 +223,13 @@ export function useVideoEditor() {
   }, [file, recipe, result, status]);
 
   useEffect(() => {
-    if (file) {
+    if (status === "exporting") {
+      document.title = `Exporting ${progress}% | Reframe`;
+    } else if (status === "loading-engine") {
+      document.title = `Loading engine... | Reframe`;
+    } else if (status === "done") {
+      document.title = `Export complete | Reframe`;
+    } else if (file) {
       document.title = `Editing: ${file.name} | Reframe`;
     } else {
       document.title = DEFAULT_TITLE;
@@ -231,7 +237,7 @@ export function useVideoEditor() {
     return () => {
       document.title = DEFAULT_TITLE;
     };
-  }, [file]);
+  }, [status, progress, file]);
 
   useEffect(() => {
     const handleKeydown = (e: KeyboardEvent) => {


### PR DESCRIPTION
## Description
Update the existing `document.title` useEffect in `useVideoEditor.ts` to reflect the current export status and progress in the browser tab title. Previously the title only updated when a file was selected and had no awareness of export state. Now the tab title dynamically updates across all states so users can monitor progress from other tabs.

## Related Issue
Closes #575 

## Type of Contribution
- [x] New feature
- [x] GSSoC contribution 

## Participant Info
- GitHub username: Kr1491
- Contribution level: Beginner

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes
- [x] This PR is related to a valid issue