### PR TITLE
feat: editor onboarding tour — 4-step spotlight guide for first-time users

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@ffmpeg/util": "^0.12.2",
         "clsx": "^2.1.1",
         "focus-trap-react": "^12.0.1",
+        "jszip": "^3.10.1",
         "lottie-web": "^5.12.2",
         "lucide-react": "^0.469.0",
         "next": "^15.1.8",
@@ -388,6 +389,8 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
+    "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
@@ -548,9 +551,13 @@
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
+
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
 
@@ -608,7 +615,7 @@
 
     "is-weakset": ["is-weakset@2.0.4", "", { "dependencies": { "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ=="],
 
-    "isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+    "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -630,6 +637,8 @@
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
 
+    "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
+
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "language-subtag-registry": ["language-subtag-registry@0.3.23", "", {}, "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ=="],
@@ -637,6 +646,8 @@
     "language-tags": ["language-tags@1.0.9", "", { "dependencies": { "language-subtag-registry": "^0.3.20" } }, "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -732,6 +743,8 @@
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
@@ -772,6 +785,8 @@
 
     "prettier-plugin-tailwindcss": ["prettier-plugin-tailwindcss@0.8.0", "", { "peerDependencies": { "@ianvs/prettier-plugin-sort-imports": "*", "@prettier/plugin-hermes": "*", "@prettier/plugin-oxc": "*", "@prettier/plugin-pug": "*", "@shopify/prettier-plugin-liquid": "*", "@trivago/prettier-plugin-sort-imports": "*", "@zackad/prettier-plugin-twig": "*", "prettier": "^3.0", "prettier-plugin-astro": "*", "prettier-plugin-css-order": "*", "prettier-plugin-jsdoc": "*", "prettier-plugin-marko": "*", "prettier-plugin-multiline-arrays": "*", "prettier-plugin-organize-attributes": "*", "prettier-plugin-organize-imports": "*", "prettier-plugin-sort-imports": "*", "prettier-plugin-svelte": "*" }, "optionalPeers": ["@ianvs/prettier-plugin-sort-imports", "@prettier/plugin-hermes", "@prettier/plugin-oxc", "@prettier/plugin-pug", "@shopify/prettier-plugin-liquid", "@trivago/prettier-plugin-sort-imports", "@zackad/prettier-plugin-twig", "prettier-plugin-astro", "prettier-plugin-css-order", "prettier-plugin-jsdoc", "prettier-plugin-marko", "prettier-plugin-multiline-arrays", "prettier-plugin-organize-attributes", "prettier-plugin-organize-imports", "prettier-plugin-sort-imports", "prettier-plugin-svelte"] }, "sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g=="],
 
+    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
+
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
@@ -785,6 +800,8 @@
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
+
+    "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
@@ -808,6 +825,8 @@
 
     "safe-array-concat": ["safe-array-concat@1.1.4", "", { "dependencies": { "call-bind": "^1.0.9", "call-bound": "^1.0.4", "get-intrinsic": "^1.3.0", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg=="],
 
+    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
     "safe-push-apply": ["safe-push-apply@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "isarray": "^2.0.5" } }, "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA=="],
 
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
@@ -821,6 +840,8 @@
     "set-function-name": ["set-function-name@2.0.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "functions-have-names": "^1.2.3", "has-property-descriptors": "^1.0.2" } }, "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ=="],
 
     "set-proto": ["set-proto@1.0.0", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0" } }, "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw=="],
+
+    "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
@@ -859,6 +880,8 @@
     "string.prototype.trimend": ["string.prototype.trimend@1.0.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ=="],
 
     "string.prototype.trimstart": ["string.prototype.trimstart@1.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg=="],
+
+    "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
@@ -982,7 +1005,13 @@
 
     "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
+    "safe-array-concat/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+
+    "safe-push-apply/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+
     "sharp/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
+    "which-builtin-type/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
     "@next/eslint-plugin-next/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -188,6 +188,7 @@ export default function FileUpload({
 );
   const DropZone = () => (
     <div
+      id="upload-zone"
       role="button"
       tabIndex={0}
       onDragOver={(e) => {

--- a/src/components/OnboardingTour.tsx
+++ b/src/components/OnboardingTour.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import { createPortal } from "react-dom";
+
+const TOUR_KEY = "reframe_onboarding_complete";
+
+interface TourStep {
+  targetId: string;
+  title: string;
+  description: string;
+  position?: "top" | "bottom" | "left" | "right";
+  requiresFile?: boolean;
+}
+
+const TOUR_STEPS: TourStep[] = [
+   {
+    targetId: "upload-zone",
+    title: "Drop your video here",
+    description: "Click to browse or drag and drop a video file to get started.",
+    position: "right",
+  },
+  {
+    targetId: "preset-selector",
+    title: "Pick an output format",
+    description: "Choose a preset optimised for your platform — Instagram, YouTube, TikTok and more.",
+    position: "left",
+  },
+  {
+    targetId: "preset-selector",
+    title: "Trim & adjust",
+    description: "After uploading, set in/out points and tweak colour in the controls that appear on the left.",
+    position: "left",
+  },
+    {
+    targetId: "export-button",
+    title: "Export your video",
+    description: "Click Export (or press ⌘↵) to process your video locally — nothing ever leaves your device.",
+    position: "top",  
+  },
+];
+
+const PADDING = 12; // spotlight padding around target element
+const TOOLTIP_OFFSET = 16;
+
+interface Rect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+function getTooltipStyle(
+  rect: Rect,
+  position: TourStep["position"],
+  tooltipRef: React.RefObject<HTMLDivElement | null>
+): React.CSSProperties {
+  const tooltip = tooltipRef.current;
+  const tw = tooltip?.offsetWidth ?? 320;
+  const th = tooltip?.offsetHeight ?? 140;
+
+  const sr = {
+    top: rect.top - PADDING,
+    left: rect.left - PADDING,
+    width: rect.width + PADDING * 2,
+    height: rect.height + PADDING * 2,
+  };
+
+  switch (position) {
+    case "top":
+      return {
+        top: sr.top - th - TOOLTIP_OFFSET,
+        left: sr.left + sr.width / 2 - tw / 2,
+      };
+    case "left":
+      return {
+        top: sr.top + sr.height / 2 - th / 2,
+        left: sr.left - tw - TOOLTIP_OFFSET,
+      };
+    case "right":
+      return {
+        top: sr.top + sr.height / 2 - th / 2,
+        left: sr.left + sr.width + TOOLTIP_OFFSET,
+      };
+    case "bottom":
+    default:
+      return {
+        top: sr.top + sr.height + TOOLTIP_OFFSET,
+        left: sr.left + sr.width / 2 - tw / 2,
+      };
+  }
+}
+
+interface SpotlightProps {
+  rect: Rect;
+}
+
+function Spotlight({ rect }: SpotlightProps) {
+  const r = {
+    top: rect.top - PADDING,
+    left: rect.left - PADDING,
+    width: rect.width + PADDING * 2,
+    height: rect.height + PADDING * 2,
+  };
+
+  return (
+    <svg
+      className="fixed inset-0 w-full h-full pointer-events-none"
+      style={{ zIndex: 9998 }}
+      aria-hidden="true"
+    >
+      <defs>
+        <mask id="spotlight-mask">
+          <rect width="100%" height="100%" fill="white" />
+          <rect
+            x={r.left}
+            y={r.top}
+            width={r.width}
+            height={r.height}
+            rx={8}
+            fill="black"
+          />
+        </mask>
+      </defs>
+      <rect
+        width="100%"
+        height="100%"
+        fill="rgba(0,0,0,0.65)"
+        mask="url(#spotlight-mask)"
+      />
+      {/* Highlight ring */}
+      <rect
+        x={r.left}
+        y={r.top}
+        width={r.width}
+        height={r.height}
+        rx={8}
+        fill="none"
+        stroke="rgba(99,102,241,0.8)"
+        strokeWidth={2}
+      />
+    </svg>
+  );
+}
+
+interface TooltipProps {
+  step: TourStep;
+  stepIndex: number;
+  totalSteps: number;
+  rect: Rect;
+  onNext: () => void;
+  onSkip: () => void;
+  tooltipRef: React.RefObject<HTMLDivElement | null>;
+}
+
+function Tooltip({ step, stepIndex, totalSteps, rect, onNext, onSkip, tooltipRef }: TooltipProps) {
+  const style = getTooltipStyle(rect, step.position, tooltipRef);
+  const isLast = stepIndex === totalSteps - 1;
+
+  return (
+    <div
+      ref={tooltipRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Onboarding step ${stepIndex + 1} of ${totalSteps}: ${step.title}`}
+      className="fixed z-[9999] w-80 rounded-xl shadow-2xl border
+        bg-white dark:bg-zinc-900
+        border-zinc-200 dark:border-zinc-700
+        text-zinc-900 dark:text-zinc-100
+        transition-all duration-200"
+      style={{ ...style }}
+      tabIndex={-1}
+    >
+      {/* Progress bar */}
+      <div className="h-1 rounded-t-xl overflow-hidden bg-zinc-200 dark:bg-zinc-700">
+        <div
+          className="h-full bg-indigo-500 transition-all duration-300"
+          style={{ width: `${((stepIndex + 1) / totalSteps) * 100}%` }}
+        />
+      </div>
+
+      <div className="p-5">
+        {/* Step counter */}
+        <p className="text-xs font-semibold tracking-widest uppercase text-indigo-500 mb-1">
+          Step {stepIndex + 1} of {totalSteps}
+        </p>
+
+        <h2 className="text-base font-semibold mb-1">{step.title}</h2>
+        <p className="text-sm text-zinc-500 dark:text-zinc-400 leading-relaxed mb-4">
+          {step.description}
+        </p>
+
+        <div className="flex items-center justify-between gap-3">
+          <button
+            onClick={onSkip}
+            className="text-xs text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 transition-colors underline underline-offset-2"
+          >
+            Skip tour
+          </button>
+          <button
+              onClick={onNext}
+            ref={(el) => { el?.focus(); }}
+            className="px-4 py-2 rounded-lg text-sm font-medium
+              bg-indigo-600 hover:bg-indigo-500 active:bg-indigo-700
+              text-white transition-colors focus-visible:outline focus-visible:outline-2
+              focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+          >
+            {isLast ? "Done" : "Next →"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function OnboardingTour() {
+  const [stepIndex, setStepIndex] = useState(0);
+  const [visible, setVisible] = useState(false);
+  const [targetRect, setTargetRect] = useState<Rect | null>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const isFirstRender = useRef(true);  
+
+  const dismiss = useCallback(() => {
+    localStorage.setItem(TOUR_KEY, "1");
+    setVisible(false);
+  }, []);
+
+  const measureTarget = useCallback((id: string): Promise<Rect | null> => {
+  return new Promise((resolve) => {
+    const attempt = (tries: number) => {
+      const el = document.getElementById(id);
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth", block: "center" });
+        setTimeout(() => {
+          const r = el.getBoundingClientRect();
+          resolve({ top: r.top, left: r.left, width: r.width, height: r.height });
+        }, 400); // wait for scroll to finish
+        return;
+      }
+      if (tries <= 0) {
+        resolve(null);
+        return;
+      }
+      setTimeout(() => attempt(tries - 1), 300);
+    };
+    attempt(5);
+  });
+}, []);
+
+  // Initialise on mount
+  useEffect(() => {
+  if (localStorage.getItem(TOUR_KEY)) return;
+  const t = setTimeout(async () => {
+    const rect = await measureTarget(TOUR_STEPS[0].targetId);
+    if (rect) {
+      setTargetRect(rect);
+      setVisible(true);
+    }
+  }, 600);
+  return () => clearTimeout(t);
+}, [measureTarget]);
+
+// Measure target whenever step changes (skip on first render — init effect handles that)
+useEffect(() => {
+  if (!visible) return;
+  if (isFirstRender.current) {
+    isFirstRender.current = false;
+    return;
+  }
+  measureTarget(TOUR_STEPS[stepIndex].targetId).then((rect) => {
+    if (rect) {
+      setTargetRect(rect);
+      setTimeout(() => tooltipRef.current?.focus(), 50);
+    } else {
+      if (stepIndex < TOUR_STEPS.length - 1) {
+        setStepIndex((i) => i + 1);
+      } else {
+        dismiss();
+      }
+    }
+  });
+}, [stepIndex, visible, measureTarget, dismiss]);
+
+  // Re-measure on resize
+  useEffect(() => {
+  if (!visible) return;
+  const onResize = () => {
+    measureTarget(TOUR_STEPS[stepIndex].targetId).then(setTargetRect);
+  };
+  window.addEventListener("resize", onResize);
+  return () => window.removeEventListener("resize", onResize);
+}, [visible, stepIndex, measureTarget]);
+
+  // Keyboard support
+  useEffect(() => {
+    if (!visible) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") dismiss();
+      if (e.key === "ArrowRight" || e.key === "Enter") {
+        if (stepIndex < TOUR_STEPS.length - 1) setStepIndex((i) => i + 1);
+        else dismiss();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [visible, stepIndex, dismiss]);
+
+  if (!visible || !targetRect) return null;
+
+  return createPortal(
+    <>
+      {/* Clickable backdrop to skip */}
+      <div
+        className="fixed inset-0"
+        style={{ zIndex: 9997 }}
+        aria-hidden="true"
+        onClick={dismiss}
+      />
+      <Spotlight rect={targetRect} />
+      <Tooltip
+        step={TOUR_STEPS[stepIndex]}
+        stepIndex={stepIndex}
+        totalSteps={TOUR_STEPS.length}
+        rect={targetRect}
+        onNext={() => {
+          if (stepIndex < TOUR_STEPS.length - 1) setStepIndex((i) => i + 1);
+          else dismiss();
+        }}
+        onSkip={dismiss}
+        tooltipRef={tooltipRef}
+      />
+    </>,
+    document.body
+  );
+}

--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -82,7 +82,7 @@ export default function PresetSelector({ recipe, onChange }: Props) {
   );
 
   return (
-    <div className="space-y-3">
+    <div id="preset-selector" className="space-y-3">
       <div className="relative">
         <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
           <Search size={14} className="text-[var(--muted)]" />

--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -65,7 +65,7 @@ export default function TrimControl({ recipe, onChange, duration }: Props) {
     "w-full text-sm px-3 py-2 border border-[var(--border)] rounded-md bg-[var(--bg)] font-heading focus:outline-none focus:ring-2 focus:ring-film-400 text-[var(--text)] transition-shadow";
 
   return (
-    <div className="space-y-3">
+    <div id="trim-control" className="space-y-3">
       <div className="flex gap-3">
         <div className="flex-1">
           <label htmlFor="trim-start" className="text-sm font-heading font-semibold uppercase tracking-wider text-[var(--muted)] block mb-2">

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -21,6 +21,7 @@ import {
   Layers, Crop, Scissors, RotateCw, Volume2,
   SlidersHorizontal, Zap, AlertTriangle, Github
 } from "lucide-react";
+import OnboardingTour from "./OnboardingTour";
 
 interface SectionProps {
   icon: React.ReactNode;
@@ -89,6 +90,7 @@ export default function VideoEditor() {
   return (
     <div className="min-h-screen relative flex flex-col" style={{ background: "var(--bg)" }}>
       <ExportOverlay status={status} progress={progress} onCancel={cancelExport} />
+      <OnboardingTour />
 
       <div aria-live="polite" aria-atomic="true" className="sr-only">
         {status === "exporting" && `Exporting video: ${progress}%`}
@@ -342,6 +344,7 @@ export default function VideoEditor() {
             </div>
 
             <button
+              id="export-button"
               type="button"
               onClick={handleExport}
               disabled={!file || isProcessing}


### PR DESCRIPTION
## Description
Added a 4-step onboarding spotlight tour for first-time users. The tour highlights key UI elements (upload zone, preset selector, trim controls, export button) with a dimmed overlay and tooltip. Dismissal is stored in localStorage so the tour only appears once.

## Related Issue
Closes #680

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: Pranav-IIITM
- Contribution level: Intermediate

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes
- [x] This PR is related to a valid issue

----
## Screen Recording
Attached below showing the onboarding tour workflow and localStorage persistence.

https://github.com/user-attachments/assets/f7a8d403-7029-47a2-a325-24e1ad8d3dd3

