### PR TITLE
fix: increase extractMetadata timeout from 500ms to 5s (#729)

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -15,8 +15,8 @@ export function extractMetadata(file: File): Promise<{ width: number; height: nu
     const video = document.createElement("video");
     const timeout = setTimeout(() => {
       URL.revokeObjectURL(url);
-      reject( new Error("Video metaData load timeout"))
-    }, 500);
+      reject( new Error("Video metaData load timeout — the file may be too large or the device too slow. Please try again.") );
+    }, 5000);
 
     video.preload = "metadata";
     video.onloadedmetadata = () => {


### PR DESCRIPTION
## What
Increased the `extractMetadata` timeout from 500ms to 5000ms and 
improved the timeout error message.

## Why
500ms is too aggressive for large files (>200MB) on mid/low-end devices 
or busy browser tabs. The browser can legitimately take a few seconds to 
parse metadata headers, causing valid files to be rejected with a silent 
Layer 4 error and no recovery path for the user.

5s was chosen over the issue's suggested 10–15s because `onloadedmetadata` 
fires as soon as headers are parsed — not after the full file loads — so 
anything beyond 5s is almost certainly a corrupt or unsupported file, not 
a slow device.

## Changes
- Timeout: `500` → `5000`
- Error: `"Video metaData load timeout"` → `"Video metadata load timeout — 
the file may be too large or the device too slow. Please try again."`

Closes #729

Please add the appropriate labels for GSSoC so I can get the points.