### PR TITLE
docs: require screen recordings for UI/feature PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,8 +14,28 @@
 - GitHub username:
 - Contribution level (Beginner/Intermediate/Advanced):
 
+## Screen Recording
+
+<!-- REQUIRED for all UI / feature / design changes. -->
+<!-- Drag a video file here or paste a Loom link below. -->
+<!-- PRs touching any visible UI without a recording will NOT be merged. -->
+
+> **How to record:** run `bun run dev` → open http://localhost:3000 → demonstrate the full working flow of your change, including any edge cases.
+>
+> - **macOS**: `Cmd + Shift + 5` → Record Selected Portion, or use QuickTime Player
+> - **Windows**: `Win + G` → Xbox Game Bar → Capture
+> - **Linux**: OBS Studio, GNOME Screenshot tool, or `kazam`
+> - **Any OS**: [Loom](https://loom.com) (free screen recorder, great for sharing)
+
+**Recording / Loom link:** <!-- drag file here or paste link -->
+
 ## Checklist
 - [ ] I have read the contribution guidelines
 - [ ] My changes follow the project structure
-- [ ] I have tested my changes
+- [ ] I have tested my changes in Chrome, Firefox, and Safari
+- [ ] `bun run lint` passes (no ESLint errors)
+- [ ] `bunx tsc --noEmit` passes (no TypeScript errors)
+- [ ] New interactive elements have `aria-label` / accessible names
+- [ ] No `console.log` statements left in
 - [ ] This PR is related to a valid issue
+- [ ] **Screen recording attached above** (required for UI/feature/design changes)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -325,8 +325,27 @@ git commit -m "feat: add aria-label to export button"
 3. Fill in the PR template:
    - Describe what you changed and why
    - Reference the issue: `Closes #<issue-number>`
-   - Add screenshots for UI changes
+   - **Attach a screen recording** (required for UI/feature changes — see below)
 4. Submit the PR — maintainers will review within a few days
+
+### Screen Recording Requirement
+
+**Any PR that adds or modifies a UI element, a user-facing feature, or any visual behaviour must include a screen recording of the working change running on your local machine.**
+
+This is a hard requirement — PRs without a recording will not be merged until one is added.
+
+**What to record:**
+- Run `bun run dev` and open `http://localhost:3000`
+- Demonstrate the full working flow of your change (e.g. upload a video → use the new control → export → see the result)
+- Show any edge cases your implementation handles (empty state, error state, etc.)
+
+**How to record:**
+- **macOS**: `Cmd + Shift + 5` → Record Selected Portion, or use QuickTime Player
+- **Windows**: `Win + G` → Xbox Game Bar → Capture
+- **Linux**: OBS Studio, GNOME Screenshot tool, or `kazam`
+- **Any OS**: [Loom](https://loom.com) (free, great for sharing)
+
+Attach the recording directly to the PR by dragging the file into the GitHub comment box, or paste a Loom/shareable link.
 
 ### PR Checklist
 
@@ -336,6 +355,7 @@ git commit -m "feat: add aria-label to export button"
 - [ ] UI changes tested on mobile (use browser DevTools)
 - [ ] Accessibility: new interactive elements have ARIA labels
 - [ ] Issue number referenced in PR description
+- [ ] **Screen recording attached** (required for all UI/feature PRs)
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a **Screen Recording Requirement** section to `CONTRIBUTING.md` — any PR that touches a UI element or user-facing feature must include a working recording of the change on the contributor's local machine before it can be merged
- Updates the **PR template** to include an explicit recording field with platform-specific instructions (macOS, Windows, Linux, Loom)

## Why

We've had a number of UI PRs that look fine in code but break at runtime, or that describe their changes without showing them working. Requiring a screen recording from `localhost:3000` gives maintainers a fast, unambiguous signal that the feature actually works end-to-end before merging.

## Changes

- `CONTRIBUTING.md` — new _Screen Recording Requirement_ subsection under _Submitting a Pull Request_; PR Checklist now includes a recording checkbox
- `.github/PULL_REQUEST_TEMPLATE.md` — new **Screen Recording** section with recording instructions and a field for the recording/link; Checklist updated

Closes #<!-- none — this is a docs/infra change -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)