### PR TITLE
feat(trim): replace number inputs with draggable timeline scrubber

### DIFF
--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { EditRecipe } from "@/lib/types";
-import { useState } from "react";
+import { useState,useRef,useEffect,useCallback } from "react";
 import { AlertCircle } from "lucide-react";
 
 interface Props {
@@ -15,6 +15,49 @@ export default function TrimControl({ recipe, onChange, duration }: Props) {
   const [invalidEnd, setEnd] = useState(false);
   const [startErrorMsg, setStartErrorMsg] = useState("");
   const [endErrorMsg, setEndErrorMsg] = useState("");
+  const trackRef = useRef<HTMLDivElement>(null);
+  const dragging = useRef<"start"|"end" | null>(null);
+
+
+ 
+  const xToSeconds = useCallback((clientX: number) => {
+  const track = trackRef.current;
+  if (!track || duration <= 0) return 0;
+  const { left, width } = track.getBoundingClientRect();
+  const ratio = Math.max(0, Math.min(1, (clientX - left) / width));
+  return parseFloat((ratio * duration).toFixed(1));
+}, [duration]);
+
+const applyDrag = useCallback((clientX: number) => {
+  const seconds = xToSeconds(clientX);
+  if (dragging.current === "start") {
+    const clamped = Math.min(seconds, (recipe.trimEnd ?? duration) - 0.1);
+    onChange({ trimStart: Math.max(0, clamped) });
+  } else if (dragging.current === "end") {
+    const clamped = Math.max(seconds, recipe.trimStart + 0.1);
+    onChange({ trimEnd: Math.min(duration, clamped) });
+  }
+}, [xToSeconds, duration, recipe.trimStart, recipe.trimEnd, onChange]);
+
+useEffect(()=>{
+   const onMove = (e: MouseEvent | TouchEvent) => {
+    const clientX = "touches" in e ? e.touches[0].clientX : e.clientX;
+    applyDrag(clientX);
+  };
+  const onUp = () => { dragging.current = null; };
+
+  document.addEventListener("mousemove", onMove);
+  document.addEventListener("mouseup", onUp);
+  document.addEventListener("touchmove", onMove);
+  document.addEventListener("touchend", onUp);
+
+  return () => {
+    document.removeEventListener("mousemove", onMove);
+    document.removeEventListener("mouseup", onUp);
+    document.removeEventListener("touchmove", onMove);
+    document.removeEventListener("touchend", onUp);
+  };
+},[applyDrag])
 
   const handleStart = (val: string) => {
     const n = parseFloat(val);
@@ -66,6 +109,64 @@ export default function TrimControl({ recipe, onChange, duration }: Props) {
 
   return (
     <div className="space-y-3">
+{duration > 0 && (
+  <div
+    ref={trackRef}
+    className="relative h-6 flex items-center cursor-pointer select-none"
+    onClick={(e) => {
+      if (dragging.current) return;
+      const s = xToSeconds(e.clientX);
+      onChange({ trimStart: s });
+    }}
+  >
+   
+    <div className="absolute inset-x-0 h-1.5 rounded-full bg-[var(--border)]" />
+
+  
+    <div
+      className="absolute h-1.5 rounded-full bg-film-400 opacity-60"
+      style={{
+        left: `${(recipe.trimStart / duration) * 100}%`,
+        right: `${((duration - (recipe.trimEnd ?? duration)) / duration) * 100}%`,
+      }}
+    />
+
+   
+    <div
+      role="slider"
+      aria-label="Trim start"
+      aria-valuenow={recipe.trimStart}
+      aria-valuemin={0}
+      aria-valuemax={duration}
+      tabIndex={0}
+      className="absolute w-4 h-4 rounded-full bg-white border-2 border-film-400 shadow cursor-grab active:cursor-grabbing -translate-x-1/2 focus:outline-none focus:ring-2 focus:ring-film-400"
+      style={{ left: `${(recipe.trimStart / duration) * 100}%` }}
+      onMouseDown={() => { dragging.current = "start"; }}
+      onTouchStart={() => { dragging.current = "start"; }}
+      onKeyDown={(e) => {
+        if (e.key === "ArrowLeft") onChange({ trimStart: Math.max(0, recipe.trimStart - 0.1) });
+        if (e.key === "ArrowRight") onChange({ trimStart: Math.min((recipe.trimEnd ?? duration) - 0.1, recipe.trimStart + 0.1) });
+      }}
+    />
+
+    <div
+      role="slider"
+      aria-label="Trim end"
+      aria-valuenow={recipe.trimEnd ?? duration}
+      aria-valuemin={0}
+      aria-valuemax={duration}
+      tabIndex={0}
+      className="absolute w-4 h-4 rounded-full bg-white border-2 border-film-400 shadow cursor-grab active:cursor-grabbing -translate-x-1/2 focus:outline-none focus:ring-2 focus:ring-film-400"
+      style={{ left: `${((recipe.trimEnd ?? duration) / duration) * 100}%` }}
+      onMouseDown={() => { dragging.current = "end"; }}
+      onTouchStart={() => { dragging.current = "end"; }}
+      onKeyDown={(e) => {
+        if (e.key === "ArrowLeft") onChange({ trimEnd: Math.max(recipe.trimStart + 0.1, (recipe.trimEnd ?? duration) - 0.1) });
+        if (e.key === "ArrowRight") onChange({ trimEnd: Math.min(duration, (recipe.trimEnd ?? duration) + 0.1) });
+      }}
+    />
+  </div>
+)}
       <div className="flex gap-3">
         <div className="flex-1">
           <label htmlFor="trim-start" className="text-sm font-heading font-semibold uppercase tracking-wider text-[var(--muted)] block mb-2">


### PR DESCRIPTION


## Description
Replaced the static number inputs in `TrimControl.tsx` with an interactive timeline scrubber. Users can now drag handles to set trim start/end instead of typing seconds manually. Number inputs remain below for fine-tuning and stay in sync with the scrubber.

## Related Issue
Closes #666

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] GSSoC contribution

## Participant Info
- GitHub username: aarishmansur
- Contribution level (Beginner/Intermediate/Advanced): Advanced

## Screen Recording

https://github.com/user-attachments/assets/109d94f5-d488-484e-a147-8445f2f24efa



## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)