### PR TITLE
fix: resolve video preview overflow for large resolution uploads

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -114,7 +114,7 @@ export default function VideoEditor() {
 
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-5">
 
-          <div className="space-y-4">
+          <div className="space-y-4 min-w-0">
             <div className="bg-[var(--surface)] rounded-xl p-5 border border-[var(--border)] animate-fade-in">
               <FileUpload onFileSelect={handleFileSelect} currentFile={file} fileError={fileError} />
 


### PR DESCRIPTION
## Problem
Uploading a high-resolution video (such as 1920x1080 or 4K) caused the video preview section to expand beyond the editor layout boundaries. This pushed major UI components outside the viewport and introduced unwanted horizontal scrolling.

## Root Cause
The CSS grid track containing the video preview used the default `min-width: auto`, which prevented the grid item from shrinking below the video's intrinsic size. As a result, large videos caused the overall layout to overflow.

## Solution
Added `min-w-0` to the first grid column in `VideoEditor.tsx`. This allows the grid track to shrink properly, ensuring the video preview scales within its container and the editor layout remains fully responsive.

## Result
- Video preview now scales correctly for all video sizes
- Editor UI remains inside the viewport
- Removed horizontal overflow and scrolling
- No existing functionality affected

Closes #638 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/de11872e-3847-48f3-92ac-1d94ef9c3a4f" />
