### PR TITLE
fix: prevent zero-length clip in TrimControl (#14)

### DIFF
--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -7,6 +7,8 @@ import { formatDuration } from "@/lib/utils";
 import { useAudioWaveform } from "@/hooks/useAudioWaveform";
 import WaveformCanvas from "@/components/WaveformCanvas";
 
+const MIN_CLIP_DURATION = 0.1;
+
 interface Props {
   recipe: EditRecipe;
   onChange: (patch: Partial<EditRecipe>) => void;
@@ -61,7 +63,7 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
       return;
     }
 
-    if (recipe.trimEnd !== null && n >= recipe.trimEnd) {
+    if (recipe.trimEnd !== null && n >= recipe.trimEnd - MIN_CLIP_DURATION) {
       setStart(true);
       setStartErrorMsg("Start time must be less than the end time.");
       return;
@@ -69,7 +71,6 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
 
     setStart(false);
     setStartErrorMsg("");
-
     onChange({ trimStart: n });
   };
 
@@ -81,8 +82,6 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
     }
 
     const n = parseFloat(val);
-
-    onChange({ trimEnd: n });
 
     if (isNaN(n)) {
       setEnd(true);
@@ -96,7 +95,7 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
       return;
     }
 
-    if (n <= recipe.trimStart) {
+    if (n <= recipe.trimStart + MIN_CLIP_DURATION) {
       setEnd(true);
       setEndErrorMsg("End time must be greater than start time.");
       return;
@@ -112,6 +111,7 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
 
     setEnd(false);
     setEndErrorMsg("");
+    onChange({ trimEnd: n });
   };
 
   const inputClass =
@@ -207,6 +207,12 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
         <p className="text-sm text-[var(--muted)] font-heading mt-1">
           Clip: {formatDuration(clipLength)} of {formatDuration(duration)}
         </p>
+      )}
+      {recipe.trimEnd !== null &&
+        recipe.trimEnd - recipe.trimStart < MIN_CLIP_DURATION && (
+          <p className="text-[10px] text-red-500 font-heading">
+            Clip must be at least 0.1 seconds long.
+          </p>
       )}
     </div>
   );


### PR DESCRIPTION
## Description
Fixes a validation bug in `TrimControl` where `trimStart` could be set equal to `trimEnd`, producing a zero-length video passed to FFmpeg. The fix enforces a minimum gap (`MIN_CLIP_DURATION = 0.1s`) between the start and end values, replacing the previous `>=` / `<=` equality checks with a gap-aware comparison.

## Related Issue
Closes #14

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- **GitHub username:**wei123-web
- **Contribution level:** Beginner

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [ ] Screen recording attached above (required for UI/feature/design changes)