### PR TITLE
feat: add custom export presets + Other small Fix in FileUpload.tsx

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -101,50 +101,58 @@ export default function FileUpload({
   };
 
   const FileInfo = () => (
-    <div className="flex items-center gap-3 px-4 py-3 bg-film-50 border border-film-200 rounded-lg">
-      <Film size={18} className="text-film-600 shrink-0" />
+    <div className="rounded-lg border border-film-200 bg-film-50 px-4 py-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 items-start gap-3">
+          <Film size={18} className="mt-0.5 shrink-0 text-film-600" />
 
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2 mb-0.5">
-          <p className="text-sm font-medium text-[var(--text)] truncate">
-            {currentFile?.name}
-          </p>
-          {currentFile && (
-            <span className="px-2 py-0.5 bg-gray-700 text-white font-bold tracking-wider rounded text-[10px] uppercase">
-              {currentFile.name.includes('.') ? currentFile.name.split('.').pop() : 'VIDEO'}
-            </span>
-          )}
+          <div className="min-w-0">
+            <div className="mb-1 flex min-w-0 flex-wrap items-center gap-2">
+              {currentFile && (
+                <span className="shrink-0 rounded bg-gray-700 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-white">
+                  {currentFile.name.includes(".") ? currentFile.name.split(".").pop() : "VIDEO"}
+                </span>
+              )}
+              <p className="min-w-0 break-all text-sm font-medium text-[var(--text)]">
+                {currentFile?.name}
+              </p>
+            </div>
+
+            <p className="text-xs text-[var(--muted)]">
+              {formatBytes(currentFile?.size ?? 0)}
+              {duration !== null
+                ? ` - ${formatDuration(duration)}`
+                : " - Loading metadata..."}
+            </p>
+          </div>
         </div>
 
-        <p className="text-xs text-[var(--muted)]">
-          {formatBytes(currentFile?.size ?? 0)}
-          {duration !== null
-            ? ` • ${formatDuration(duration)}`
-            : " • Loading metadata..."}
+        <button
+          type="button"
+          onClick={() => inputRef.current?.click()}
+          className="self-start whitespace-nowrap text-xs font-semibold uppercase tracking-wide text-film-600 hover:text-film-700 sm:self-center"
+        >
+          Change
+          <span className="ml-1 text-[var(--muted)]">(Ctrl+O)</span>
+        </button>
+      </div>
+
+      <div className="mt-3 flex flex-col gap-2 border-t border-film-200 pt-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="inline-flex w-fit items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm font-heading font-medium text-[var(--muted)]">
+          <FolderOpen size={14} />
+          MP4 / MOV / AVI / WebM
+        </div>
+        <p className="text-xs text-gray-500">
+          Supports MP4, MOV, AVI, MKV, WebM, and most video formats
         </p>
       </div>
 
-      <button
-        type="button"
-        onClick={() => inputRef.current?.click()}
-        className="text-xs font-semibold text-film-600 hover:text-film-700 uppercase tracking-wide"
-      >
-        Change
-        <span className="text-[var(--muted)] ml-1">(Ctrl+O)</span>
-      </button>
-
-      <div className="flex items-center gap-2 px-4 py-2 bg-[var(--surface)] border border-[var(--border)] rounded-lg text-sm font-heading font-medium text-[var(--muted)]">
-      <FolderOpen size={14} />
-        MP4 / MOV / AVI / WebM
-      </div>
-      <p className="text-xs text-gray-500">
-        Supports: MP4, MOV, AVI, MKV, WebM, and most video formats
-      </p>
       {fileError && (
-        <p className="text-xs text-red-500 mt-2 font-medium">
+        <p className="mt-2 text-xs font-medium text-red-500">
           {fileError}
         </p>
       )}
+
       <input
         ref={inputRef}
         type="file"

--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -1,14 +1,22 @@
 "use client";
 
-import { PRESETS } from "@/lib/presets";
+import {
+  BUILT_IN_PRESETS,
+  CustomPreset,
+  MAX_CUSTOM_PRESETS,
+} from "@/lib/presets";
 import { EditRecipe } from "@/lib/types";
-import { Settings2, Lock, Unlock } from "lucide-react";
-import { useState, useCallback, useRef } from "react";
+import { Settings2, Lock, Unlock, Save, X } from "lucide-react";
+import { FormEvent, useEffect, useState, useCallback, useRef } from "react";
 import { cn } from "@/lib/utils";
 
 interface Props {
   recipe: EditRecipe;
+  customPresets: CustomPreset[];
   onChange: (patch: Partial<EditRecipe>) => void;
+  onSavePreset: (name: string) => { ok: boolean; message: string };
+  onDeletePreset: (id: string) => void;
+  onSelectCustomPreset: (id: string) => void;
 }
 
 function getOrientationLabel(width: number, height: number): string {
@@ -37,51 +45,108 @@ function RatioBox({ width, height, active }: { width: number; height: number; ac
   );
 }
 
-export default function PresetSelector({ recipe, onChange }: Props) {
-
+export default function PresetSelector({
+  recipe,
+  customPresets,
+  onChange,
+  onSavePreset,
+  onDeletePreset,
+  onSelectCustomPreset,
+}: Props) {
   const [locked, setLocked] = useState(false);
-  const [aspectRatio, setAspectRatio] = useState<number>(16 / 9);
+  const [isSaveOpen, setIsSaveOpen] = useState(false);
+  const [presetName, setPresetName] = useState("");
+  const [feedback, setFeedback] = useState<string | null>(null);
 
   const lockedRef = useRef(false);
-const aspectRatioRef = useRef(16 / 9);
+  const aspectRatioRef = useRef(16 / 9);
+  const presetNameRef = useRef<HTMLInputElement>(null);
+  const isCustomRecipe = recipe.preset === "custom" || customPresets.some((preset) => preset.id === recipe.preset);
 
-const handleToggleLock = useCallback(() => {
-  if (!lockedRef.current) {
-    const w = recipe.customWidth ?? 1920;
-    const h = recipe.customHeight ?? 1080;
-    const ratio = h !== 0 ? w / h : 16 / 9;
-    setAspectRatio(ratio);
-    aspectRatioRef.current = ratio;
-  }
-  setLocked((prev) => {
-    lockedRef.current = !prev;
-    return !prev;
-  });
-}, [recipe.customWidth, recipe.customHeight]);
+  useEffect(() => {
+    if (isSaveOpen) {
+      presetNameRef.current?.focus();
+    }
+  }, [isSaveOpen]);
+
+  const handleToggleLock = useCallback(() => {
+    if (!lockedRef.current) {
+      const w = recipe.customWidth ?? 1920;
+      const h = recipe.customHeight ?? 1080;
+      const ratio = h !== 0 ? w / h : 16 / 9;
+      aspectRatioRef.current = ratio;
+    }
+    setLocked((prev) => {
+      lockedRef.current = !prev;
+      return !prev;
+    });
+  }, [recipe.customWidth, recipe.customHeight]);
 
   const handleWidthChange = useCallback((w: number) => {
-  const patch: Partial<EditRecipe> = { customWidth: w };
-  if (lockedRef.current) patch.customHeight = Math.round(w / aspectRatioRef.current);
-  onChange(patch);
-}, [onChange]);
+    const patch: Partial<EditRecipe> = { preset: "custom", customWidth: w };
+    if (lockedRef.current) patch.customHeight = Math.round(w / aspectRatioRef.current);
+    onChange(patch);
+  }, [onChange]);
 
-const handleHeightChange = useCallback((h: number) => {
-  const patch: Partial<EditRecipe> = { customHeight: h };
-  if (lockedRef.current) patch.customWidth = Math.round(h * aspectRatioRef.current);
-  onChange(patch);
-}, [onChange]);
+  const handleHeightChange = useCallback((h: number) => {
+    const patch: Partial<EditRecipe> = { preset: "custom", customHeight: h };
+    if (lockedRef.current) patch.customWidth = Math.round(h * aspectRatioRef.current);
+    onChange(patch);
+  }, [onChange]);
+
+  const handleOpenSave = () => {
+    if (customPresets.length >= MAX_CUSTOM_PRESETS) {
+      setFeedback(`You can save up to ${MAX_CUSTOM_PRESETS} custom presets. Delete one before saving another.`);
+      return;
+    }
+
+    setPresetName("");
+    setFeedback(null);
+    setIsSaveOpen(true);
+  };
+
+  const handleSave = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const result = onSavePreset(presetName);
+    setFeedback(result.message);
+
+    if (result.ok) {
+      setIsSaveOpen(false);
+      setPresetName("");
+    }
+  };
 
   return (
     <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)]">
+          Built-in
+        </p>
+        <button
+          type="button"
+          onClick={handleOpenSave}
+          className="inline-flex min-h-[36px] items-center gap-2 rounded-lg border border-film-500 px-3 py-2 text-xs font-heading font-bold uppercase tracking-wider text-film-600 transition-colors hover:bg-film-50"
+        >
+          <Save size={14} />
+          Save preset
+        </button>
+      </div>
+
+      {feedback && (
+        <p className="rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-xs text-[var(--muted)]">
+          {feedback}
+        </p>
+      )}
+
       <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-        {PRESETS.filter((p) => p.id !== "custom").map((preset) => {
+        {BUILT_IN_PRESETS.filter((p) => p.id !== "custom").map((preset) => {
           const active = recipe.preset === preset.id;
           return (
             <button
               type="button"
               key={preset.id}
               onClick={() => onChange({ preset: preset.id })}
-              title={`${preset.label} — ${preset.width}×${preset.height} — ${getOrientationLabel(preset.width, preset.height)}`}
+              title={`${preset.label} - ${preset.width}x${preset.height} - ${getOrientationLabel(preset.width, preset.height)}`}
               aria-label={`Select ${preset.label} preset, ${preset.width} by ${preset.height} pixels`}
               aria-pressed={active}
               className={cn(
@@ -109,7 +174,7 @@ const handleHeightChange = useCallback((h: number) => {
 
         <button
           type="button"
-          title="Custom — Set your own dimensions"
+          title="Custom - Set your own dimensions"
           aria-label="Select custom dimensions preset"
           aria-pressed={recipe.preset === "custom"}
           onClick={() => onChange({ preset: "custom" })}
@@ -139,7 +204,61 @@ const handleHeightChange = useCallback((h: number) => {
         </button>
       </div>
 
-      {recipe.preset === "custom" && (
+      {customPresets.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)]">
+            Custom
+          </p>
+          <div className="grid grid-cols-1 gap-2">
+            {customPresets.map((preset) => {
+              const active = recipe.preset === preset.id;
+              const width = preset.recipe.customWidth;
+              const height = preset.recipe.customHeight;
+
+              return (
+                <div
+                  key={preset.id}
+                  className={cn(
+                    "flex min-h-[48px] items-center rounded-lg border bg-[var(--surface)] transition-colors",
+                    active ? "border-film-500 bg-film-50" : "border-[var(--border)] hover:border-film-300"
+                  )}
+                >
+                  <button
+                    type="button"
+                    onClick={() => onSelectCustomPreset(preset.id)}
+                    aria-pressed={active}
+                    className="flex min-w-0 flex-1 items-center gap-2 p-2.5 text-left"
+                  >
+                    <RatioBox width={width} height={height} active={active} />
+                    <div className="min-w-0">
+                      <p className={cn(
+                        "truncate text-xs font-heading font-bold",
+                        active ? "text-film-700" : "text-[var(--text)]"
+                      )}>
+                        {preset.name}
+                      </p>
+                      <p className="mt-0.5 text-[10px] leading-tight text-[var(--muted)]">
+                        {width}x{height} - CRF {preset.recipe.quality} - {preset.recipe.format.toUpperCase()}
+                      </p>
+                    </div>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onDeletePreset(preset.id)}
+                    aria-label={`Delete ${preset.name} custom preset`}
+                    title="Delete preset"
+                    className="mr-2 inline-flex min-h-[32px] min-w-[32px] items-center justify-center rounded-md text-[var(--muted)] transition-colors hover:bg-red-50 hover:text-red-600"
+                  >
+                    <X size={14} />
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {isCustomRecipe && (
         <div className="flex gap-3 items-center p-3 bg-[var(--surface)] rounded-lg border border-[var(--border)] animate-fade-in">
           <div className="flex-1">
             <label htmlFor="custom-width" className="text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)] block mb-1.5">
@@ -196,10 +315,66 @@ const handleHeightChange = useCallback((h: number) => {
             />
             {recipe.customHeight % 2 !== 0 && (
               <p className="text-[10px] text-amber-500 mt-1">
-                Warning- Odd number will round up to {recipe.customHeight + 1}
+                Warning - Odd number will round up to {recipe.customHeight + 1}
               </p>
             )}
           </div>
+        </div>
+      )}
+
+      {isSaveOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4">
+          <form
+            onSubmit={handleSave}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="save-preset-title"
+            className="w-full max-w-sm rounded-xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-xl"
+          >
+            <div className="mb-4 flex items-center justify-between gap-3">
+              <h4 id="save-preset-title" className="font-heading text-sm font-bold uppercase tracking-widest text-[var(--text)]">
+                Save preset
+              </h4>
+              <button
+                type="button"
+                onClick={() => setIsSaveOpen(false)}
+                aria-label="Close save preset dialog"
+                className="inline-flex min-h-[32px] min-w-[32px] items-center justify-center rounded-md text-[var(--muted)] hover:bg-[var(--border)]"
+              >
+                <X size={16} />
+              </button>
+            </div>
+
+            <label htmlFor="preset-name" className="mb-1.5 block text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)]">
+              Preset name
+            </label>
+            <input
+              id="preset-name"
+              ref={presetNameRef}
+              value={presetName}
+              onChange={(event) => setPresetName(event.target.value)}
+              maxLength={60}
+              placeholder="Instagram portrait 1080p"
+              className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2 text-sm font-heading focus:outline-none focus:ring-2 focus:ring-film-400"
+            />
+
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setIsSaveOpen(false)}
+                className="rounded-lg border border-[var(--border)] px-3 py-2 text-xs font-heading font-bold uppercase tracking-wider text-[var(--muted)] hover:bg-[var(--border)]"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={!presetName.trim()}
+                className="rounded-lg bg-film-600 px-3 py-2 text-xs font-heading font-bold uppercase tracking-wider text-white transition-colors hover:bg-film-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Save
+              </button>
+            </div>
+          </form>
         </div>
       )}
     </div>

--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/lib/presets";
 import { EditRecipe } from "@/lib/types";
 import { Settings2, Lock, Unlock, Save, X } from "lucide-react";
-import { FormEvent, useEffect, useState, useCallback, useRef } from "react";
+import { ChangeEvent, FormEvent, useEffect, useState, useCallback, useRef } from "react";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -45,6 +45,10 @@ function RatioBox({ width, height, active }: { width: number; height: number; ac
   );
 }
 
+function sanitizeDimensionInput(value: string): string {
+  return value.replace(/\D/g, "").replace(/^0+(?=\d)/, "");
+}
+
 export default function PresetSelector({
   recipe,
   customPresets,
@@ -57,6 +61,8 @@ export default function PresetSelector({
   const [isSaveOpen, setIsSaveOpen] = useState(false);
   const [presetName, setPresetName] = useState("");
   const [feedback, setFeedback] = useState<string | null>(null);
+  const [widthInput, setWidthInput] = useState(String(recipe.customWidth));
+  const [heightInput, setHeightInput] = useState(String(recipe.customHeight));
 
   const lockedRef = useRef(false);
   const aspectRatioRef = useRef(16 / 9);
@@ -68,6 +74,14 @@ export default function PresetSelector({
       presetNameRef.current?.focus();
     }
   }, [isSaveOpen]);
+
+  useEffect(() => {
+    setWidthInput(String(recipe.customWidth));
+  }, [recipe.customWidth]);
+
+  useEffect(() => {
+    setHeightInput(String(recipe.customHeight));
+  }, [recipe.customHeight]);
 
   const handleToggleLock = useCallback(() => {
     if (!lockedRef.current) {
@@ -93,6 +107,20 @@ export default function PresetSelector({
     if (lockedRef.current) patch.customWidth = Math.round(h * aspectRatioRef.current);
     onChange(patch);
   }, [onChange]);
+
+  const handleWidthInputChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    const nextValue = sanitizeDimensionInput(event.target.value);
+    setWidthInput(nextValue);
+    if (!nextValue) return;
+    handleWidthChange(Number(nextValue));
+  }, [handleWidthChange]);
+
+  const handleHeightInputChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    const nextValue = sanitizeDimensionInput(event.target.value);
+    setHeightInput(nextValue);
+    if (!nextValue) return;
+    handleHeightChange(Number(nextValue));
+  }, [handleHeightChange]);
 
   const handleOpenSave = () => {
     if (customPresets.length >= MAX_CUSTOM_PRESETS) {
@@ -271,9 +299,12 @@ export default function PresetSelector({
               min={16}
               max={7680}
               step={2}
-              value={recipe.customWidth}
+              value={widthInput}
               spellCheck={false}
-              onChange={(e) => handleWidthChange(Number(e.target.value))}
+              onChange={handleWidthInputChange}
+              onBlur={() => {
+                if (!widthInput) setWidthInput(String(recipe.customWidth));
+              }}
               className="w-full text-sm px-3 py-1.5 border border-[var(--border)] rounded-md bg-[var(--bg)] font-heading focus:outline-none focus:ring-2 focus:ring-film-400 transition-shadow"
             />
             {recipe.customWidth % 2 !== 0 && (
@@ -308,9 +339,12 @@ export default function PresetSelector({
               min={16}
               max={7680}
               step={2}
-              value={recipe.customHeight}
+              value={heightInput}
               spellCheck={false}
-              onChange={(e) => handleHeightChange(Number(e.target.value))}
+              onChange={handleHeightInputChange}
+              onBlur={() => {
+                if (!heightInput) setHeightInput(String(recipe.customHeight));
+              }}
               className="w-full text-sm px-3 py-1.5 border border-[var(--border)] rounded-md bg-[var(--bg)] font-heading focus:outline-none focus:ring-2 focus:ring-film-400 transition-shadow"
             />
             {recipe.customHeight % 2 !== 0 && (

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -49,7 +49,8 @@ function Section({ icon, title, children, delay = 0 }: SectionProps) {
 export default function VideoEditor() {
   const {
     file, duration, recipe, status, progress,
-    result, error, updateRecipe,
+    result, error, customPresets, updateRecipe,
+    saveCustomPreset, deleteCustomPreset, loadCustomPreset,
     handleFileSelect, fileError, handleExport, cancelExport, reset, resetSettings,
     videoRef,
     seekTo,
@@ -122,7 +123,7 @@ export default function VideoEditor() {
 
               {file && (
                 <div className="mt-4 animate-fade-in">
-                  <VideoPreview file={file} videoRef={videoRef} />
+                  <VideoPreview file={file} recipe={recipe} videoRef={videoRef} />
 
                   <div className="mt-3">
                     <ThumbnailStrip
@@ -320,7 +321,14 @@ export default function VideoEditor() {
           )}>
             <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6 animate-fade-in" style={{ animationDelay: "50ms" }}>
               <Section icon={<Layers size={12} />} title="Output size">
-                <PresetSelector recipe={recipe} onChange={updateRecipe} />
+                <PresetSelector
+                  recipe={recipe}
+                  customPresets={customPresets}
+                  onChange={updateRecipe}
+                  onSavePreset={saveCustomPreset}
+                  onDeletePreset={deleteCustomPreset}
+                  onSelectCustomPreset={loadCustomPreset}
+                />
               </Section>
 
               <Section icon={<Crop size={12} />} title="Framing" delay={100}>

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useRef, useState, RefObject } from "react";
 import { EditRecipe } from "@/lib/types";
-import { getPresetById } from "@/lib/presets";
+import { getRecipeDimensions } from "@/lib/presets";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -78,11 +78,7 @@ export default function VideoPreview({ file, recipe, videoRef }: Props) {
   const overlay = (() => {
     if (!recipe || !showOverlay) return null;
 
-    const preset = recipe.preset === "custom"
-      ? { width: recipe.customWidth, height: recipe.customHeight }
-      : getPresetById(recipe.preset);
-
-    if (!preset) return null;
+    const preset = getRecipeDimensions(recipe);
 
     // Preview container is 16:9
     const containerW = 16;

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -224,7 +224,6 @@ export function useVideoEditor() {
      }  catch (err) {
       if (exportCancelledRef.current) return;
 
-      console.error("export failed:", err);
       if (err instanceof FFmpegLoadError) {
         setError(err.message);
       } else if (err instanceof Error && err.message.includes('network')) {

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -4,6 +4,13 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { EditRecipe, ExportResult, ExportStatus, MAX_FILE_SIZE } from "@/lib/types";
 import { DEFAULT_RECIPE } from "@/lib/constants";
 import { loadFFmpeg, exportVideo, terminateFFmpeg, FFmpegLoadError } from "@/lib/ffmpeg";
+import {
+  CustomPreset,
+  MAX_CUSTOM_PRESETS,
+  getRecipeDimensions,
+  loadCustomPresets,
+  saveCustomPresets,
+} from "@/lib/presets";
 
 const DEFAULT_TITLE = "Reframe — Resize, trim, and export videos in your browser";
 
@@ -69,13 +76,65 @@ export function useVideoEditor() {
   const [result, setResult] = useState<ExportResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [fileError, setFileError] = useState("");
+  const [customPresets, setCustomPresets] = useState<CustomPreset[]>([]);
   const exportAbortControllerRef = useRef<AbortController | null>(null);
   const exportCancelledRef = useRef(false);
   const videoRef = useRef<HTMLVideoElement>(null);
 
+  useEffect(() => {
+    setCustomPresets(loadCustomPresets());
+  }, []);
+
   const updateRecipe = useCallback((patch: Partial<EditRecipe>) => {
     setRecipe((prev) => ({ ...prev, ...patch }));
   }, []);
+
+  const saveCustomPreset = useCallback((name: string) => {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      return { ok: false, message: "Preset name is required." };
+    }
+
+    if (customPresets.length >= MAX_CUSTOM_PRESETS) {
+      return {
+        ok: false,
+        message: `You can save up to ${MAX_CUSTOM_PRESETS} custom presets. Delete one before saving another.`,
+      };
+    }
+
+    const dimensions = getRecipeDimensions(recipe);
+    const id = `custom-preset-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const preset: CustomPreset = {
+      id,
+      name: trimmedName,
+      createdAt: Date.now(),
+      recipe: {
+        ...recipe,
+        preset: id,
+        customWidth: dimensions.width,
+        customHeight: dimensions.height,
+      },
+    };
+
+    const nextPresets = [preset, ...customPresets].slice(0, MAX_CUSTOM_PRESETS);
+    setCustomPresets(nextPresets);
+    saveCustomPresets(nextPresets);
+
+    return { ok: true, message: `"${trimmedName}" saved.` };
+  }, [customPresets, recipe]);
+
+  const deleteCustomPreset = useCallback((id: string) => {
+    const nextPresets = customPresets.filter((preset) => preset.id !== id);
+    setCustomPresets(nextPresets);
+    saveCustomPresets(nextPresets);
+    setRecipe((prev) => prev.preset === id ? { ...prev, preset: "custom" } : prev);
+  }, [customPresets]);
+
+  const loadCustomPreset = useCallback((id: string) => {
+    const preset = customPresets.find((item) => item.id === id);
+    if (!preset) return;
+    setRecipe(preset.recipe);
+  }, [customPresets]);
 
   const handleFileSelect = useCallback(async (selectedFile: File) => {
     setResult(null);
@@ -272,6 +331,7 @@ export function useVideoEditor() {
     file,
     duration,
     recipe,
+    customPresets,
     status,
     progress,
     result,
@@ -279,6 +339,9 @@ export function useVideoEditor() {
     videoRef,
     seekTo,
     updateRecipe,
+    saveCustomPreset,
+    deleteCustomPreset,
+    loadCustomPreset,
     handleFileSelect,
     fileError,
     handleExport,

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -2,7 +2,6 @@ import { FFmpeg } from "@ffmpeg/ffmpeg";
 import { fetchFile, toBlobURL } from "@ffmpeg/util";
 import { EditRecipe, ExportResult } from "./types";
 import { getRecipeDimensions } from "./presets";
-import { simd } from "wasm-feature-detect";
 
 const CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd";
 
@@ -40,16 +39,9 @@ export async function loadFFmpeg(signal?: AbortSignal,
   try {
 
     ffmpeg.on("progress", handleProgress);
-    // Check if the user's browser supports WebAssembly SIMD
-    const isSimdSupported = await simd();
-
-    // Dynamically set the core filename
-    const coreName = isSimdSupported ? "ffmpeg-core-simd" : "ffmpeg-core";
-
-    // Load FFmpeg using the dynamic URLs + the new signal parameter
     await ffmpeg.load({
-      coreURL: await toBlobURL(`${CORE_BASE_URL}/${coreName}.js`, "text/javascript"),
-      wasmURL: await toBlobURL(`${CORE_BASE_URL}/${coreName}.wasm`, "application/wasm"),
+      coreURL: await toBlobURL(`${CORE_BASE_URL}/ffmpeg-core.js`, "text/javascript"),
+      wasmURL: await toBlobURL(`${CORE_BASE_URL}/ffmpeg-core.wasm`, "application/wasm"),
     }, { signal });
     onProgress?.(100);
     return ffmpeg;

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -1,7 +1,7 @@
 import { FFmpeg } from "@ffmpeg/ffmpeg";
 import { fetchFile, toBlobURL } from "@ffmpeg/util";
 import { EditRecipe, ExportResult } from "./types";
-import { getPresetById } from "./presets";
+import { getRecipeDimensions } from "./presets";
 import { simd } from "wasm-feature-detect";
 
 const CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd";
@@ -163,15 +163,7 @@ export async function exportVideo(
   signal?: AbortSignal
 ): Promise<ExportResult> {
   const sessionId = buildSessionId();
-  let targetW: number, targetH: number;
-  if (recipe.preset === "custom") {
-    targetW = recipe.customWidth;
-    targetH = recipe.customHeight;
-  } else {
-    const preset = getPresetById(recipe.preset);
-    targetW = preset?.width ?? 1920;
-    targetH = preset?.height ?? 1080;
-  }
+  let { width: targetW, height: targetH } = getRecipeDimensions(recipe);
 
   // dimensions must be even for libx264
   targetW = Math.round(targetW / 2) * 2;
@@ -308,4 +300,4 @@ export async function exportVideo(
       }
     }
   }
-}
+}

--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -41,6 +41,10 @@ export function getPresetById(id: string): Preset | undefined {
 }
 
 export function getRecipeDimensions(recipe: Pick<EditRecipe, "preset" | "customWidth" | "customHeight">) {
+  if (recipe.preset === "custom") {
+    return { width: recipe.customWidth, height: recipe.customHeight };
+  }
+
   const preset = getPresetById(recipe.preset);
   return preset
     ? { width: preset.width, height: preset.height }

--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -1,3 +1,6 @@
+import type { EditRecipe } from "./types";
+import { DEFAULT_RECIPE } from "./constants";
+
 export interface Preset {
   id: string;
   label: string;
@@ -6,7 +9,17 @@ export interface Preset {
   height: number;
 }
 
-export const PRESETS: Preset[] = [
+export interface CustomPreset {
+  id: string;
+  name: string;
+  recipe: EditRecipe;
+  createdAt: number;
+}
+
+export const CUSTOM_PRESET_STORAGE_KEY = "reframe.customPresets";
+export const MAX_CUSTOM_PRESETS = 10;
+
+export const BUILT_IN_PRESETS: Preset[] = [
   { id: "vertical-9-16",      label: "9 : 16",    platform: "Reels · TikTok · Shorts", width: 1080,  height: 1920 },
   { id: "instagram-4-5",      label: "4 : 5",     platform: "Instagram Feed",            width: 1080,  height: 1350 },
   { id: "square-1-1",         label: "1 : 1",     platform: "Square",                    width: 1080,  height: 1080 },
@@ -20,7 +33,105 @@ export const PRESETS: Preset[] = [
   { id: "custom",             label: "Custom",    platform: "Set your own",              width: 1920,  height: 1080 },
 ];
 
+export const PRESETS = BUILT_IN_PRESETS;
+
 /** Returns the preset matching the given ID, or undefined if no match is found. */
 export function getPresetById(id: string): Preset | undefined {
-  return PRESETS.find((p) => p.id === id);
+  return BUILT_IN_PRESETS.find((p) => p.id === id);
+}
+
+export function getRecipeDimensions(recipe: Pick<EditRecipe, "preset" | "customWidth" | "customHeight">) {
+  const preset = getPresetById(recipe.preset);
+  return preset
+    ? { width: preset.width, height: preset.height }
+    : { width: recipe.customWidth, height: recipe.customHeight };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function normalizeNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function normalizeBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function normalizeRecipe(value: unknown, presetId: string): EditRecipe | null {
+  if (!isRecord(value)) return null;
+
+  const format = value.format === "webm" || value.format === "mkv" || value.format === "mp4"
+    ? value.format
+    : DEFAULT_RECIPE.format;
+  const framing = value.framing === "fill" || value.framing === "fit"
+    ? value.framing
+    : DEFAULT_RECIPE.framing;
+  const rotate = value.rotate === 90 || value.rotate === 180 || value.rotate === 270 || value.rotate === 0
+    ? value.rotate
+    : DEFAULT_RECIPE.rotate;
+
+  return {
+    ...DEFAULT_RECIPE,
+    preset: presetId,
+    customWidth: normalizeNumber(value.customWidth, DEFAULT_RECIPE.customWidth),
+    customHeight: normalizeNumber(value.customHeight, DEFAULT_RECIPE.customHeight),
+    framing,
+    trimStart: normalizeNumber(value.trimStart, DEFAULT_RECIPE.trimStart),
+    trimEnd: value.trimEnd === null || typeof value.trimEnd !== "number"
+      ? DEFAULT_RECIPE.trimEnd
+      : normalizeNumber(value.trimEnd, DEFAULT_RECIPE.trimEnd ?? 0),
+    rotate,
+    keepAudio: normalizeBoolean(value.keepAudio, DEFAULT_RECIPE.keepAudio),
+    speed: normalizeNumber(value.speed, DEFAULT_RECIPE.speed),
+    quality: normalizeNumber(value.quality, DEFAULT_RECIPE.quality),
+    format,
+    stabilization: normalizeBoolean(value.stabilization, DEFAULT_RECIPE.stabilization),
+    brightness: normalizeNumber(value.brightness, DEFAULT_RECIPE.brightness),
+    contrast: normalizeNumber(value.contrast, DEFAULT_RECIPE.contrast),
+    saturation: normalizeNumber(value.saturation, DEFAULT_RECIPE.saturation),
+  };
+}
+
+function normalizeCustomPreset(value: unknown): CustomPreset | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.id !== "string" || typeof value.name !== "string") return null;
+
+  const recipe = normalizeRecipe(value.recipe, value.id);
+  if (!recipe) return null;
+
+  return {
+    id: value.id,
+    name: value.name,
+    recipe,
+    createdAt: normalizeNumber(value.createdAt, Date.now()),
+  };
+}
+
+export function loadCustomPresets(): CustomPreset[] {
+  if (typeof window === "undefined") return [];
+
+  try {
+    const raw = window.localStorage.getItem(CUSTOM_PRESET_STORAGE_KEY);
+    if (!raw) return [];
+
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed
+      .map(normalizeCustomPreset)
+      .filter((preset): preset is CustomPreset => preset !== null)
+      .slice(0, MAX_CUSTOM_PRESETS);
+  } catch {
+    return [];
+  }
+}
+
+export function saveCustomPresets(presets: CustomPreset[]) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(
+    CUSTOM_PRESET_STORAGE_KEY,
+    JSON.stringify(presets.slice(0, MAX_CUSTOM_PRESETS))
+  );
 }

--- a/src/lib/tests/presets.test.ts
+++ b/src/lib/tests/presets.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getPresetById, PRESETS } from "../presets";
+import { getPresetById, getRecipeDimensions, PRESETS } from "../presets";
 
 describe('getPresetById', () => {
   it('returns correct preset for valid id', () => {
@@ -20,5 +20,21 @@ describe('getPresetById', () => {
       expect(p.label).toBeTruthy();
       expect(p.platform).toBeTruthy();
     });
+  });
+
+  it('uses built-in dimensions for built-in preset ids', () => {
+    expect(getRecipeDimensions({
+      preset: 'instagram-4-5',
+      customWidth: 1920,
+      customHeight: 1080,
+    })).toEqual({ width: 1080, height: 1350 });
+  });
+
+  it('uses recipe dimensions for custom preset ids', () => {
+    expect(getRecipeDimensions({
+      preset: 'custom-preset-123',
+      customWidth: 1080,
+      customHeight: 1350,
+    })).toEqual({ width: 1080, height: 1350 });
   });
 });

--- a/src/lib/tests/presets.test.ts
+++ b/src/lib/tests/presets.test.ts
@@ -37,4 +37,12 @@ describe('getPresetById', () => {
       customHeight: 1350,
     })).toEqual({ width: 1080, height: 1350 });
   });
+
+  it('uses recipe dimensions for the custom preset editor', () => {
+    expect(getRecipeDimensions({
+      preset: 'custom',
+      customWidth: 1080,
+      customHeight: 1350,
+    })).toEqual({ width: 1080, height: 1350 });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #683 

Adds custom export presets so users can save their current `EditRecipe` with a name and reuse it later.

## What Changed

- Added custom preset persistence with `localStorage`
- Split built-in presets from custom preset handling
- Added a “Save preset” button near the preset selector
- Added a modal for naming custom presets
- Added a “Custom” section below built-in presets
- Added delete buttons for individual custom presets
- Enforced a max of 10 custom presets with a helpful message
- Updated export and preview dimension resolution so saved custom preset IDs restore the correct dimensions
- Added tests for built-in vs custom preset dimension lookup

## Testing

- [x] `bun test`
- [x] `bun run build`
- [x] Custom preset can be saved
- [x] Custom preset appears under Custom section
- [x] Custom preset persists after reload
- [x] Selecting custom preset restores saved settings
- [x] Custom preset can be deleted
- [x] Max 10 custom presets message appears

