### PR TITLE
fix: remove leftover debug console.log from useVideoEditor

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -415,19 +415,6 @@ export function useVideoEditor() {
     setError(null);
   }, [result]);
 
-  useEffect(() => {
-    if (process.env.NODE_ENV !== "development") return;
-    if (status !== "exporting") return;
-
-    const interval = setInterval(() => {
-      const mem = (performance as Performance & { memory?: { usedJSHeapSize: number } }).memory;
-      if (mem) {
-        console.log("[Reframe Memory]", Math.round(mem.usedJSHeapSize / 1e6), "MB used");
-      }
-    }, 1000);
-
-    return () => clearInterval(interval);
-  }, [status]);
 
   useEffect(() => {
     localStorage.setItem("soundOnCompletion", String(recipe.soundOnCompletion));


### PR DESCRIPTION
## Description
Removed a leftover debug `console.log` from `useVideoEditor.ts` (line 258) that was tracking memory usage. This ensures adherence to the rule defined in `CONTRIBUTING.md` ("No console.log: Remove debug logs before submitting").

## Related Issue
None (Minor Code Cleanup)

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: vivekyadav-3
- Contribution level (Beginner/Intermediate/Advanced): Beginner

## Screen Recording
**Recording / Loom link:** N/A - This is a pure code-cleanup PR with no UI/design changes.

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [ ] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [ ] **Screen recording attached above** (required for UI/feature/design changes)


Closes #736