### PR TITLE
fix: terminate FFmpeg instance on component unmount to prevent memory…

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -364,6 +364,12 @@ export function useVideoEditor() {
     }
    },[result?.blobUrl])
 
+  useEffect(() => {
+    return () => {
+      terminateFFmpeg();
+    };
+  }, []);
+
   const resetSettings = useCallback(() => {
     setRecipe(DEFAULT_RECIPE);
   }, []);


### PR DESCRIPTION
## Description

Fixed a memory leak where the FFmpeg WASM instance wasn't being cleaned up when the component unmounts. If a user navigated away during an active export, the FFmpeg process kept running in the background even though the React state was already gone.

Added a `useEffect` cleanup in `useVideoEditor.ts` that calls `terminateFFmpeg()` on unmount. The `terminateFFmpeg()` function in `ffmpeg.ts` already had `ffmpegInstance = null` after `.terminate()` so that part was already good  just needed to hook it into the component lifecycle.

## Related Issue

Closes #32

## Type of Contribution

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info

- GitHub username: aarishmansur
- Contribution level (Beginner/Intermediate/Advanced):Intermediate

## Checklist

- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes
- [x] This PR is related to a valid issue