### PR TITLE
fix: prevent accidental navigation during video export

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -348,13 +348,13 @@ export function useVideoEditor() {
   useEffect(() => {
     const shouldWarn =
       status === "exporting" ||
-      status === "loading-engine" ||
-      status === "done";
+      status === "loading-engine";
 
     if (!shouldWarn) return;
 
     const handler = (e: BeforeUnloadEvent) => {
       e.preventDefault();
+      e.returnValue = "";
     };
 
     window.addEventListener("beforeunload", handler);


### PR DESCRIPTION
## Description

This PR fixes the issue where refreshing or closing the browser tab during an active video export would immediately cancel the export process without warning.

### Changes Made

* Updated the `beforeunload` event listener in `useVideoEditor.ts`
* Added `e.returnValue = ""` to ensure modern browsers trigger the native confirmation dialog
* Refined the `shouldWarn` condition to activate only during:

  * `loading-engine`
  * `exporting`
* Removed the `done` status from the warning condition so the event listener detaches correctly after a successful export

These changes improve export reliability and help prevent accidental interruption during long-running video exports.

---

## Related Issue

Closes #740 

---

## Type of Contribution

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] GSSoC contribution

---

## Participant Info

* GitHub username: @Ram-sah19
* Contribution level: Intermediate

---

## Screenshot
<img width="1912" height="912" alt="image" src="https://github.com/user-attachments/assets/50aa0011-e08f-48a3-960c-60f4f96453f4" />
<img width="1912" height="912" alt="image" src="https://github.com/user-attachments/assets/50aa0011-e08f-48a3-960c-60f4f96453f4" />


---

## Checklist

* [x] I have read the contribution guidelines
* [x] My changes follow the project structure
* [x] I have tested my changes in Chrome, Firefox, and Safari
* [x] `bun run lint` passes (no ESLint errors)
* [x] `bunx tsc --noEmit` passes (no TypeScript errors)
* [x] New interactive elements have `aria-label` / accessible names
* [x] No `console.log` statements left in
* [x] This PR is related to a valid issue
* [x] Screen recording attached above
