### PR TITLE
fix: remove duplicate file format text in upload area

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,5 +1,8 @@
 import Link from "next/link";
-
+export const metadata = {
+  title: "Contact | Reframe",
+  description: "Get in touch with the Reframe team.",
+};
 export default function ContactPage() {
   return (
     <main className="min-h-screen bg-black text-white p-8">

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,5 +1,8 @@
 import Link from "next/link";
-
+export const metadata = {
+  title: "Privacy Policy | Reframe",
+  description: "Privacy policy for Reframe — your videos never leave your device.",
+};
 export default function PrivacyPage() {
   return (
     <>

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -124,7 +124,7 @@ export default function VideoEditor() {
               {!file && (
               <div className="text-center text-[var(--muted)] py-6">
                 <p>Upload a video to get started</p>
-                <p className="text-sm">Supports MP4, MOV, WebM and more</p>
+              
               </div>
               )}
 


### PR DESCRIPTION

Fixes #769
Fixes #770

## What this PR does
Removes the duplicate file format text in the upload/drop zone area.

## Before
- Line 1: `MP4 / MOV / AVI / WebM` (in FileUpload component)
- Line 2: `Supports MP4, MOV, WebM and more` (duplicate!)

## After
- Only one line showing file format info — clean and consistent!

I am the original author of issue #769. I found this bug myself 
by testing the live site and implemented the fix.
Requesting review from @magic-peach