### PR TITLE
feat: auto-detect optimal preset based on video aspect ratio

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -58,6 +58,7 @@ export default function VideoEditor() {
     overlayPosition, setOverlayPosition,
     overlaySize, setOverlaySize,
     overlayOpacity, setOverlayOpacity,
+    recommendedPreset,
   } = useVideoEditor();
   const [copied, setCopied] = useState(false);
   const downloadRef = useRef<HTMLDivElement>(null);
@@ -315,6 +316,13 @@ export default function VideoEditor() {
           )}>
             <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6 animate-fade-in" style={{ animationDelay: "50ms" }}>
               <Section icon={<Layers size={12} />} title="Output size">
+                {recommendedPreset && (
+                  <div className="mb-4 rounded-2xl border border-film-200 bg-film-50 p-3 text-sm text-film-700">
+                    <p>
+                      We detected a {recommendedPreset.label.replace(/\s/g, "")} video → Recommended: {recommendedPreset.platform.split("·")[0].trim()} ({recommendedPreset.label.replace(/\s/g, "")})
+                    </p>
+                  </div>
+                )}
                 <PresetSelector recipe={recipe} onChange={updateRecipe} />
               </Section>
 

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -1,9 +1,11 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { EditRecipe, ExportResult, ExportStatus, MAX_FILE_SIZE, OverlayPosition } from "@/lib/types";
 import { DEFAULT_RECIPE, SPEED_STEPS } from "@/lib/constants";
+import { getPresetById } from "@/lib/presets";
 import { loadFFmpeg, exportVideo, terminateFFmpeg, FFmpegLoadError } from "@/lib/ffmpeg";
+import { suggestPreset } from "@/lib/presetSuggestion";
 
 const DEFAULT_TITLE = "Reframe — Resize, trim, and export videos in your browser";
 
@@ -115,6 +117,11 @@ function validateRecipe(recipe: EditRecipe, duration: number ): string | null {
 export function useVideoEditor() {
   const [file, setFile] = useState<File | null>(null);
   const [duration, setDuration] = useState<number>(0);
+  const [videoMetadata, setVideoMetadata] = useState<{
+    width: number;
+    height: number;
+    duration: number;
+  } | null>(null);
   const [recipe, setRecipe] = useState({
     ...DEFAULT_RECIPE,
     soundOnCompletion:
@@ -177,17 +184,23 @@ export function useVideoEditor() {
     }
   }, [recipe.preset, recipe.quality, recipe.speed, recipe.customWidth, recipe.customHeight]);
 
+  const recommendedPreset = useMemo(() => {
+    if (!videoMetadata) return null;
+    return getPresetById(suggestPreset(videoMetadata.width, videoMetadata.height)) ?? null;
+  }, [videoMetadata]);
+
   const handleFileSelect = useCallback(async (selectedFile: File) => {
     setResult(null);
     setStatus("idle");
     setError(null);
     setFile(null);
+    setVideoMetadata(null);
     if (!selectedFile.type.startsWith("video/")) {
-    setFileError("Please upload a video file only.");
-    return;
-  }
+      setFileError("Please upload a video file only.");
+      return;
+    }
 
-  setFileError("");
+    setFileError("");
 
     // LAYER 0: Size check
     if (selectedFile.size > MAX_FILE_SIZE) {
@@ -219,10 +232,21 @@ export function useVideoEditor() {
     }
 
     try {
-      const { duration: dur } = await extractMetadata(selectedFile);
+      const { width, height, duration: dur } = await extractMetadata(selectedFile);
       setDuration(dur);
+      setVideoMetadata({ width, height, duration: dur });
       setFile(selectedFile);
-      setRecipe((prev) => ({ ...prev, trimStart: 0, trimEnd: null }));
+      setRecipe((prev) => {
+        const suggestedPreset = suggestPreset(width, height);
+        const shouldApplySuggestion = prev.preset === DEFAULT_RECIPE.preset;
+
+        return {
+          ...prev,
+          trimStart: 0,
+          trimEnd: null,
+          ...(shouldApplySuggestion ? { preset: suggestedPreset } : {}),
+        };
+      });
     } catch (err) {
       setError(`Layer 4 Validation Failed: ${err instanceof Error ? err.message : "Unknown error"}`);
       setStatus("error");
@@ -382,6 +406,7 @@ export function useVideoEditor() {
   const reset = useCallback(() => {
     if (result?.blobUrl) URL.revokeObjectURL(result.blobUrl);
     setFile(null);
+    setVideoMetadata(null);
     setDuration(0);
     setRecipe(DEFAULT_RECIPE);
     setStatus("idle");
@@ -446,5 +471,6 @@ export function useVideoEditor() {
     setOverlaySize,
     overlayOpacity,
     setOverlayOpacity,
+    recommendedPreset,
   };
 }

--- a/src/lib/presetSuggestion.ts
+++ b/src/lib/presetSuggestion.ts
@@ -1,0 +1,22 @@
+export type SuggestedPresetId =
+  | "vertical-9-16"
+  | "landscape-16-9"
+  | "square-1-1";
+
+export function suggestPreset(width: number, height: number): SuggestedPresetId {
+  const ratio = width / height;
+
+  if (Math.abs(ratio - 9 / 16) < 0.05) {
+    return "vertical-9-16";
+  }
+
+  if (Math.abs(ratio - 16 / 9) < 0.05) {
+    return "landscape-16-9";
+  }
+
+  if (Math.abs(ratio - 1) < 0.05) {
+    return "square-1-1";
+  }
+
+  return "vertical-9-16";
+}

--- a/src/lib/tests/presetSuggestion.test.ts
+++ b/src/lib/tests/presetSuggestion.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { suggestPreset } from "../presetSuggestion";
+
+describe("suggestPreset", () => {
+  it("suggests vertical 9:16 for a tall video", () => {
+    expect(suggestPreset(1080, 1920)).toBe("vertical-9-16");
+  });
+
+  it("suggests landscape 16:9 for a wide video", () => {
+    expect(suggestPreset(1920, 1080)).toBe("landscape-16-9");
+  });
+
+  it("suggests square 1:1 for a square video", () => {
+    expect(suggestPreset(1080, 1080)).toBe("square-1-1");
+  });
+
+  it("falls back to vertical 9:16 when no close ratio matches", () => {
+    expect(suggestPreset(1440, 900)).toBe("vertical-9-16");
+  });
+});


### PR DESCRIPTION
## Summary

Implements automatic preset recommendation based on uploaded video aspect ratio.

When a user uploads a video, the editor now detects the video dimensions and suggests the closest matching export preset automatically (e.g. portrait videos → vertical preset, widescreen videos → YouTube preset).

Closes #96

---

## What Changed

### Added preset suggestion utility

Created:

```txt
src/lib/presetSuggestion.ts
```

This utility:

* calculates aspect ratio from uploaded video dimensions
* matches the closest preset
* provides a clean fallback behavior

---

### Automatic preset detection

Integrated uploaded video metadata detection into the editor workflow.

The editor now:

* detects uploaded video dimensions
* recommends the closest preset automatically
* pre-selects the recommended preset when appropriate

---

### Recommendation UI

Added a contextual recommendation message such as:

```txt
We detected a 16:9 video → Recommended: YouTube (16:9)
```

The recommendation:

* updates automatically
* keeps existing preset selection UX intact
* still allows full manual override

---

### Tests

Added tests for preset suggestion logic:

```txt
src/lib/tests/presetSuggestion.test.ts
```

---

## Validation

Verified successfully:

* `bun run build` ✅
* `bun run lint` ✅
* `bunx tsc --noEmit` ✅

---

## Notes

* No additional dependencies added
* Existing export workflow preserved
* UI kept consistent with current Reframe styling/system
* Manual preset override behavior remains fully supported