### PR TITLE
feat: export success sound with mute toggle

### DIFF
--- a/src/components/DownloadResult.tsx
+++ b/src/components/DownloadResult.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { ExportResult } from "@/lib/types";
 import { formatBytes } from "@/lib/utils";
-import { Download, RotateCcw, Share2, AlertCircle } from "lucide-react";
+import { Download, RotateCcw, Share2, AlertCircle, Volume2, VolumeX } from "lucide-react";
 import LottiePlayer from "./LottiePlayer";
 import successAnim from "@/lib/lottie/success.json";
 import { cn } from "@/lib/utils";
@@ -15,9 +15,10 @@ interface Props {
   result: ExportResult;
   onReset: () => void;
   soundOnCompletion: boolean;
+  onToggleSound: () => void;
 }
 
-export default function DownloadResult({ result, onReset, soundOnCompletion }: Props) {
+export default function DownloadResult({ result, onReset, soundOnCompletion, onToggleSound }: Props) {
   const defaultName = `reframe_${result.width}x${result.height}`;
   const [name, setName] = useState(defaultName);
 
@@ -41,15 +42,26 @@ export default function DownloadResult({ result, onReset, soundOnCompletion }: P
 
   return (
     <div className="p-5 bg-[var(--surface)] border border-[var(--border)] rounded-xl space-y-4">
-      <div className="flex items-center gap-4">
-        <div className="w-12 h-12 shrink-0">
-          <LottiePlayer animationData={successAnim} loop={false} autoplay />
-        </div>
-        <div>
-          <p className="font-heading font-bold text-base text-[var(--text)]">Export complete</p>
-          <p className="text-xs text-[var(--muted)] mt-0.5">Ready to download</p>
-        </div>
-      </div>
+      <div className="flex items-center justify-between">
+  <div className="flex items-center gap-4">
+    <div className="w-12 h-12 shrink-0">
+      <LottiePlayer animationData={successAnim} loop={false} autoplay />
+    </div>
+    <div>
+      <p className="font-heading font-bold text-base text-[var(--text)]">Export complete</p>
+      <p className="text-xs text-[var(--muted)] mt-0.5">Ready to download</p>
+    </div>
+  </div>
+  <button
+    type="button"
+    onClick={onToggleSound}
+    aria-label={soundOnCompletion ? "Mute completion sound" : "Unmute completion sound"}
+    className="p-2 rounded-lg border border-[var(--border)] text-[var(--muted)] hover:bg-[var(--bg)] transition-colors"
+    title={soundOnCompletion ? "Sound on" : "Sound off"}
+  >
+    {soundOnCompletion ? <Volume2 size={14} /> : <VolumeX size={14} />}
+  </button>
+</div>
 
       <div className="grid grid-cols-2 gap-2 text-sm">
         <div className="bg-[var(--bg)] rounded-lg p-3 border border-[var(--border)]">

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -59,6 +59,7 @@ export default function VideoEditor() {
     overlaySize, setOverlaySize,
     overlayOpacity, setOverlayOpacity,
     recommendedPreset,
+    toggleSound,
   } = useVideoEditor();
   const [copied, setCopied] = useState(false);
   const downloadRef = useRef<HTMLDivElement>(null);
@@ -305,7 +306,7 @@ export default function VideoEditor() {
 
             {status === "done" && result && (
               <div role="status" className="animate-fade-in" ref={downloadRef}>
-                <DownloadResult result={result} onReset={reset} soundOnCompletion={recipe.soundOnCompletion} />
+                <DownloadResult result={result} onReset={reset} soundOnCompletion={recipe.soundOnCompletion} onToggleSound={toggleSound} />
               </div>
             )}
           </div>

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -438,6 +438,10 @@ export function useVideoEditor() {
     }
   }, []);
 
+  const toggleSound = useCallback(() => {
+  updateRecipe({ soundOnCompletion: !recipe.soundOnCompletion });
+}, [recipe.soundOnCompletion, updateRecipe]);
+
   return {
     file,
     duration,
@@ -472,5 +476,6 @@ export function useVideoEditor() {
     overlayOpacity,
     setOverlayOpacity,
     recommendedPreset,
+    toggleSound,
   };
 }


### PR DESCRIPTION
## Description
Implements export success sound and mute toggle as described in #681. When export completes, a short chime plays and a mute toggle button appears in the result card. The preference is saved in localStorage.

## Related Issue
Closes #681

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: Pranav-IIITM
- Contribution level: Intermediate

## Screen Recording

To see the result see 00:17

https://github.com/user-attachments/assets/b8d42379-442b-4d74-855c-8d78e2f628a3



## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)