### PR TITLE
feat: add custom export presets

### DIFF
--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -1,16 +1,20 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { ChangeEvent, FormEvent, useCallback, useEffect, useRef, useState } from "react";
 
-import { Search, Settings2 } from "lucide-react";
+import { Search, Settings2, Save, X } from "lucide-react";
 
-import { PRESETS } from "@/lib/presets";
+import { CustomPreset, MAX_CUSTOM_PRESETS, PRESETS } from "@/lib/presets";
 import { EditRecipe } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 interface Props {
   recipe: EditRecipe;
+  customPresets: CustomPreset[];
   onChange: (patch: Partial<EditRecipe>) => void;
+  onSavePreset: (name: string) => { ok: boolean; message: string };
+  onDeletePreset: (id: string) => void;
+  onSelectCustomPreset: (id: string) => void;
 }
 
 function getOrientationLabel(width: number, height: number): string {
@@ -47,6 +51,10 @@ function RatioBox({
       style={{ width: w, height: h }}
     />
   );
+}
+
+function sanitizeDimensionInput(value: string): string {
+  return value.replace(/\D/g, "").replace(/^0+(?=\d)/, "");
 }
 
 const QUICK_ACTIONS = [
@@ -102,8 +110,25 @@ const QUICK_ACTIONS = [
   },
 ] as const;
 
-export default function PresetSelector({ recipe, onChange }: Props) {
+export default function PresetSelector({
+  recipe,
+  customPresets,
+  onChange,
+  onSavePreset,
+  onDeletePreset,
+  onSelectCustomPreset,
+}: Props) {
   const [search, setSearch] = useState("");
+  const [isSaveOpen, setIsSaveOpen] = useState(false);
+  const [presetName, setPresetName] = useState("");
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [widthInput, setWidthInput] = useState(String(recipe.customWidth));
+  const [heightInput, setHeightInput] = useState(String(recipe.customHeight));
+  const presetNameRef = useRef<HTMLInputElement>(null);
+
+  const isCustomRecipe =
+    recipe.preset === "custom" ||
+    customPresets.some((preset) => preset.id === recipe.preset);
 
   const filteredPresets = PRESETS.filter(
     (preset) =>
@@ -120,23 +145,55 @@ export default function PresetSelector({ recipe, onChange }: Props) {
     [onChange],
   );
 
-  const handleWidthChange = useCallback(
-    (width: number) => {
-      if (!isNaN(width) && width >= 16 && width <= 7680) {
-        onChange({ customWidth: width });
-      }
-    },
-    [onChange],
-  );
+  useEffect(() => {
+    if (isSaveOpen) {
+      presetNameRef.current?.focus();
+    }
+  }, [isSaveOpen]);
 
-  const handleHeightChange = useCallback(
-    (height: number) => {
-      if (!isNaN(height) && height >= 16 && height <= 7680) {
-        onChange({ customHeight: height });
-      }
-    },
-    [onChange],
-  );
+  useEffect(() => {
+    setWidthInput(String(recipe.customWidth));
+  }, [recipe.customWidth]);
+
+  useEffect(() => {
+    setHeightInput(String(recipe.customHeight));
+  }, [recipe.customHeight]);
+
+  const handleWidthInputChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    const nextValue = sanitizeDimensionInput(event.target.value);
+    setWidthInput(nextValue);
+    if (!nextValue) return;
+    onChange({ preset: "custom", customWidth: Number(nextValue) });
+  }, [onChange]);
+
+  const handleHeightInputChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    const nextValue = sanitizeDimensionInput(event.target.value);
+    setHeightInput(nextValue);
+    if (!nextValue) return;
+    onChange({ preset: "custom", customHeight: Number(nextValue) });
+  }, [onChange]);
+
+  const handleOpenSave = () => {
+    if (customPresets.length >= MAX_CUSTOM_PRESETS) {
+      setFeedback(`You can save up to ${MAX_CUSTOM_PRESETS} custom presets. Delete one before saving another.`);
+      return;
+    }
+
+    setPresetName("");
+    setFeedback(null);
+    setIsSaveOpen(true);
+  };
+
+  const handleSave = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const result = onSavePreset(presetName);
+    setFeedback(result.message);
+
+    if (result.ok) {
+      setIsSaveOpen(false);
+      setPresetName("");
+    }
+  };
 
   return (
     <div className="space-y-3">
@@ -170,18 +227,33 @@ export default function PresetSelector({ recipe, onChange }: Props) {
         })}
       </div>
 
-      <div className="relative">
-        <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-          <Search size={14} className="text-[var(--muted)]" />
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <div className="relative flex-1">
+          <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+            <Search size={14} className="text-[var(--muted)]" />
+          </div>
+          <input
+            type="text"
+            placeholder="Search formats..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] py-2 pl-9 pr-3 text-sm font-heading text-[var(--text)] transition-shadow focus:outline-none focus:ring-2 focus:ring-film-400"
+          />
         </div>
-        <input
-          type="text"
-          placeholder="Search formats..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] py-2 pl-9 pr-3 text-sm font-heading text-[var(--text)] transition-shadow focus:outline-none focus:ring-2 focus:ring-film-400"
-        />
+
+        <button
+          type="button"
+          onClick={handleOpenSave}
+          className="inline-flex min-h-[40px] items-center justify-center gap-2 rounded-lg border border-film-300 bg-film-50 px-3 text-xs font-heading font-bold uppercase tracking-wider text-film-700 transition-colors hover:bg-film-100"
+        >
+          <Save size={14} />
+          Save preset
+        </button>
       </div>
+
+      {feedback && (
+        <p className="text-xs font-medium text-[var(--muted)]">{feedback}</p>
+      )}
 
       <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
         {filteredPresets.length === 0 ? (
@@ -272,65 +344,193 @@ export default function PresetSelector({ recipe, onChange }: Props) {
         </button>
       </div>
 
-      {recipe.preset === "custom" && (
-        <div className="mt-2 flex items-center gap-4 rounded-lg border border-[var(--border)] bg-[var(--surface)] p-4 shadow-sm animate-fade-in">
-          <div className="flex-1">
-            <label
-              htmlFor="custom-width"
-              className="mb-1.5 block text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)]"
-            >
-              Width
-            </label>
-            <input
-              id="custom-width"
-              type="number"
-              autoComplete="off" 
-              min={16}
-              max={7680}
-              step={2}
-              value={recipe.customWidth}
-              onChange={(e) => handleWidthChange(Number(e.target.value))}
-              className="w-full min-w-20 rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2 text-sm font-heading transition-all focus:outline-none focus:ring-2 focus:ring-film-400 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-            />
-          </div>
+      {customPresets.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-[10px] font-heading font-bold uppercase tracking-widest text-[var(--muted)]">
+            Custom
+          </p>
+          <div className="grid grid-cols-1 gap-2">
+            {customPresets.map((preset) => {
+              const active = recipe.preset === preset.id;
+              const { customWidth, customHeight, quality, format } = preset.recipe;
 
-          <div className="flex h-full flex-col items-center justify-center">
-            <span className="font-heading text-sm font-medium text-[var(--muted)]">
-              ×
-            </span>
+              return (
+                <div
+                  key={preset.id}
+                  className={cn(
+                    "flex items-center gap-3 rounded-lg border bg-[var(--surface)] p-3 transition-colors",
+                    active
+                      ? "border-film-500 bg-film-50"
+                      : "border-[var(--border)] hover:border-film-300",
+                  )}
+                >
+                  <button
+                    type="button"
+                    onClick={() => onSelectCustomPreset(preset.id)}
+                    className="flex min-w-0 flex-1 items-center gap-3 text-left"
+                    aria-pressed={active}
+                  >
+                    <RatioBox
+                      width={customWidth}
+                      height={customHeight}
+                      active={active}
+                    />
+                    <span className="min-w-0">
+                      <span
+                        className={cn(
+                          "block truncate text-sm font-heading font-bold",
+                          active ? "text-film-700" : "text-[var(--text)]",
+                        )}
+                      >
+                        {preset.name}
+                      </span>
+                      <span className="block text-[11px] leading-tight text-[var(--muted)]">
+                        {customWidth}x{customHeight} - CRF {quality} - {format.toUpperCase()}
+                      </span>
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onDeletePreset(preset.id)}
+                    className="rounded-md p-1.5 text-[var(--muted)] transition-colors hover:bg-[var(--border)] hover:text-[var(--text)]"
+                    aria-label={`Delete ${preset.name} preset`}
+                  >
+                    <X size={15} />
+                  </button>
+                </div>
+              );
+            })}
           </div>
+        </div>
+      )}
 
-          <div className="flex-1">
-            <label
-              htmlFor="custom-height"
-              className="mb-1.5 block text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)]"
-            >
-              Height
-            </label>
-            <input
-              id="custom-height"
-              type="number"
-              autoComplete="off"
-              min={16}
-              max={7680}
-              step={2}
-              value={recipe.customHeight}
-              onChange={(e) => handleHeightChange(Number(e.target.value))}
-              className="w-full min-w-20 rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2 text-sm font-heading transition-all focus:outline-none focus:ring-2 focus:ring-film-400 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-            />
-          </div>
+      {isCustomRecipe && (
+        <div className="mt-2 rounded-lg border border-[var(--border)] bg-[var(--surface)] p-3 shadow-sm animate-fade-in">
+          <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-end gap-2">
+            <div className="min-w-0">
+              <label
+                htmlFor="custom-width"
+                className="mb-1.5 block text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)]"
+              >
+                Width (px)
+              </label>
+              <input
+                id="custom-width"
+                type="number"
+                inputMode="numeric"
+                autoComplete="off"
+                spellCheck={false}
+                min={16}
+                max={7680}
+                step={2}
+                value={widthInput}
+                onChange={handleWidthInputChange}
+                onBlur={() => {
+                  if (!widthInput) setWidthInput(String(recipe.customWidth));
+                }}
+                className="h-10 w-full min-w-0 rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 text-sm font-heading transition-all focus:outline-none focus:ring-2 focus:ring-film-400 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              />
+            </div>
 
-          <div className="hidden h-full flex-col justify-end sm:flex">
-            <span className="mb-1.5 block text-center text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)]">
-              Ratio
-            </span>
-            <div className="flex h-[38px] items-center rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 text-xs font-medium text-film-700">
-              {getOrientationLabel(
-                recipe.customWidth || 0,
-                recipe.customHeight || 0,
-              )}
+            <div className="flex h-10 items-center pb-px">
+              <span className="font-heading text-sm font-medium text-[var(--muted)]">
+                x
+              </span>
+            </div>
+
+            <div className="min-w-0">
+              <label
+                htmlFor="custom-height"
+                className="mb-1.5 block text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)]"
+              >
+                Height (px)
+              </label>
+              <input
+                id="custom-height"
+                type="number"
+                inputMode="numeric"
+                autoComplete="off"
+                spellCheck={false}
+                min={16}
+                max={7680}
+                step={2}
+                value={heightInput}
+                onChange={handleHeightInputChange}
+                onBlur={() => {
+                  if (!heightInput) setHeightInput(String(recipe.customHeight));
+                }}
+                className="h-10 w-full min-w-0 rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 text-sm font-heading transition-all focus:outline-none focus:ring-2 focus:ring-film-400 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              />
             </div>
           </div>
+
+          <p className="mt-2 text-center text-[11px] font-medium text-[var(--muted)]">
+            {recipe.customWidth}x{recipe.customHeight} -{" "}
+            {getOrientationLabel(recipe.customWidth || 1, recipe.customHeight || 1)}
+          </p>
+        </div>
+      )}
+
+      {isSaveOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="save-preset-title"
+        >
+          <form
+            onSubmit={handleSave}
+            className="w-full max-w-sm rounded-xl border border-[var(--border)] bg-[var(--surface)] p-5 shadow-xl"
+          >
+            <div className="mb-4 flex items-center justify-between gap-3">
+              <h3
+                id="save-preset-title"
+                className="font-heading text-lg font-bold text-[var(--text)]"
+              >
+                Save preset
+              </h3>
+              <button
+                type="button"
+                onClick={() => setIsSaveOpen(false)}
+                className="rounded-md p-1.5 text-[var(--muted)] transition-colors hover:bg-[var(--border)] hover:text-[var(--text)]"
+                aria-label="Close save preset dialog"
+              >
+                <X size={16} />
+              </button>
+            </div>
+
+            <label
+              htmlFor="preset-name"
+              className="mb-1.5 block text-xs font-heading font-bold uppercase tracking-wider text-[var(--muted)]"
+            >
+              Preset name
+            </label>
+            <input
+              id="preset-name"
+              ref={presetNameRef}
+              type="text"
+              value={presetName}
+              onChange={(event) => setPresetName(event.target.value)}
+              placeholder="Instagram portrait 1080p"
+              className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2 text-sm font-heading text-[var(--text)] focus:outline-none focus:ring-2 focus:ring-film-400"
+            />
+
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setIsSaveOpen(false)}
+                className="rounded-lg border border-[var(--border)] px-3 py-2 text-xs font-heading font-bold uppercase tracking-wider text-[var(--muted)] transition-colors hover:bg-[var(--border)]"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="rounded-lg bg-film-600 px-3 py-2 text-xs font-heading font-bold uppercase tracking-wider text-white transition-colors hover:bg-film-700"
+              >
+                Save preset
+              </button>
+            </div>
+          </form>
         </div>
       )}
     </div>

--- a/src/components/ThumbnailStrip.tsx
+++ b/src/components/ThumbnailStrip.tsx
@@ -43,6 +43,10 @@ export default function ThumbnailStrip({
     objectUrlsRef.current = [];
   }, []);
 
+  const cancelThumbnailRun = useCallback(() => {
+    lastRunIdRef.current += 1;
+  }, []);
+
   const generateThumbnails = useCallback(async () => {
     if (!videoSrc || duration <= 0) return;
 
@@ -144,10 +148,10 @@ export default function ThumbnailStrip({
       generateThumbnails();
     }
     return () => {
-      lastRunIdRef.current++;
+      cancelThumbnailRun();
       revokeAllObjectUrls();
     };
-  }, [generateThumbnails, revokeAllObjectUrls, videoSrc, duration]);
+  }, [cancelThumbnailRun, generateThumbnails, revokeAllObjectUrls, videoSrc, duration]);
 
   const formatTime = (seconds: number) => {
     const m = Math.floor(seconds / 60);

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -18,8 +18,8 @@ import ImageOverlay from "./ImageOverlay"
 
 import { cn } from "@/lib/utils";
 import {
-  Layers, Crop, Scissors, RotateCw, Volume2,
-  SlidersHorizontal, Zap, AlertTriangle, Github, Copy
+  Layers, Scissors, RotateCw, Volume2,
+  SlidersHorizontal, Zap, AlertTriangle, Copy
 } from "lucide-react";
 import OnboardingTour from "./OnboardingTour";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
@@ -206,7 +206,8 @@ function KeyboardShortcutsPanel() {
 export default function VideoEditor() {
   const {
     file, duration, recipe, status, progress,
-    result, error, updateRecipe,
+    result, error, customPresets, updateRecipe,
+    saveCustomPreset, deleteCustomPreset, loadCustomPreset,
     handleFileSelect, fileError, handleExport, cancelExport, reset, resetSettings,
     videoRef,
     seekTo,
@@ -571,7 +572,14 @@ export default function VideoEditor() {
                     </p>
                   </div>
                 )}
-                <PresetSelector recipe={recipe} onChange={updateRecipe} />
+                <PresetSelector
+                  recipe={recipe}
+                  customPresets={customPresets}
+                  onChange={updateRecipe}
+                  onSavePreset={saveCustomPreset}
+                  onDeletePreset={deleteCustomPreset}
+                  onSelectCustomPreset={loadCustomPreset}
+                />
                 <div className="mt-3">
                   <FramingControl recipe={recipe} onChange={updateRecipe} />
                 </div>

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useRef, useState, useCallback, RefObject } from "react";
 import { EditRecipe } from "@/lib/types";
-import { getPresetById } from "@/lib/presets";
+import { getRecipeDimensions } from "@/lib/presets";
 import { cn } from "@/lib/utils";
 import { Camera } from "lucide-react";
 import ComparisonPreview from "./ComparisonPreview";
@@ -111,11 +111,7 @@ export default function VideoPreview({ file, recipe, videoRef }: Props) {
   const overlay = (() => {
     if (!recipe || !showOverlay) return null;
 
-    const preset = recipe.preset === "custom"
-      ? { width: recipe.customWidth, height: recipe.customHeight }
-      : getPresetById(recipe.preset);
-
-    if (!preset) return null;
+    const preset = getRecipeDimensions(recipe);
 
     // Preview container is 16:9
     const containerW = 16;

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -3,7 +3,14 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { EditRecipe, ExportResult, ExportStatus, MAX_FILE_SIZE, OverlayPosition, isValidRecipe } from "@/lib/types";
 import { DEFAULT_RECIPE, SPEED_STEPS } from "@/lib/constants";
-import { getPresetById } from "@/lib/presets";
+import {
+  CustomPreset,
+  MAX_CUSTOM_PRESETS,
+  getPresetById,
+  getRecipeDimensions,
+  loadCustomPresets,
+  saveCustomPresets,
+} from "@/lib/presets";
 import { loadFFmpeg, exportVideo, terminateFFmpeg, FFmpegLoadError } from "@/lib/ffmpeg";
 import { suggestPreset } from "@/lib/presetSuggestion";
 import { validateDimensions, getDownscaledDimensions } from "@/utils/video-validation";
@@ -137,6 +144,7 @@ export function useVideoEditor() {
   const [result, setResult] = useState<ExportResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [fileError, setFileError] = useState("");
+  const [customPresets, setCustomPresets] = useState<CustomPreset[]>([]);
   const exportAbortControllerRef = useRef<AbortController | null>(null);
   const exportCancelledRef = useRef(false);
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -161,6 +169,61 @@ export function useVideoEditor() {
     return next;
   });
 }, []);
+
+  useEffect(() => {
+    setCustomPresets(loadCustomPresets());
+  }, []);
+
+  const saveCustomPreset = useCallback((name: string) => {
+    const trimmedName = name.trim();
+
+    if (!trimmedName) {
+      return { ok: false, message: "Preset name is required." };
+    }
+
+    if (customPresets.length >= MAX_CUSTOM_PRESETS) {
+      return {
+        ok: false,
+        message: `You can save up to ${MAX_CUSTOM_PRESETS} custom presets. Delete one before saving another.`,
+      };
+    }
+
+    const id = `custom-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const dimensions = getRecipeDimensions(recipe);
+    const presetRecipe: EditRecipe = {
+      ...recipe,
+      preset: id,
+      customWidth: dimensions.width,
+      customHeight: dimensions.height,
+    };
+    const nextPreset: CustomPreset = {
+      id,
+      name: trimmedName,
+      recipe: presetRecipe,
+      createdAt: Date.now(),
+    };
+    const nextPresets = [...customPresets, nextPreset];
+
+    setCustomPresets(nextPresets);
+    saveCustomPresets(nextPresets);
+    setRecipe(presetRecipe);
+
+    return { ok: true, message: `"${trimmedName}" saved as a custom preset.` };
+  }, [customPresets, recipe]);
+
+  const deleteCustomPreset = useCallback((id: string) => {
+    const nextPresets = customPresets.filter((preset) => preset.id !== id);
+    setCustomPresets(nextPresets);
+    saveCustomPresets(nextPresets);
+    setRecipe((prev) => prev.preset === id ? { ...prev, preset: "custom" } : prev);
+  }, [customPresets]);
+
+  const loadCustomPreset = useCallback((id: string) => {
+    const preset = customPresets.find((item) => item.id === id);
+    if (!preset) return;
+    setRecipe(preset.recipe);
+  }, [customPresets]);
+
   const isValidValue = (key: keyof EditRecipe, val: any): boolean => {
     switch (key) {
       case "preset":
@@ -641,9 +704,13 @@ export function useVideoEditor() {
     progress,
     result,
     error,
+    customPresets,
     videoRef,
     seekTo,
     updateRecipe,
+    saveCustomPreset,
+    deleteCustomPreset,
+    loadCustomPreset,
     handleFileSelect,
     fileError,
     handleExport,

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -527,7 +527,6 @@ export function useVideoEditor() {
      }  catch (err) {
       if (exportCancelledRef.current) return;
 
-      console.error("export failed:", err);
       if (err instanceof FFmpegLoadError) {
         setError(err.message);
       } else if (err instanceof Error && err.message.includes('network')) {

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -1,7 +1,7 @@
 import { FFmpeg } from "@ffmpeg/ffmpeg";
 import { fetchFile, toBlobURL } from "@ffmpeg/util";
 import { EditRecipe, ExportResult, BackgroundMusicOptions, ImageOverlayOptions } from "./types";
-import { getPresetById } from "./presets";
+import { getRecipeDimensions } from "./presets";
 import { simd } from "wasm-feature-detect";
 
 const CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd";
@@ -306,15 +306,7 @@ export async function exportVideo(
   overlayOptions?: ImageOverlayOptions
 ): Promise<ExportResult> {
   const sessionId = buildSessionId();
-  let targetW: number, targetH: number;
-  if (recipe.preset === "custom") {
-    targetW = recipe.customWidth;
-    targetH = recipe.customHeight;
-  } else {
-    const preset = getPresetById(recipe.preset);
-    targetW = preset?.width ?? 1920;
-    targetH = preset?.height ?? 1080;
-  }
+  let { width: targetW, height: targetH } = getRecipeDimensions(recipe);
 
   targetW = Math.round(targetW / 2) * 2;
   targetH = Math.round(targetH / 2) * 2;
@@ -481,7 +473,7 @@ export async function exportVideo(
       size: blob.size,
       width: targetW,
       height: targetH,
-      format: recipe.format as "mp4" | "webm" | "mkv",
+      format: recipe.format,
     };
   } finally {
     ffmpeg.off("progress", handleProgress);

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -2,7 +2,6 @@ import { FFmpeg } from "@ffmpeg/ffmpeg";
 import { fetchFile, toBlobURL } from "@ffmpeg/util";
 import { EditRecipe, ExportResult, BackgroundMusicOptions, ImageOverlayOptions } from "./types";
 import { getRecipeDimensions } from "./presets";
-import { simd } from "wasm-feature-detect";
 
 const CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd";
 

--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -1,3 +1,6 @@
+import type { EditRecipe } from "./types";
+import { DEFAULT_RECIPE } from "./constants";
+
 export interface Preset {
   id: string;
   label: string;
@@ -6,7 +9,17 @@ export interface Preset {
   height: number;
 }
 
-export const PRESETS: Preset[] = [
+export interface CustomPreset {
+  id: string;
+  name: string;
+  recipe: EditRecipe;
+  createdAt: number;
+}
+
+export const CUSTOM_PRESET_STORAGE_KEY = "reframe.customPresets";
+export const MAX_CUSTOM_PRESETS = 10;
+
+export const BUILT_IN_PRESETS: Preset[] = [
   { id: "vertical-9-16",      label: "9 : 16",    platform: "Reels · TikTok · Shorts", width: 1080,  height: 1920 },
   { id: "instagram-4-5",      label: "4 : 5",     platform: "Instagram Feed",            width: 1080,  height: 1350 },
   { id: "square-1-1",         label: "1 : 1",     platform: "Square",                    width: 1080,  height: 1080 },
@@ -20,7 +33,112 @@ export const PRESETS: Preset[] = [
   { id: "custom",             label: "Custom",    platform: "Set your own",              width: 1920,  height: 1080 },
 ];
 
+export const PRESETS = BUILT_IN_PRESETS;
+
 /** Returns the preset matching the given ID, or undefined if no match is found. */
 export function getPresetById(id: string): Preset | undefined {
-  return PRESETS.find((p) => p.id === id);
+  return BUILT_IN_PRESETS.find((p) => p.id === id);
+}
+
+export function getRecipeDimensions(recipe: Pick<EditRecipe, "preset" | "customWidth" | "customHeight">) {
+  if (recipe.preset === "custom") {
+    return { width: recipe.customWidth, height: recipe.customHeight };
+  }
+
+  const preset = getPresetById(recipe.preset);
+  return preset
+    ? { width: preset.width, height: preset.height }
+    : { width: recipe.customWidth, height: recipe.customHeight };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function normalizeNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function normalizeBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function normalizeRecipe(value: unknown, presetId: string): EditRecipe | null {
+  if (!isRecord(value)) return null;
+
+  const format = value.format === "webm" || value.format === "mkv" || value.format === "mp4" || value.format === "gif"
+    ? value.format
+    : DEFAULT_RECIPE.format;
+  const framing = value.framing === "fill" || value.framing === "fit"
+    ? value.framing
+    : DEFAULT_RECIPE.framing;
+  const rotate = value.rotate === 90 || value.rotate === 180 || value.rotate === 270 || value.rotate === 0
+    ? value.rotate
+    : DEFAULT_RECIPE.rotate;
+
+  return {
+    ...DEFAULT_RECIPE,
+    preset: presetId,
+    customWidth: normalizeNumber(value.customWidth, DEFAULT_RECIPE.customWidth),
+    customHeight: normalizeNumber(value.customHeight, DEFAULT_RECIPE.customHeight),
+    framing,
+    trimStart: normalizeNumber(value.trimStart, DEFAULT_RECIPE.trimStart),
+    trimEnd: value.trimEnd === null || typeof value.trimEnd !== "number"
+      ? DEFAULT_RECIPE.trimEnd
+      : normalizeNumber(value.trimEnd, DEFAULT_RECIPE.trimEnd ?? 0),
+    rotate,
+    keepAudio: normalizeBoolean(value.keepAudio, DEFAULT_RECIPE.keepAudio),
+    normalizeAudio: normalizeBoolean(value.normalizeAudio, DEFAULT_RECIPE.normalizeAudio),
+    speed: normalizeNumber(value.speed, DEFAULT_RECIPE.speed),
+    quality: normalizeNumber(value.quality, DEFAULT_RECIPE.quality),
+    format,
+    stabilization: normalizeBoolean(value.stabilization, DEFAULT_RECIPE.stabilization),
+    brightness: normalizeNumber(value.brightness, DEFAULT_RECIPE.brightness),
+    contrast: normalizeNumber(value.contrast, DEFAULT_RECIPE.contrast),
+    saturation: normalizeNumber(value.saturation, DEFAULT_RECIPE.saturation),
+    soundOnCompletion: normalizeBoolean(value.soundOnCompletion, DEFAULT_RECIPE.soundOnCompletion),
+    version: DEFAULT_RECIPE.version,
+  };
+}
+
+function normalizeCustomPreset(value: unknown): CustomPreset | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.id !== "string" || typeof value.name !== "string") return null;
+
+  const recipe = normalizeRecipe(value.recipe, value.id);
+  if (!recipe) return null;
+
+  return {
+    id: value.id,
+    name: value.name,
+    recipe,
+    createdAt: normalizeNumber(value.createdAt, Date.now()),
+  };
+}
+
+export function loadCustomPresets(): CustomPreset[] {
+  if (typeof window === "undefined") return [];
+
+  try {
+    const raw = window.localStorage.getItem(CUSTOM_PRESET_STORAGE_KEY);
+    if (!raw) return [];
+
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed
+      .map(normalizeCustomPreset)
+      .filter((preset): preset is CustomPreset => preset !== null)
+      .slice(0, MAX_CUSTOM_PRESETS);
+  } catch {
+    return [];
+  }
+}
+
+export function saveCustomPresets(presets: CustomPreset[]) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(
+    CUSTOM_PRESET_STORAGE_KEY,
+    JSON.stringify(presets.slice(0, MAX_CUSTOM_PRESETS))
+  );
 }

--- a/src/lib/tests/presets.test.ts
+++ b/src/lib/tests/presets.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getPresetById, PRESETS } from "../presets";
+import { getPresetById, getRecipeDimensions, PRESETS } from "../presets";
 
 describe('getPresetById', () => {
   it('returns correct preset for valid id', () => {
@@ -20,5 +20,21 @@ describe('getPresetById', () => {
       expect(p.label).toBeTruthy();
       expect(p.platform).toBeTruthy();
     });
+  });
+
+  it('uses built-in dimensions for built-in preset ids', () => {
+    expect(getRecipeDimensions({
+      preset: 'instagram-4-5',
+      customWidth: 1920,
+      customHeight: 1080,
+    })).toEqual({ width: 1080, height: 1350 });
+  });
+
+  it('uses recipe dimensions for custom preset ids', () => {
+    expect(getRecipeDimensions({
+      preset: 'custom-preset-123',
+      customWidth: 1080,
+      customHeight: 1350,
+    })).toEqual({ width: 1080, height: 1350 });
   });
 });

--- a/src/lib/tests/presets.test.ts
+++ b/src/lib/tests/presets.test.ts
@@ -37,4 +37,12 @@ describe('getPresetById', () => {
       customHeight: 1350,
     })).toEqual({ width: 1080, height: 1350 });
   });
+
+  it('uses recipe dimensions for the custom preset editor', () => {
+    expect(getRecipeDimensions({
+      preset: 'custom',
+      customWidth: 1080,
+      customHeight: 1350,
+    })).toEqual({ width: 1080, height: 1350 });
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,11 @@
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  oxc: {
+    jsx: {
+      runtime: 'automatic',
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,2 +1,16 @@
 // Vitest setup: polyfills and global mocks
 import '@testing-library/jest-dom/vitest'
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+})


### PR DESCRIPTION


https://github.com/user-attachments/assets/e45fc0b6-67e8-431a-a7d9-b10835457df7

## Summary

Fixes #683 

Adds custom export presets so users can save their current `EditRecipe` with a name and reuse it later.

## What Changed

- Added custom preset persistence with `localStorage`
- Split built-in presets from custom preset handling
- Added a “Save preset” button near the preset selector
- Added a modal for naming custom presets
- Added a “Custom” section below built-in presets
- Added delete buttons for individual custom presets
- Enforced a max of 10 custom presets with a helpful message
- Updated export and preview dimension resolution so saved custom preset IDs restore the correct dimensions
- Added tests for built-in vs custom preset dimension lookup

## Testing

- [x] `bun test`
- [x] `bun run build`
- [x] Custom preset can be saved
- [x] Custom preset appears under Custom section
- [x] Custom preset persists after reload
- [x] Selecting custom preset restores saved settings
- [x] Custom preset can be deleted
- [x] Max 10 custom presets message appears
