### PR TITLE
feat: warn user before closing tab during export or when download is …

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -263,6 +263,22 @@ export function useVideoEditor() {
   }, [status, progress, file]);
 
   useEffect(() => {
+    const shouldWarn =
+      status === "exporting" ||
+      status === "loading-engine" ||
+      status === "done";
+
+    if (!shouldWarn) return;
+
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+    };
+
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [status]);
+  
+  useEffect(() => {
     const handleKeydown = (e: KeyboardEvent) => {
       if (
         (e.ctrlKey || e.metaKey) &&


### PR DESCRIPTION
## Description
Add a `beforeunload` event listener in `useVideoEditor.ts` that triggers the browser's native "Leave site?" dialog when the user tries to close or refresh the tab during an active export or when a completed download is ready. The warning is automatically removed once the user resets back to idle state.

## Related Issue
Closes #628 

## Type of Contribution
- [x] New feature
- [x] GSSoC contribution

## Participant Info
- GitHub username: Kr1491
- Contribution level: Beginner

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes
- [x] This PR is related to a valid issue