### PR TITLE
feat: add video sharpening filter option

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -489,7 +489,7 @@ export default function VideoEditor() {
                           value={recipe.sharpness}
                           onChange={(e) => updateRecipe({ sharpness: Number(e.target.value) })}
                           aria-label="Adjust sharpness"
-                          className="w-full"
+                          className="w-full accent-film-600"
                         />
                       </div>
                     </div>

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -246,6 +246,30 @@ export default function VideoEditor() {
                           className="w-full"
                         />
                       </div>
+                      {/* Sharpness */}
+                      <div className="space-y-2">
+                        <div className="flex items-center justify-between text-xs">
+                          <label htmlFor="sharpness-slider">Sharpness</label>
+                          <button
+                            type="button"
+                            onClick={() => updateRecipe({ sharpness: 0 })}
+                            className="text-film-500 hover:underline"
+                          >
+                            Reset
+                          </button>
+                        </div>
+                        <input
+                          id="sharpness-slider"
+                          type="range"
+                          min="0"
+                          max="3"
+                          step="1"
+                          value={recipe.sharpness}
+                          onChange={(e) => updateRecipe({ sharpness: Number(e.target.value) })}
+                          aria-label="Adjust sharpness"
+                          className="w-full"
+                        />
+                      </div>
                     </div>
                   </Section>
                   <Section icon={<SlidersHorizontal size={12} />} title="Output format" delay={190}>

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -468,6 +468,30 @@ export default function VideoEditor() {
                           className="w-full accent-film-600"
                         />
                       </div>
+                      {/* Sharpness */}
+                      <div className="space-y-2">
+                        <div className="flex items-center justify-between text-xs">
+                          <label htmlFor="sharpness-slider">Sharpness</label>
+                          <button
+                            type="button"
+                            onClick={() => updateRecipe({ sharpness: 0 })}
+                            className="text-film-500 hover:underline"
+                          >
+                            Reset
+                          </button>
+                        </div>
+                        <input
+                          id="sharpness-slider"
+                          type="range"
+                          min="0"
+                          max="3"
+                          step="1"
+                          value={recipe.sharpness}
+                          onChange={(e) => updateRecipe({ sharpness: Number(e.target.value) })}
+                          aria-label="Adjust sharpness"
+                          className="w-full"
+                        />
+                      </div>
                     </div>
                   </Section>
                   <Section icon={<SlidersHorizontal size={12} />} title="Output format" delay={190}>

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -106,6 +106,10 @@ function validateRecipe(recipe: EditRecipe, duration: number ): string | null {
       recipe.saturation < 0 || recipe.saturation > 3,
       "Saturation must be between 0 and 3.",
     ],
+    [
+      recipe.sharpness < 0 || recipe.sharpness > 3,
+      "Sharpness must be between 0 and 3.",
+    ],
   ];
 
   return (

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -110,6 +110,10 @@ function validateRecipe(recipe: EditRecipe, duration: number ): string | null {
       recipe.saturation < 0 || recipe.saturation > 3,
       "Saturation must be between 0 and 3.",
     ],
+    [
+      recipe.sharpness < 0 || recipe.sharpness > 3,
+      "Sharpness must be between 0 and 3.",
+    ],
   ];
 
   return (

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -19,4 +19,5 @@ export const DEFAULT_RECIPE: EditRecipe = {
   saturation: 1,
   stabilization: false,
   soundOnCompletion: false,
+  sharpness: 0,
 };

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -24,5 +24,4 @@ export const DEFAULT_RECIPE: EditRecipe = {
   sharpness: 0,
   normalizeAudio: false,
   version: RECIPE_VERSION,
-  sharpness: 0,
 };

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -23,4 +23,5 @@ export const DEFAULT_RECIPE: EditRecipe = {
   soundOnCompletion: false,
   normalizeAudio: false,
   version: RECIPE_VERSION,
+  sharpness: 0,
 };

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -120,6 +120,9 @@ function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number):
       `crop=${targetW}:${targetH}`
     );
   }
+  if (recipe.sharpness !== 0) {
+    filters.push(`unsharp=5:5:${recipe.sharpness}:5:5:0.0`);
+  }
 
   if (recipe.speed !== 1) {
     const pts = (1 / recipe.speed).toFixed(4);

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -130,6 +130,9 @@ export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: n
       `crop=${targetW}:${targetH}`
     );
   }
+  if (recipe.sharpness !== 0) {
+    filters.push(`unsharp=5:5:${recipe.sharpness}:5:5:0.0`);
+  }
 
   if (recipe.speed !== 1) {
   const pts = (1 / recipe.speed).toFixed(4);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,6 +20,7 @@ export interface EditRecipe {
   saturation: number;
   soundOnCompletion: boolean;
   version: number;
+  sharpness: number;
 }
 
 export type OverlayPosition =

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,6 +15,7 @@ export interface EditRecipe {
   contrast: number;
   saturation: number;
   soundOnCompletion: boolean;
+  sharpness: number;
 }
 
 export type OverlayPosition =
@@ -80,6 +81,7 @@ export const DEFAULT_RECIPE: EditRecipe = {
   contrast: 0,
   saturation: 0,
   soundOnCompletion: false,
+  sharpness: 1,
 };
 
 export const MAX_FILE_SIZE =


### PR DESCRIPTION
## Description
- Added video sharpening filter using ffmpeg `unsharp` filter.

## Related Issue
Closes #130 

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: MaitrayeeK
- Contribution level (Beginner):

## Screen Recording

https://github.com/user-attachments/assets/1d77fcbc-f880-405a-af65-b2e1442227e1

<!-- REQUIRED for all UI / feature / design changes. -->
<!-- Drag a video file here or paste a Loom link below. -->
<!-- PRs touching any visible UI without a recording will NOT be merged. -->

> **How to record:** run `bun run dev` → open http://localhost:3000 → demonstrate the full working flow of your change, including any edge cases.
>
> - **macOS**: `Cmd + Shift + 5` → Record Selected Portion, or use QuickTime Player
> - **Windows**: `Win + G` → Xbox Game Bar → Capture
> - **Linux**: OBS Studio, GNOME Screenshot tool, or `kazam`
> - **Any OS**: [Loom](https://loom.com) (free screen recorder, great for sharing)


## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)

Note: Real time preview is not done in this PR.
