### PR TITLE
feat: add formatted video and live clip duration display

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -4,34 +4,25 @@ import { useRef, useState, useEffect} from "react";
 import { Film, FolderOpen } from "lucide-react";
 import LottiePlayer from "./LottiePlayer";
 import uploadAnim from "@/lib/lottie/upload.json";
-import { cn, formatBytes } from "@/lib/utils";
+import { cn, formatBytes, formatDuration } from "@/lib/utils";
 import { MAX_FILE_SIZE, WARNING_FILE_SIZE } from "@/lib/types";
 
 interface Props {
   onFileSelect: (file: File) => void;
   currentFile: File | null;
   fileError: string;
-}
-
-function formatDuration(seconds: number) {
-  const mins = Math.floor(seconds / 60);
-  const secs = Math.floor(seconds % 60);
-
-  return `${mins.toString().padStart(2, "0")}:${secs
-    .toString()
-    .padStart(2, "0")}`;
+  duration: number;
 }
 
 export default function FileUpload({
   onFileSelect,
   currentFile,
   fileError,
+  duration,
 }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const [dragging, setDragging] = useState(false);
-  const [duration, setDuration] = useState<number | null>(null);
-
   const [error, setError] = useState("");
   const [warning, setWarning] = useState("");
   
@@ -49,7 +40,6 @@ export default function FileUpload({
   const handleFile = (file: File) => {
     setError("");
     setWarning("");
-    setDuration(null);
 
     // Validate type
     if (!file.type.startsWith("video/")) {
@@ -81,18 +71,6 @@ export default function FileUpload({
         )}). Processing may take ~${estimatedMinutes} minutes and affect performance on low-memory devices.`
       );
     }
-
-    // Extract metadata safely
-    const video = document.createElement("video");
-    video.preload = "metadata";
-
-    const url = URL.createObjectURL(file);
-    video.src = url;
-
-    video.onloadedmetadata = () => {
-      URL.revokeObjectURL(url);
-      setDuration(video.duration);
-    };
 
     onFileSelect(file);
   };
@@ -130,12 +108,15 @@ export default function FileUpload({
               </span>
             )}
           </div>
-          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-            {formatBytes(currentFile?.size ?? 0)}
-            {duration !== null
-              ? ` • ${formatDuration(duration)}`
-              : " • Loading metadata..."}
-          </p>
+          <div className="text-xs text-gray-500 dark:text-gray-400 mt-1 space-y-0.5">
+            <p>{formatBytes(currentFile?.size ?? 0)}</p>
+
+            <p>
+              {duration > 0
+                ? `Duration: ${formatDuration(duration)}`
+                : "Loading duration..."}
+            </p>
+          </div>
         </div>
       </div>
 

--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { EditRecipe } from "@/lib/types";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { AlertCircle } from "lucide-react";
+import { formatDuration } from "@/lib/utils";
 
 interface Props {
   recipe: EditRecipe;
@@ -15,50 +16,101 @@ export default function TrimControl({ recipe, onChange, duration }: Props) {
   const [invalidEnd, setEnd] = useState(false);
   const [startErrorMsg, setStartErrorMsg] = useState("");
   const [endErrorMsg, setEndErrorMsg] = useState("");
+  const [startInput, setStartInput] = useState(
+  recipe.trimStart.toString()
+  );
+
+  useEffect(() => {
+    setStartInput(recipe.trimStart.toString());
+  }, [recipe.trimStart]);
+
+  const clipLength =
+  (recipe.trimEnd ?? duration) - recipe.trimStart;
 
   const handleStart = (val: string) => {
-    const n = parseFloat(val);
-    if (isNaN(n) || n < 0) {
-      setStart(true);
-      setStartErrorMsg("Start time must be 0 or greater.");
-      return;
-    }
-    if (duration > 0 && n >= duration) {
-      setStart(true);
-      setStartErrorMsg(`Start time must be less than duration (${duration.toFixed(1)}s).`);
-      return;
-    }
-    if (recipe.trimEnd !== null && n >= recipe.trimEnd) {
-      setStart(true);
-      setStartErrorMsg("Start time must be less than the end time.");
-      return;
-    }
+  setStartInput(val);
+
+  if (val === "") {
     setStart(false);
     setStartErrorMsg("");
-    onChange({ trimStart: n });
+    return;
+  }
+
+  const n = parseFloat(val);
+
+  if (isNaN(n)) {
+    setStart(true);
+    setStartErrorMsg("Enter a valid number.");
+    return;
+  }
+
+  if (n < 0) {
+    setStart(true);
+    setStartErrorMsg("Start time must be 0 or greater.");
+    return;
+  }
+
+  if (duration > 0 && n >= duration) {
+    setStart(true);
+    setStartErrorMsg(
+      `Start time must be less than duration (${duration.toFixed(1)}s).`
+    );
+    return;
+  }
+
+  if (recipe.trimEnd !== null && n >= recipe.trimEnd) {
+    setStart(true);
+    setStartErrorMsg("Start time must be less than the end time.");
+    return;
+  }
+
+  setStart(false);
+  setStartErrorMsg("");
+
+  onChange({ trimStart: n });
   };
 
   const handleEnd = (val: string) => {
+
     if (val === "") {
       setEnd(false);
       setEndErrorMsg("");
       onChange({ trimEnd: null });
       return;
     }
+
     const n = parseFloat(val);
-    if (isNaN(n) || n <= 0 || n <= recipe.trimStart) {
+
+    onChange({ trimEnd: n });
+
+    if (isNaN(n)) {
+      setEnd(true);
+      setEndErrorMsg("Enter a valid number.");
+      return;
+    }
+
+    if (n <= 0) {
+      setEnd(true);
+      setEndErrorMsg("End time must be greater than 0.");
+      return;
+    }
+
+    if (n <= recipe.trimStart) {
       setEnd(true);
       setEndErrorMsg("End time must be greater than start time.");
       return;
     }
-    if (duration > 0 && n > duration) {
+
+    if (duration > 0 && n > duration + 0.01) {
       setEnd(true);
-      setEndErrorMsg(`End time cannot exceed duration (${duration.toFixed(1)}s).`);
+      setEndErrorMsg(
+        `End time cannot exceed duration (${duration.toFixed(1)}s).`
+      );
       return;
     }
+
     setEnd(false);
     setEndErrorMsg("");
-    onChange({ trimEnd: n });
   };
 
   const inputClass =
@@ -77,7 +129,7 @@ export default function TrimControl({ recipe, onChange, duration }: Props) {
             min={0}
             max={duration > 0 ? duration : undefined}
             step={0.1}
-            value={recipe.trimStart}
+            value={startInput}
             spellCheck={false}
             onChange={(e) => handleStart(e.target.value)}
             aria-label="Trim start time in seconds"
@@ -121,13 +173,17 @@ export default function TrimControl({ recipe, onChange, duration }: Props) {
             </p>
           )}
         </div>
+
       </div>
       {duration > 0 && (
-        <p className="text-sm text-[var(--muted)] font-heading mt-1">
-          Duration: {duration.toFixed(1)}s
-        </p>
-      )}
-    </div>
+      <p className="text-sm text-[var(--muted)] font-heading mt-1">
+        Clip: {formatDuration(clipLength)} of{" "}
+        {formatDuration(duration)}
+      </p>
+        )}
+      </div>
+    
   );
+  
 }
 

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -117,7 +117,7 @@ export default function VideoEditor() {
 
           <div className="space-y-4">
             <div className="bg-[var(--surface)] rounded-xl p-5 border border-[var(--border)] animate-fade-in">
-              <FileUpload onFileSelect={handleFileSelect} currentFile={file} fileError={fileError} />
+              <FileUpload onFileSelect={handleFileSelect} currentFile={file} fileError={fileError} duration={duration} />
 
               {!file && (
               <div className="text-center text-[var(--muted)] py-6">

--- a/src/lib/tests/utils.test.ts
+++ b/src/lib/tests/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatBytes } from "../utils";
+import { formatBytes, formatDuration  } from "../utils";
 
 describe("formatBytes", () => {
   it("returns '0 Bytes' for zero input", () => {
@@ -37,5 +37,35 @@ describe("formatBytes", () => {
 
   it("clamps negative decimals to zero", () => {
     expect(formatBytes(1536, -1)).toBe("2 KB");
+  });
+});
+
+describe("formatDuration", () => {
+  it("formats zero seconds", () => {
+    expect(formatDuration(0)).toBe("0:00");
+  });
+
+  it("formats seconds under one minute", () => {
+    expect(formatDuration(5)).toBe("0:05");
+  });
+
+  it("formats minutes and seconds", () => {
+    expect(formatDuration(65)).toBe("1:05");
+  });
+
+  it("formats hours correctly", () => {
+    expect(formatDuration(3605)).toBe("1:00:05");
+  });
+
+  it("handles NaN values", () => {
+    expect(formatDuration(NaN)).toBe("0:00");
+  });
+
+  it("handles Infinity values", () => {
+    expect(formatDuration(Infinity)).toBe("0:00");
+  });
+
+  it("handles negative values", () => {
+    expect(formatDuration(-1)).toBe("0:00");
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,3 +20,25 @@ export function formatBytes(bytes: number, decimals = 1) {
     parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i]
   );
 }
+
+export function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return "0:00";
+  }
+
+  const totalSeconds = Math.round(seconds);
+
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const secs = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}:${minutes
+      .toString()
+      .padStart(2, "0")}:${secs
+      .toString()
+      .padStart(2, "0")}`;
+  }
+
+  return `${minutes}:${secs.toString().padStart(2, "0")}`;
+}


### PR DESCRIPTION
## Description

Implemented formatted video duration display and live clip duration updates in the editor UI.

### Changes made

* Added reusable `formatDuration(seconds)` utility in `src/lib/utils.ts`
* Display total video duration next to uploaded file information
* Added live clip duration preview in `TrimControl`
* Improved trim input UX and validation handling
* Added support for `H:MM:SS` formatting for videos longer than 1 hour
* Added unit tests for `formatDuration` edge cases and formatting behavior

## Related Issue

Closes #675

## Type of Contribution

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [x] GSSoC contribution

## Participant Info

* GitHub username: @imuniqueshiv
* Contribution level: Beginner

## Checklist

* [x] I have read the contribution guidelines
* [x] My changes follow the project structure
* [x] I have tested my changes
* [x] This PR is related to a valid issue

## Testing

* Ran `bun test`
* All tests passing (33/33)

## Demo

Included screen recording demonstrating:

https://github.com/user-attachments/assets/8d4d96cc-cf82-47a3-8694-90cd9243aad6

* total video duration display after upload
* proper formatting for long-duration videos
* live clip duration updates during trimming
* trim input validation behavior
