### PR TITLE
fix: replace NodeJS.Timeout with environment-agnostic ReturnType to unblock CI

### DIFF
--- a/src/components/TipCarousel.tsx
+++ b/src/components/TipCarousel.tsx
@@ -46,8 +46,8 @@ const TIPS: Tip[] = [
 export default function TipCarousel() {
   const [activeIdx, setActiveIdx] = useState(0);
   const [isFading, setIsFading] = useState(false);
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const rotateTip = () => {
     setIsFading(true);


### PR DESCRIPTION
### Overview
Resolves a TypeScript compilation vulnerability caused by environment-specific typing leaking into a frontend React component. 

`TipCarousel.tsx` was previously relying on `NodeJS.Timeout` for its interval and timeout refs. In strict browser-targeted CI build steps (or when `@types/node` is not explicitly loaded into the frontend context), this causes the `tsc` compiler to throw a namespace resolution error, breaking the pipeline.

### Changes Executed
- Refactored `timeoutRef` to use the environment-agnostic `ReturnType<typeof setTimeout>`
- Refactored `intervalRef` to use the environment-agnostic `ReturnType<typeof setInterval>`

This ensures the component typing is strictly inferred from the execution environment without relying on Node-specific globals, allowing `npm run type-check` to pass flawlessly across all environments.

### Type of Change
- [x] Bug fix (pipeline/type resolution)
- [ ] New feature
- [ ] Breaking change

### Checklist
- [x] Local type-check (`tsc --noEmit`) passes cleanly
- [x] Zero runtime logic altered; strictly a type safety patch