### PR TITLE
fix: resolve video title text invisibility on dark background

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -119,7 +119,7 @@ export default function FileUpload({
 
         <div className="flex-1 min-w-0">
           <div className="flex flex-wrap items-center gap-2 mb-0.5">
-            <p className="text-sm font-semibold text-gray-800 truncate max-w-[320px] xl:max-w-[420px]">
+            <p className="text-sm font-semibold text-film-700 truncate max-w-[320px] xl:max-w-[420px]">
               {currentFile?.name}
             </p>
             {currentFile && (


### PR DESCRIPTION
## Description
Fixed a contrast issue where the uploaded video title/filename was completely invisible when the application was in dark mode. Changed the text color to a high-contrast shade to ensure readability against the dark background.

## Related Issue
Closes #643 

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: Vagventure
- Contribution level (Beginner/Intermediate/Advanced): Beginner

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes
- [x] This PR is related to a valid issue