### PR TITLE
feat: integrate ffmpeg deshake filter for video stabilization

### DIFF
--- a/src/components/ExportSettings.tsx
+++ b/src/components/ExportSettings.tsx
@@ -132,7 +132,7 @@ export default function ExportSettings({
       </div>
 
       <div>
-        <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center justify-between mb-1">
           <label
             htmlFor="stabilization-toggle"
             className="text-sm font-heading font-semibold uppercase tracking-wider text-[var(--muted)] flex items-center gap-2"
@@ -148,8 +148,7 @@ export default function ExportSettings({
               checked={recipe.stabilization}
               onChange={(e) =>
                 onChange({
-                  stabilization:
-                    e.target.checked,
+                  stabilization: e.target.checked,
                 })
               }
               aria-label="Enable video stabilization"
@@ -159,12 +158,17 @@ export default function ExportSettings({
           </span>
         </div>
 
+        {/* Short descriptive label explaining what the setting does */}
+        <p className="text-xs text-[var(--muted)] mb-1">
+          Reduce camera shake
+        </p>
+
         <div className="flex justify-end">
           <span
             className={cn(
-              "text-sm",
+              "text-xs",
               recipe.stabilization
-                ? "text-red-700"
+                ? "text-red-700 font-medium"
                 : "text-[var(--muted)]"
             )}
           >

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -96,17 +96,17 @@ function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number):
     filters.push("setpts=PTS-STARTPTS");
   }
 
+ 
+  if (recipe.stabilization) {
+    filters.push("deshake");
+  }
+
   if (recipe.rotate === 90) {
     filters.push("transpose=1");
   } else if (recipe.rotate === 180) {
     filters.push("transpose=1,transpose=1");
   } else if (recipe.rotate === 270) {
     filters.push("transpose=2");
-  }
-
-  // Integrated from main branch layout enhancements
-  if ((recipe as any).stabilization) {
-    filters.push("deshake=x=-1:y=-1:w=-1:h=-1:rx=16:ry=16");
   }
 
   if (recipe.framing === "fit") {


### PR DESCRIPTION
### Description
This PR implements the video stabilization feature by connecting the frontend UI toggle to the backend FFmpeg pipeline. When the stabilization setting (recipe.stabilization) is checked, the deshake filter is appended to the video filter graph chain (filters array) inside the FFmpeg execution engine. Additionally, a short descriptive label ("Reduce camera shake") was added to the export settings panel to enhance user clarity.

### Related Issue
Closes #665 

### Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] GSSoC contribution

### Participant Info
- GitHub username: Vagventure
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

### Screen Recording
For this demonstration, I utilized a custom-created 3D animation video specifically built with severe, high-amplitude camera shakes to rigorously test the filter's stabilization capabilities.

**Visual Verification** (Before vs. After)
During local testing, I compared exports of the same handheld footage with the toggle on and off:

* **Stabilization OFF:** The footage contains large, high-amplitude camera shakes.

[![Stabilization OFF](https://github.com/user-attachments/assets/81fec67e-17db-49e7-b28c-f1e7dbd0b815)
](https://github.com/user-attachments/assets/c864cb13-aa5b-4e61-8e6b-f57cc434ca97)



* **Stabilization ON:** The large shakes are successfully dampened, significantly reducing their overall amplitude (resulting in minor micro-jitters instead of massive shifting).


https://github.com/user-attachments/assets/ea2e99e4-1b60-45df-9c95-b7fb14616ba0



### Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above**