### PR TITLE
fix : fixed the inverted slider

### DIFF
--- a/src/components/ExportSettings.tsx
+++ b/src/components/ExportSettings.tsx
@@ -74,10 +74,10 @@ export default function ExportSettings({
           min={18}
           max={30}
           step={1}
-          value={recipe.quality}
+          value={48 - recipe.quality}
           onChange={(e) =>
             onChange({
-              quality: Number(
+              quality: 48 - Number(
                 e.target.value
               ),
             })
@@ -94,11 +94,11 @@ export default function ExportSettings({
         >
           <div className="flex justify-between">
             <span className="text-sm text-[var(--muted)]">
-              Best quality
+              Smallest file
             </span>
 
             <span className="text-sm text-[var(--muted)]">
-              Smallest file
+              Best quality
             </span>
           </div>
 


### PR DESCRIPTION
## Description

Fixed the inverted export quality slider logic in the export settings UI.

### Changes made:

* Corrected the slider behavior so that moving the slider toward the right now properly represents **High quality** output.
* Moving the slider toward the left now correctly represents **Small file / lower quality** output.
* Fixed incorrect label mapping between slider position, CRF values, and estimated file size.

### Correct behavior after fix:

* **Right side** → High quality, lower CRF, larger file size
* **Left side** → Smaller file, higher CRF, smaller file size

Also added before/after screenshots to demonstrate the fix.

## Related Issue

Closes #741 

## Type of Contribution

* [x] Bug fix
* [x] GSSoC contribution

## Participant Info

* GitHub username: pratyuxxhh
* Contribution level: Intermediate

## Screenshots 

Before 
<img width="584" height="381" alt="image" src="https://github.com/user-attachments/assets/5c0b35a9-e37d-47eb-a9a1-2f58e389a6ce" />


After
<img width="650" height="306" alt="image" src="https://github.com/user-attachments/assets/927fb912-8184-4d31-a883-6f9c1eb0af84" />


## Checklist

* [x] I have read the contribution guidelines
* [x] My changes follow the project structure
* [x] I have tested my changes in Chrome, Firefox, and Safari
* [x] `bun run lint` passes (no ESLint errors)
* [x] `bunx tsc --noEmit` passes (no TypeScript errors)
* [x] New interactive elements have `aria-label` / accessible names
* [x] No `console.log` statements left in
* [x] This PR is related to a valid issue
* [x] **Screen recording attached above** (required for UI/feature/design changes)
