### PR TITLE
fix: remove duplicate DEFAULT_RECIPE and SPEED_STEPS from types.ts

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -53,37 +53,6 @@ export type ExportStatus =
   | "done"
   | "error";
 
-export const SPEED_STEPS = [
-  0.25,
-  0.5,
-  0.75,
-  1,
-  1.25,
-  1.5,
-  2,
-  4,
-] as const;
-
-export const DEFAULT_RECIPE: EditRecipe = {
-  preset: "vertical-9-16",
-  customWidth: 1920,
-  customHeight: 1080,
-  framing: "fit",
-  trimStart: 0,
-  trimEnd: null,
-  rotate: 0,
-  keepAudio: true,
-  normalizeAudio: false,
-  speed: 1,
-  quality: 23,
-  format: "mp4",
-  stabilization: false,
-  brightness: 0,
-  contrast: 0,
-  saturation: 0,
-  soundOnCompletion: false,
-};
-
 export const MAX_FILE_SIZE =
   2 * 1024 * 1024 * 1024;
 


### PR DESCRIPTION
## What
Removed `DEFAULT_RECIPE` and `SPEED_STEPS` exports from `src/lib/types.ts`.

## Why
Both constants were defined in two places with conflicting values:

| | `types.ts` | `constants.ts` |
|---|---|---|
| `contrast` | 0 | 1 |
| `saturation` | 0 | 1 |

`contrast: 0` and `saturation: 0` are broken FFmpeg `eq` filter values — they produce a flat grey and greyscale image respectively. Any code importing from `types.ts` would silently get these broken defaults.

## How
Deleted both exports from `types.ts`. All existing consumers (`useVideoEditor.ts`, `AudioSpeedControl.tsx`) already import from `constants.ts`, so no import paths needed updating.

Closes #726 

Please add the appropriate labels for GSSoC so that I can get the points