### PR TITLE
fix: resolve conflicting upload size validation limits

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -47,20 +47,14 @@ export default function FileUpload({
       return;
     }
 
-    if (file.size > 500 * 1024 * 1024) {
-      setError("File size exceeds 500MB limit. Please select a smaller video.");
+    if (file.size > MAX_FILE_SIZE) {
+      setError( 
+        `File too large (${formatBytes(file.size)
+      }). Maximum allowed size is 2GB.`
+    );
       return;
     }
 
-    // Hard limit
-    if (file.size > MAX_FILE_SIZE) {
-      setError(
-        `File too large (${formatBytes(
-          file.size
-        )}). Maximum allowed size is 2GB.`
-      );
-      return;
-    }
 
     // Soft warning
     if (file.size > WARNING_FILE_SIZE) {


### PR DESCRIPTION
## Description

This PR resolves conflicting file upload size validations in `FileUpload.tsx`.

### Changes made

* Removed the conflicting hardcoded `500MB` validation
* Aligned upload validation with the existing `2GB` upload limit
* Ensured upload behavior matches the UI messaging shown in the upload component

## Related Issue

Fixes #701

## Type of Contribution

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [x] GSSoC contribution

## Participant Info

* GitHub username: @charu2210
* Contribution level: Beginner

## Validation

* Verified upload flow works correctly locally
* `npm run lint` passed successfully
* `npx tsc --noEmit` passed successfully

## Checklist

* [x] I have read the contribution guidelines
* [x] My changes follow the project structure
* [x] `bun run lint` passes (no ESLint errors)
* [x] `bunx tsc --noEmit` passes (no TypeScript errors)
* [x] No `console.log` statements left in
* [x] This PR is related to a valid issue