### PR TITLE
feat: implement Content Security Policy headers (#139)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self' https://cdn.jsdelivr.net; worker-src blob:; img-src 'self' blob: data:; media-src blob:;" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description
Adds Content Security Policy (CSP) headers via vercel.json to prevent XSS attacks and unauthorized resource loading.

## Changes Made
- Added vercel.json with CSP headers
- Allows FFmpeg WASM via `wasm-unsafe-eval`
- Allows blob URLs for video preview and download
- Allows cdn.jsdelivr.net for external resources

## Related Issue
Closes #139

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: wei123-web
- Contribution level: Beginner

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] This PR is related to a valid issue
- [x] No console.log statements left in