### PR TITLE
feat: add export history panel with re-download support

### DIFF
--- a/src/components/ExportHistory.tsx
+++ b/src/components/ExportHistory.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState } from "react";
+
+interface ExportHistoryItem {
+  id: string;
+  blobUrl: string;
+  filename: string;
+  format: string;
+  size: number;
+  width: number;
+  height: number;
+  exportedAt: number;
+}
+
+interface ExportHistoryProps {
+  history: ExportHistoryItem[];
+  onClear: () => void;
+}
+
+function formatFileSize(bytes: number) {
+  if (bytes < 1024) return `${bytes} B`;
+
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export default function ExportHistory({
+  history,
+  onClear,
+}: ExportHistoryProps) {
+  const [isOpen, setIsOpen] = useState(true);
+
+  if (!history.length) return null;
+
+  const handleDownload = (item: ExportHistoryItem) => {
+    const link = document.createElement("a");
+
+    link.href = item.blobUrl;
+    link.download = item.filename;
+
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  return (
+    <div className="mt-6 bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 animate-fade-in">
+      <div className="flex items-center justify-between gap-4">
+        <button
+          type="button"
+          onClick={() => setIsOpen((prev) => !prev)}
+          className="flex items-center gap-2 text-left"
+        >
+          <h3 className="text-sm font-heading font-bold uppercase tracking-widest text-[var(--muted)]">
+            Recent Exports
+          </h3>
+
+          <span className="text-xs text-[var(--muted)]">
+            {isOpen ? "▲" : "▼"}
+          </span>
+        </button>
+
+        <button
+          type="button"
+          onClick={onClear}
+          className="
+            px-3 py-1.5
+            rounded-lg
+            border border-[var(--border)]
+            bg-[var(--surface)]
+            text-xs font-heading font-bold uppercase tracking-widest
+            text-[var(--muted)]
+            hover:border-film-500
+            hover:text-film-500
+            transition-all
+          "
+        >
+          Clear History
+        </button>
+      </div>
+
+      <p className="mt-3 text-xs text-[var(--muted)] opacity-70">
+        History is cleared when you close or refresh the page.
+      </p>
+
+      {isOpen && (
+        <div className="mt-4 space-y-3">
+          {history.map((item) => (
+            <div
+              key={item.id}
+              className="
+                flex flex-col gap-4
+                rounded-xl
+                border border-[var(--border)]
+                bg-[var(--surface)]
+                p-4
+                md:flex-row
+                md:items-center
+                md:justify-between
+              "
+            >
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-semibold text-[var(--text)]">
+                  {item.filename}
+                </p>
+
+                <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-[var(--muted)]">
+                  <span>{item.format.toUpperCase()}</span>
+
+                  <span>•</span>
+
+                  <span>
+                    {item.width}×{item.height}
+                  </span>
+
+                  <span>•</span>
+
+                  <span>{formatFileSize(item.size)}</span>
+                </div>
+
+                <p className="mt-2 text-xs text-[var(--muted)] opacity-70">
+                  Exported{" "}
+                  {new Date(item.exportedAt).toLocaleString()}
+                </p>
+              </div>
+
+              <button
+                type="button"
+                onClick={() => handleDownload(item)}
+                className="
+                  px-4 py-2
+                  rounded-lg
+                  bg-film-600
+                  hover:bg-film-700
+                  text-white
+                  text-sm font-semibold
+                  transition-all
+                  active:scale-[0.98]
+                  whitespace-nowrap
+                "
+              >
+                Download
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -743,7 +743,11 @@ return () => {
             )}
 
             {status === "done" && result && (
-              <div role="status" className="animate-fade-in" ref={downloadRef}>
+              <div
+                role="status"
+                className="animate-fade-in"
+                ref={downloadRef}
+              >
                 <DownloadResult
                   result={result}
                   onReset={reset}

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -16,16 +16,25 @@ import FormatSelector from "./FormatSelector";
 import ExportSettings from "./ExportSettings";
 import ExportOverlay from "./ExportOverlay";
 import DownloadResult from "./DownloadResult";
-import ImageOverlay from "./ImageOverlay"
+import ImageOverlay from "./ImageOverlay";
 import { getPresetById } from "@/lib/presets";
 
 import { cn } from "@/lib/utils";
 import {
-  Layers, Crop, Scissors, RotateCw, Volume2, Type,
-  SlidersHorizontal, Zap, AlertTriangle, Github, Copy
+  Layers,
+  Crop,
+  Scissors,
+  RotateCw,
+  Volume2,
+  Type,
+  SlidersHorizontal,
+  Zap,
+  AlertTriangle,
+  Github,
+  Copy,
 } from "lucide-react";
 import OnboardingTour from "./OnboardingTour";
-import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import ExportHistory from "@/components/ExportHistory";
 
 interface SectionProps {
   icon: React.ReactNode;
@@ -52,7 +61,6 @@ function Section({ icon, title, children, delay = 0 }: SectionProps) {
   );
 }
 
-/** Accordion section with collapsible content. */
 function AccordionSection({
   id,
   icon,
@@ -81,7 +89,9 @@ function AccordionSection({
       >
         <div className="flex items-center gap-2">
           <span className="text-film-500 opacity-80">{icon}</span>
-          <span className="text-sm font-heading font-bold uppercase tracking-widest text-[var(--muted)]">{title}</span>
+          <span className="text-sm font-heading font-bold uppercase tracking-widest text-[var(--muted)]">
+            {title}
+          </span>
         </div>
         <svg
           aria-hidden="true"
@@ -89,9 +99,18 @@ function AccordionSection({
           height="12"
           viewBox="0 0 12 12"
           fill="none"
-          className={cn("text-[var(--muted)] transition-transform duration-200", isOpen && "rotate-180")}
+          className={cn(
+            "text-[var(--muted)] transition-transform duration-200",
+            isOpen && "rotate-180",
+          )}
         >
-          <path d="M2 4l4 4 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          <path
+            d="M2 4l4 4 4-4"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
         </svg>
       </button>
 
@@ -99,7 +118,7 @@ function AccordionSection({
         id={`${id}-panel`}
         className={cn(
           "transition-all duration-200",
-          isOpen ? "block" : "hidden"
+          isOpen ? "block" : "hidden",
         )}
       >
         <div className="px-3 pt-3 pb-0">{children}</div>
@@ -108,7 +127,6 @@ function AccordionSection({
   );
 }
 
-/** Inline keyboard hint badge. */
 function Kbd({ children }: { children: React.ReactNode }) {
   return (
     <kbd className="inline-flex items-center justify-center min-w-[1.5rem] px-1.5 py-0.5 rounded border border-[var(--border)] bg-[var(--bg)] text-[10px] font-mono text-[var(--muted)] leading-none">
@@ -117,42 +135,37 @@ function Kbd({ children }: { children: React.ReactNode }) {
   );
 }
 
-/** Collapsible panel that lists all keyboard shortcuts. */
 function KeyboardShortcutsPanel() {
   const [open, setOpen] = useState(false);
 
   const shortcuts: { keys: React.ReactNode[]; label: string }[] = [
-  {
-    keys: [
-      <Kbd key="ctrl">Ctrl</Kbd>,
-      <span key="plus1" className="text-[var(--muted)] text-xs">+</span>,
-      <Kbd key="shift">Shift</Kbd>,
-      <span key="plus2" className="text-[var(--muted)] text-xs">+</span>,
-      <Kbd key="e">E</Kbd>
-    ],
-    label: "Export video",
-  },
-  {
-    keys: [<Kbd key="m">M</Kbd>],
-    label: "Toggle audio mute",
-  },
-  {
-    keys: [<Kbd key="r">R</Kbd>],
-    label: "Reset all settings",
-  },
-  {
-    keys: [<Kbd key="esc">Esc</Kbd>],
-    label: "Cancel export",
-  },
-  {
-    keys: [<Kbd key="1">1</Kbd>, <span key="dash" className="text-[var(--muted)] text-xs">–</span>, <Kbd key="9">9</Kbd>],
-    label: "Switch preset by index",
-  },
-  {
-    keys: [<Kbd key="question">?</Kbd>],
-    label: "Toggle this panel",
-  },
-];
+    {
+      keys: [<Kbd key="m">M</Kbd>],
+      label: "Toggle audio mute",
+    },
+    {
+      keys: [
+        <Kbd key="ctrl">Ctrl</Kbd>,
+        <span key="plus" className="text-[var(--muted)] text-xs">
+          +
+        </span>,
+        <Kbd key="enter">↵</Kbd>,
+      ],
+      label: "Export video",
+    },
+    {
+      keys: [<Kbd key="r">R</Kbd>],
+      label: "Reset all settings",
+    },
+    {
+      keys: [<Kbd key="esc">Esc</Kbd>],
+      label: "Cancel export",
+    },
+    {
+      keys: [<Kbd key="question">?</Kbd>],
+      label: "Toggle shortcuts panel",
+    },
+  ];
 
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] animate-fade-in overflow-hidden">
@@ -173,9 +186,18 @@ function KeyboardShortcutsPanel() {
           height="12"
           viewBox="0 0 12 12"
           fill="none"
-          className={cn("text-[var(--muted)] transition-transform duration-200", open && "rotate-180")}
+          className={cn(
+            "text-[var(--muted)] transition-transform duration-200",
+            open && "rotate-180",
+          )}
         >
-          <path d="M2 4l4 4 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          <path
+            d="M2 4l4 4 4-4"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
         </svg>
       </button>
 
@@ -185,7 +207,10 @@ function KeyboardShortcutsPanel() {
           className="px-4 pb-3 space-y-2 border-t border-[var(--border)]"
         >
           {shortcuts.map(({ keys, label }) => (
-            <li key={label} className="flex items-center justify-between gap-3 pt-2">
+            <li
+              key={label}
+              className="flex items-center justify-between gap-3 pt-2"
+            >
               <span className="text-xs text-[var(--muted)]">{label}</span>
               <span className="flex items-center gap-1 shrink-0">{keys}</span>
             </li>
@@ -198,30 +223,37 @@ function KeyboardShortcutsPanel() {
 
 export default function VideoEditor() {
   const {
-    file, duration, recipe, status, progress,
-    result, error, exportStartedAt, updateRecipe,
-    handleFileSelect, fileError, handleExport, cancelExport, reset, resetSettings,
+    file,
+    duration,
+    currentTime,
+    recipe,
+    status,
+    progress,
+    result,
+    exportStartedAt,
+    exportHistory,
+    clearExportHistory,
+    error,
+    updateRecipe,
+    handleFileSelect,
+    fileError,
+    handleExport,
+    cancelExport,
+    reset,
+    resetSettings,
     videoRef,
     seekTo,
-    overlayFile, setOverlayFile,
-    overlayPosition, setOverlayPosition,
-    overlaySize, setOverlaySize,
-    overlayOpacity, setOverlayOpacity,
+    overlayFile,
+    setOverlayFile,
+    overlayPosition,
+    setOverlayPosition,
+    overlaySize,
+    setOverlaySize,
+    overlayOpacity,
+    setOverlayOpacity,
     recommendedPreset,
-    currentTime,
     toggleSound,
   } = useVideoEditor();
-
-  useKeyboardShortcuts({
-    file,
-    recipe,
-    resetSettings,
-    updateRecipe,
-    handleExport,
-    status,
-    cancelExport,
-    onToggleShortcutsModal: () => {},
-  });
 
   const [copied, setCopied] = useState(false);
   const [shareCopied, setShareCopied] = useState(false);
@@ -279,9 +311,6 @@ export default function VideoEditor() {
     setOpenSections((prev) => ({ ...prev, [key]: !prev[key] }));
   const downloadRef = useRef<HTMLDivElement>(null);
 
-  /**
-   * Updates a text overlay property and syncs with recipe.
-   */
   const handleUpdateTextOverlay = (id: string, updates: Partial<TextOverlay>) => {
     const updatedOverlays = (recipe.textOverlays || []).map((overlay) =>
       overlay.id === id ? { ...overlay, ...updates } : overlay
@@ -302,17 +331,20 @@ export default function VideoEditor() {
   };
 
   useEffect(() => {
-    if (status === "done" && downloadRef.current) {
-      
-      const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-      downloadRef.current.scrollIntoView({
-        behavior: prefersReducedMotion ? "instant" : "smooth",
-        block: "center",
-      });
-    }
+  if (status === "done" && downloadRef.current) {
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+
+    downloadRef.current.scrollIntoView({
+      behavior: prefersReducedMotion ? "instant" : "smooth",
+      block: "center",
+    });
+  }
   }, [status]);
+
   useEffect(() => {
-const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+  const handleBeforeUnload = (e: BeforeUnloadEvent) => {
   if (file) {
     e.preventDefault();
     e.returnValue = "";
@@ -327,7 +359,8 @@ return () => {
 }, [file]);
 
   const isProcessing = status === "loading-engine" || status === "exporting";
-  const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
+  const isMac =
+    typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
 
   const intervalSeconds = useMemo(() => {
     if (duration <= 30) return 2;
@@ -338,21 +371,28 @@ return () => {
 
   const videoSrc = useMemo(
     () => (file ? URL.createObjectURL(file) : null),
-    [file]
+    [file],
   );
 
   const exportSummary = useMemo(() => {
     const preset = getPresetById(recipe.preset);
-    const width = recipe.preset === "custom" ? recipe.customWidth : (preset?.width ?? recipe.customWidth);
-    const height = recipe.preset === "custom" ? recipe.customHeight : (preset?.height ?? recipe.customHeight);
+    const width =
+      recipe.preset === "custom"
+        ? recipe.customWidth
+        : (preset?.width ?? recipe.customWidth);
+    const height =
+      recipe.preset === "custom"
+        ? recipe.customHeight
+        : (preset?.height ?? recipe.customHeight);
 
     const framingLabel = recipe.framing === "fit" ? "Fit" : "Fill";
     const speedLabel = `${recipe.speed}× speed`;
-    const qualityLabel = recipe.quality <= 21
-      ? "High"
-      : recipe.quality <= 25
-      ? "Balanced"
-      : "Small file";
+    const qualityLabel =
+      recipe.quality <= 21
+        ? "High"
+        : recipe.quality <= 25
+          ? "Balanced"
+          : "Small file";
 
     return `Exporting to ${width}×${height} ${recipe.format.toUpperCase()} • ${framingLabel} • ${speedLabel} • Quality: ${qualityLabel}`;
   }, [recipe]);
@@ -381,51 +421,55 @@ return () => {
 
       <div className="max-w-6xl mx-auto px-4 py-8 pb-6 flex-1 w-full">
         <header className="mb-10 flex flex-col items-center justify-center gap-4 animate-fade-in">
-        <div
-          className="inline-block rounded-xl border border-[var(--border)] bg-[var(--surface)] shadow-sm border-l-4 border-l-film-600 mx-auto w-fit min-w-min"
-          style={{ padding: 'clamp(0.75rem,3vw,1.25rem) clamp(1rem,5vw,2rem)', boxSizing: 'border-box' }}
-          aria-label="Reframe — video editor"
-        >
-        <h1
-          className="font-display leading-none tracking-widest2 text-[var(--text)] break-words text-center transition-all"
-          style={{ fontSize: 'clamp(2rem,10vw,4rem)', viewTransitionName: 'reframe-text' }}
-        >
-          REFRAME
-        </h1>
-        <p
-          className="font-heading text-[var(--muted)] uppercase tracking-widest text-center"
-          style={{
-            fontSize: 'clamp(0.7rem,2vw,0.875rem)',
-            marginTop: 'clamp(0.25rem,1vw,0.5rem)',
-          }}
-        >
-          Your video, any format
-        </p>
-    <div
-      className="flex md:hidden items-center justify-center gap-2 font-heading font-semibold uppercase tracking-widest text-[var(--muted)] border-t border-[var(--border)]"
-      style={{
-        fontSize: 'clamp(0.6rem,1.5vw,0.75rem)',
-        marginTop: 'clamp(0.5rem,2vw,0.75rem)',
-        paddingTop: 'clamp(0.5rem,2vw,0.75rem)',
-      }}
-    >
-      <span className="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-[var(--accent)] inline-block animate-pulse" />
-      No login. No ads. 100% private.
-    </div>
-  </div>  
-  <div
-    className="flex flex-wrap justify-center text-center items-center gap-2 text-sm font-heading font-semibold uppercase tracking-widest text-[var(--muted)] pb-1"
-    style={{ justifyContent: 'center', textAlign: 'center', margin: '0', width: 'auto' }}
-  >
-    <span className="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-[var(--accent)] inline-block animate-pulse" />
-    No login. No ads. 100% private - your video never leaves your device.
-  </div>
-    </header>
-        <div className="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-5">
+          <div
+            className="inline-block rounded-xl border border-[var(--border)] bg-[var(--surface)] shadow-sm border-l-4 border-l-film-600 mx-auto w-fit min-w-min"
+            style={{ padding: "clamp(0.75rem,3vw,1.25rem) clamp(1rem,5vw,2rem)", boxSizing: "border-box" }}
+            aria-label="Reframe — video editor"
+          >
+            <h1
+              className="font-display leading-none tracking-widest2 text-[var(--text)] break-words text-center transition-all"
+              style={{ fontSize: "clamp(2rem,10vw,4rem)", viewTransitionName: "reframe-text" }}
+            >
+              REFRAME
+            </h1>
+            <p
+              className="font-heading text-[var(--muted)] uppercase tracking-widest text-center"
+              style={{
+                fontSize: "clamp(0.7rem,2vw,0.875rem)",
+                marginTop: "clamp(0.25rem,1vw,0.5rem)",
+              }}
+            >
+              Your video, any format
+            </p>
+            <div
+              className="flex md:hidden items-center justify-center gap-2 font-heading font-semibold uppercase tracking-widest text-[var(--muted)] border-t border-[var(--border)]"
+              style={{
+                fontSize: "clamp(0.6rem,1.5vw,0.75rem)",
+                marginTop: "clamp(0.5rem,2vw,0.75rem)",
+                paddingTop: "clamp(0.5rem,2vw,0.75rem)",
+              }}
+            >
+              <span className="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-[var(--accent)] inline-block animate-pulse" />
+              No login. No ads. 100% private.
+            </div>
+          </div>
+          <div
+            className="flex flex-wrap justify-center text-center items-center gap-2 text-sm font-heading font-semibold uppercase tracking-widest text-[var(--muted)] pb-1"
+          >
+            <span className="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-[var(--accent)] inline-block animate-pulse" />
+            No login. No ads. 100% private - your video never leaves your device.
+          </div>
+        </header>
 
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-5">
           <div className="space-y-4 min-w-0">
             <div className="bg-[var(--surface)] rounded-xl p-3 border border-[var(--border)] animate-fade-in">
-              <FileUpload onFileSelect={handleFileSelect} currentFile={file} fileError={fileError} duration={duration} />
+              <FileUpload
+                onFileSelect={handleFileSelect}
+                currentFile={file}
+                fileError={fileError}
+                duration={duration}
+              />
 
               {!file && (
                 <div className="text-center text-[var(--muted)] py-6">
@@ -465,11 +509,14 @@ return () => {
                 ⚠️ Large file - processing may take several minutes
               </p>
             )}
+
             {file && (
-              <div className={cn(
-                "grid grid-cols-1 gap-4",
-                isProcessing && "pointer-events-none opacity-50"
-              )}>
+              <div
+                className={cn(
+                  "grid grid-cols-1 gap-4",
+                  isProcessing && "pointer-events-none opacity-50",
+                )}
+              >
                 <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6">
                   <AccordionSection
                     id="trim"
@@ -514,6 +561,7 @@ return () => {
                     />
                   </AccordionSection>
                 </div>
+
                 <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6">
                   <AccordionSection
                     id="audio"
@@ -525,13 +573,13 @@ return () => {
                   >
                     <AudioSpeedControl recipe={recipe} onChange={updateRecipe} />
                   </AccordionSection>
+
                   <Section
                     icon={<SlidersHorizontal size={12} />}
                     title="Adjustments"
                     delay={175}
                   >
                     <div className="space-y-5">
-                      {/* Brightness */}
                       <div className="space-y-2">
                         <div className="flex items-center justify-between text-xs">
                           <label htmlFor="brightness-slider">Brightness</label>
@@ -551,12 +599,14 @@ return () => {
                           max="1"
                           step="0.1"
                           value={recipe.brightness}
-                          onChange={(e) => updateRecipe({ brightness: Number(e.target.value) })}
+                          onChange={(e) =>
+                            updateRecipe({ brightness: Number(e.target.value) })
+                          }
                           aria-label="Adjust brightness"
                           className="w-full accent-film-600"
                         />
                       </div>
-                      {/* Contrast */}
+
                       <div className="space-y-2">
                         <div className="flex items-center justify-between text-xs">
                           <label htmlFor="contrast-slider">Contrast</label>
@@ -576,12 +626,14 @@ return () => {
                           max="2"
                           step="0.1"
                           value={recipe.contrast}
-                          onChange={(e) => updateRecipe({ contrast: Number(e.target.value) })}
+                          onChange={(e) =>
+                            updateRecipe({ contrast: Number(e.target.value) })
+                          }
                           aria-label="Adjust contrast"
                           className="w-full accent-film-600"
                         />
                       </div>
-                      {/* Saturation */}
+
                       <div className="space-y-2">
                         <div className="flex items-center justify-between text-xs">
                           <label htmlFor="saturation-slider">Saturation</label>
@@ -601,16 +653,24 @@ return () => {
                           max="3"
                           step="0.1"
                           value={recipe.saturation}
-                          onChange={(e) => updateRecipe({ saturation: Number(e.target.value) })}
+                          onChange={(e) =>
+                            updateRecipe({ saturation: Number(e.target.value) })
+                          }
                           aria-label="Adjust saturation"
                           className="w-full accent-film-600"
                         />
                       </div>
                     </div>
                   </Section>
-                  <Section icon={<SlidersHorizontal size={12} />} title="Output format" delay={190}>
+
+                  <Section
+                    icon={<SlidersHorizontal size={12} />}
+                    title="Output format"
+                    delay={190}
+                  >
                     <FormatSelector recipe={recipe} onChange={updateRecipe} />
                   </Section>
+
                   <AccordionSection
                     id="export"
                     icon={<SlidersHorizontal size={12} />}
@@ -619,8 +679,13 @@ return () => {
                     onToggle={() => toggleSection("export")}
                     delay={200}
                   >
-                    <ExportSettings recipe={recipe} duration={duration} onChange={updateRecipe} />
+                    <ExportSettings
+                      recipe={recipe}
+                      duration={duration}
+                      onChange={updateRecipe}
+                    />
                   </AccordionSection>
+
                   <Section icon={<Layers size={12} />} title="Image overlay" delay={120}>
                     <ImageOverlay
                       overlayFile={overlayFile}
@@ -642,7 +707,10 @@ return () => {
                 role="status"
                 className="flex items-start gap-3 p-4 bg-film-50 border border-film-200 rounded-xl text-film-800 text-sm animate-fade-in"
               >
-                <AlertTriangle size={16} className="shrink-0 mt-0.5 text-film-500" />
+                <AlertTriangle
+                  size={16}
+                  className="shrink-0 mt-0.5 text-film-500"
+                />
                 <div className="flex-1">
                   <p className="font-heading font-bold text-sm">Error</p>
                   <p className="text-film-600 text-sm mt-1">{error}</p>
@@ -676,15 +744,27 @@ return () => {
 
             {status === "done" && result && (
               <div role="status" className="animate-fade-in" ref={downloadRef}>
-                <DownloadResult result={result} onReset={reset} soundOnCompletion={recipe.soundOnCompletion} onToggleSound={toggleSound} />
+                <DownloadResult
+                  result={result}
+                  onReset={reset}
+                  soundOnCompletion={recipe.soundOnCompletion}
+                  onToggleSound={toggleSound}
+                />
               </div>
             )}
+
+            <ExportHistory
+              history={exportHistory}
+              onClear={clearExportHistory}
+            />
           </div>
 
-          <div className={cn(
-            "space-y-5 transition-opacity duration-300 sticky top-8 self-start",
-            (isProcessing || !file) && "pointer-events-none opacity-50"
-          )}>
+          <div
+            className={cn(
+              "space-y-5 transition-opacity duration-300 sticky top-8 self-start",
+              (isProcessing || !file) && "pointer-events-none opacity-50",
+            )}
+          >
             {!file && (
               <div className="bg-[var(--surface)] border border-[var(--border)] rounded-xl p-4 animate-fade-in">
                 <p className="text-[10px] font-heading font-bold text-film-600 uppercase tracking-widest">
@@ -695,7 +775,11 @@ return () => {
                 </p>
               </div>
             )}
-            <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6 animate-fade-in" style={{ animationDelay: "50ms" }}>
+
+            <div
+              className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6 animate-fade-in"
+              style={{ animationDelay: "50ms" }}
+            >
               <AccordionSection
                 id="resize"
                 icon={<Layers size={12} />}
@@ -707,7 +791,10 @@ return () => {
                 {recommendedPreset && (
                   <div className="mb-4 rounded-2xl border border-film-200 bg-film-50 p-3 text-sm text-film-700">
                     <p>
-                      We detected a {recommendedPreset.label.replace(/\s/g, "")} video → Recommended: {(recommendedPreset.platform.split("·")[0] ?? "").trim()} ({recommendedPreset.label.replace(/\s/g, "")})
+                      We detected a {recommendedPreset.label.replace(/\s/g, "")}{" "}
+                      video → Recommended:{" "}
+                      {(recommendedPreset.platform.split("·")[0] ?? "").trim()}{" "}
+                      ({recommendedPreset.label.replace(/\s/g, "")})
                     </p>
                   </div>
                 )}
@@ -748,19 +835,22 @@ return () => {
               id="export-button"
               type="button"
               onClick={handleExport}
-                disabled={!file || isProcessing}
-                aria-label='Export video'
-                aria-disabled={!file || isProcessing ? "true" : undefined}
-                title={!file ? "Upload a video to enable export" : undefined}
+              disabled={!file || isProcessing}
+              aria-label="Export video"
+              aria-disabled={!file || isProcessing ? "true" : undefined}
+              title={!file ? "Upload a video to enable export" : undefined}
               className={cn(
                 "w-full flex items-center justify-center gap-3 py-5 min-h-[44px] rounded-xl",
                 "font-display text-2xl tracking-widest transition-all duration-200",
                 file && !isProcessing
                   ? "bg-[var(--accent)] hover:bg-[var(--accent-hover)] hover:scale-[1.02] text-white shadow-[var(--shadow)] active:scale-[0.98] cursor-pointer"
-                  : "bg-[var(--border)] text-[var(--muted)] cursor-not-allowed"
+                  : "bg-[var(--border)] text-[var(--muted)] cursor-not-allowed",
               )}
             >
-             <Zap size={20} className={cn(file && !isProcessing && "animate-pulse")} />
+              <Zap
+                size={20}
+                className={cn(file && !isProcessing && "animate-pulse")}
+              />
               {isProcessing ? "PROCESSING" : "EXPORT"}
             </button>
 

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -1,10 +1,29 @@
 "use client";
 
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
-import { EditRecipe, ExportResult, ExportStatus, MAX_FILE_SIZE, OverlayPosition, isValidRecipe, TimelineTrack, MultiTrackEditorState } from "@/lib/types";
+
+import {
+  EditRecipe,
+  ExportResult,
+  ExportStatus,
+  MAX_FILE_SIZE,
+  OverlayPosition,
+  isValidRecipe,
+  TimelineTrack,
+  MultiTrackEditorState,
+} from "@/lib/types";
+
 import { DEFAULT_RECIPE, SPEED_STEPS } from "@/lib/constants";
+
 import { getPresetById } from "@/lib/presets";
-import { loadFFmpeg, exportVideo, terminateFFmpeg, FFmpegLoadError } from "@/lib/ffmpeg";
+
+import {
+  loadFFmpeg,
+  exportVideo,
+  terminateFFmpeg,
+  FFmpegLoadError,
+} from "@/lib/ffmpeg";
+
 import { suggestPreset } from "@/lib/presetSuggestion";
 import { validateDimensions, getDownscaledDimensions } from "@/utils/video-validation";
 import {
@@ -16,33 +35,59 @@ import {
   validateMultiTrackState,
 } from "@/lib/timeline";
 
-const DEFAULT_TITLE = "Reframe — Resize, trim, and export videos in your browser";
-  const STORAGE_KEY = "reframe:recipe";
+interface ExportHistoryItem extends ExportResult {
+  id: string;
+  filename: string;
+  exportedAt: number;
+}
 
-export function extractMetadata(file: File): Promise<{ width: number; height: number; duration: number }> {
+const DEFAULT_TITLE =
+  "Reframe — Resize, trim, and export videos in your browser";
+
+const STORAGE_KEY = "reframe:recipe";
+
+export function extractMetadata(file: File): Promise<{
+  width: number;
+  height: number;
+  duration: number;
+}> {
   return new Promise((resolve, reject) => {
     const url = URL.createObjectURL(file);
+
     const video = document.createElement("video");
+
     const timeout = setTimeout(() => {
       URL.revokeObjectURL(url);
-      reject( new Error("Video metaData load timeout — the file may be too large or the device too slow. Please try again.") );
+
+      reject(
+        new Error(
+          "Video metaData load timeout — the file may be too large or the device too slow. Please try again.",
+        ),
+      );
     }, 5000);
 
     video.preload = "metadata";
+
     video.onloadedmetadata = () => {
-      clearTimeout(timeout)
+      clearTimeout(timeout);
+
       resolve({
         width: video.videoWidth,
         height: video.videoHeight,
         duration: isFinite(video.duration) ? video.duration : 0,
       });
+
       URL.revokeObjectURL(url);
     };
+
     video.onerror = () => {
-      clearTimeout(timeout)
+      clearTimeout(timeout);
+
       URL.revokeObjectURL(url);
+
       reject(new Error("Failed to load video metadata"));
     };
+
     video.src = url;
   });
 }
@@ -50,60 +95,88 @@ export function extractMetadata(file: File): Promise<{ width: number; height: nu
 function verifyMagicBytes(file: File): Promise<boolean> {
   return new Promise((resolve) => {
     const reader = new FileReader();
+
     reader.onloadend = (e) => {
       if (!e.target?.result) {
         resolve(false);
         return;
       }
+
       const arr = new Uint8Array(e.target.result as ArrayBuffer);
-      const hex = Array.from(arr).map(b => b.toString(16).padStart(2, "0")).join("").toUpperCase();
+
+      const hex = Array.from(arr)
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("")
+        .toUpperCase();
+
       const ascii = String.fromCharCode(...arr);
 
       // WebM / MKV
-      if (hex.startsWith("1A45DFA3")) resolve(true);
+      if (hex.startsWith("1A45DFA3")) {
+        resolve(true);
+      }
+
       // AVI
-      else if (hex.startsWith("52494646")) resolve(true);
-      // MP4 / MOV (checks for 'ftyp' in first 12 bytes)
-      else if (ascii.substring(0, 12).includes("ftyp")) resolve(true);
-      else resolve(false);
+      else if (hex.startsWith("52494646")) {
+        resolve(true);
+      }
+
+      // MP4 / MOV
+      else if (ascii.substring(0, 12).includes("ftyp")) {
+        resolve(true);
+      } else {
+        resolve(false);
+      }
     };
+
     reader.onerror = () => resolve(false);
+
     reader.readAsArrayBuffer(file.slice(0, 12));
   });
 }
 
-function validateRecipe(recipe: EditRecipe, duration: number ): string | null {
+function validateRecipe(recipe: EditRecipe, duration: number): string | null {
   const validations: Array<[boolean, string]> = [
-    [
-      recipe.trimStart < 0,
-      "Trim start time cannot be less than 0 seconds.",
-    ],
+    [recipe.trimStart < 0, "Trim start time cannot be less than 0 seconds."],
+
     [
       recipe.trimEnd !== null && duration > 0 && recipe.trimEnd > duration,
       `Trim end time cannot exceed the video duration (${Math.floor(duration)}s).`,
     ],
+
     [
-      recipe.trimEnd !== null 
-        ? recipe.trimStart >= recipe.trimEnd 
-        : (duration > 0 && recipe.trimStart >= duration),
+      recipe.trimEnd !== null
+        ? recipe.trimStart >= recipe.trimEnd
+        : duration > 0 && recipe.trimStart >= duration,
       "Trim start time must be earlier than the end time.",
     ],
+
     [
-      recipe.preset === "custom" && (Number.isNaN(recipe.customWidth) || recipe.customWidth < 16 || recipe.customWidth > 7680),
+      recipe.preset === "custom" &&
+        (Number.isNaN(recipe.customWidth) ||
+          recipe.customWidth < 16 ||
+          recipe.customWidth > 7680),
       "Width must be between 16px and 7680px.",
     ],
+
     [
-      recipe.preset === "custom" && (Number.isNaN(recipe.customHeight) || recipe.customHeight < 16 || recipe.customHeight > 7680),
+      recipe.preset === "custom" &&
+        (Number.isNaN(recipe.customHeight) ||
+          recipe.customHeight < 16 ||
+          recipe.customHeight > 7680),
       "Height must be between 16px and 7680px.",
     ],
+
     [
       !(SPEED_STEPS as readonly number[]).includes(recipe.speed),
       "Please select a valid playback speed.",
     ],
+
     [
       recipe.quality < 18 || recipe.quality > 30,
       "Quality must be between 18 and 30.",
     ],
+
     [
       recipe.brightness < -1 || recipe.brightness > 1,
       "Brightness must be between -1 and 1.",
@@ -120,10 +193,7 @@ function validateRecipe(recipe: EditRecipe, duration: number ): string | null {
     ],
   ];
 
-  return (
-    validations.find(([condition]) => condition)?.[1] ??
-    null
-  );
+  return validations.find(([condition]) => condition)?.[1] ?? null;
 }
 
 function encodeRecipe(recipe: EditRecipe): string {
@@ -154,12 +224,17 @@ function migrateRecipe(recipe: Partial<EditRecipe>): EditRecipe {
 
 export function useVideoEditor() {
   const [file, setFile] = useState<File | null>(null);
+
   const [duration, setDuration] = useState<number>(0);
+
+  const [currentTime, setCurrentTime] = useState<number>(0);
+
   const [videoMetadata, setVideoMetadata] = useState<{
     width: number;
     height: number;
     duration: number;
   } | null>(null);
+
   const [recipe, setRecipe] = useState<EditRecipe>(() => {
     if (typeof window === "undefined") return { ...DEFAULT_RECIPE };
     const params = new URLSearchParams(window.location.search);
@@ -176,26 +251,43 @@ export function useVideoEditor() {
         localStorage.getItem("soundOnCompletion") === "true",
     });
   });
+
   const [status, setStatus] = useState<ExportStatus>("idle");
+
   const [progress, setProgress] = useState(0);
+
   const [result, setResult] = useState<ExportResult | null>(null);
+
+  const [exportHistory, setExportHistory] = useState<ExportHistoryItem[]>([]);
+
   const [error, setError] = useState<string | null>(null);
+
   const [fileError, setFileError] = useState("");
+
   const [exportStartedAt, setExportStartedAt] = useState<number | null>(null);
+
   const exportAbortControllerRef = useRef<AbortController | null>(null);
+
   const exportCancelledRef = useRef(false);
+
   const videoRef = useRef<HTMLVideoElement>(null);
 
   const [musicFile, setMusicFile] = useState<File | null>(null);
+
   const [musicVolume, setMusicVolume] = useState(70);
+
   const [originalAudioVolume, setOriginalAudioVolume] = useState(40);
+
   const [loopMusic, setLoopMusic] = useState(false);
 
   const [overlayFile, setOverlayFile] = useState<File | null>(null);
-  const [overlayPosition, setOverlayPosition] = useState<OverlayPosition>("bottom-right");
+
+  const [overlayPosition, setOverlayPosition] =
+    useState<OverlayPosition>("bottom-right");
+
   const [overlaySize, setOverlaySize] = useState(150);
+
   const [overlayOpacity, setOverlayOpacity] = useState(100);
-  const [currentTime, setCurrentTime] = useState(0);
 
   // Phase 1 MVP: Multi-track timeline support
   const [multiTrackState, setMultiTrackState] = useState<MultiTrackEditorState>(createMultiTrackState);
@@ -218,16 +310,6 @@ export function useVideoEditor() {
     return track;
   }, [addTrack]);
 
-  const updateRecipe = useCallback((patch: Partial<EditRecipe>) => {
-  setRecipe((prev) => {
-    const next = { ...prev, ...patch };
-    // GIF has no audio — force keepAudio off
-    if (next.format === "gif") {
-      next.keepAudio = false;
-    }
-    return next;
-  });
-}, []);
   const isValidValue = (key: keyof EditRecipe, val: any): boolean => {
     switch (key) {
       case "preset":
@@ -261,138 +343,28 @@ export function useVideoEditor() {
     }
   };
 
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    try {
-      const params = new URLSearchParams(window.location.search);
-      const recipeKeys = Object.keys(DEFAULT_RECIPE) as Array<keyof EditRecipe>;
-      const hasRecipeParams = recipeKeys.some(key => params.has(key));
+  const updateRecipe = useCallback((patch: Partial<EditRecipe>) => {
+    setRecipe((prev) => {
+      const next = {
+        ...prev,
+        ...patch,
+      };
 
-      if (hasRecipeParams) {
-        const updatedPatch: Partial<EditRecipe> = {};
-        recipeKeys.forEach((key) => {
-          const paramVal = params.get(key);
-          if (paramVal !== null) {
-            const defaultType = typeof DEFAULT_RECIPE[key];
-            let parsedVal: any;
-
-            if (defaultType === "number") {
-              parsedVal = parseFloat(paramVal);
-            } else if (defaultType === "boolean") {
-              parsedVal = paramVal === "true";
-            } else {
-              parsedVal = paramVal === "null" ? null : paramVal;
-            }
-
-            if (isValidValue(key, parsedVal)) {
-              (updatedPatch as any)[key] = parsedVal;
-            }
-          }
-        });
-
-        if (Object.keys(updatedPatch).length > 0) {
-          setRecipe(prev => ({
-            ...prev,
-            ...updatedPatch
-          }));
-        }
-      } else {
-        // Try full recipe restore first (new key)
-        try {
-          const raw = localStorage.getItem(STORAGE_KEY);
-          if (raw) {
-            const parsed = JSON.parse(raw);
-            if (isValidRecipe(parsed)) {
-              setRecipe(parsed);
-              return;
-            }
-          }
-        } catch {
-          // ignore parse/validation errors and fall back to legacy
-        }
-
-        // Legacy partial settings (keep for backward compatibility)
-        const saved = localStorage.getItem("reframe-settings");
-        if (saved) {
-          const parsed = JSON.parse(saved);
-          const sanitizeDimension = (val: unknown, fallback: number): number => {
-            const n = Number(val);
-            return Number.isFinite(n) && n >= 16 && n <= 7680 ? n : fallback;
-          };
-          setRecipe(prev => ({
-            ...prev,
-            preset: parsed.preset ?? prev.preset,
-            quality: parsed.quality ?? prev.quality,
-            speed: parsed.speed ?? prev.speed,
-            customWidth: sanitizeDimension(parsed.customWidth, prev.customWidth),
-            customHeight: sanitizeDimension(parsed.customHeight, prev.customHeight),
-          }));
-        }
+      if (next.format === "gif") {
+        next.keepAudio = false;
       }
-    } catch (e) {
-      // ignore
-    }
+
+      return next;
+    });
   }, []);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    try {
-      const params = new URLSearchParams();
-      const recipeKeys = Object.keys(DEFAULT_RECIPE) as Array<keyof EditRecipe>;
-
-      recipeKeys.forEach((key) => {
-        const currentVal = recipe[key];
-        const defaultVal = DEFAULT_RECIPE[key];
-
-        if (currentVal !== defaultVal) {
-          params.set(key, currentVal === null ? "null" : String(currentVal));
-        }
-      });
-
-      const newQuery = params.toString();
-      const currentQuery = window.location.search.replace(/^\?/, "");
-
-      if (newQuery !== currentQuery) {
-        const newUrl = newQuery
-          ? `${window.location.pathname}?${newQuery}`
-          : window.location.pathname;
-        window.history.replaceState(null, "", newUrl);
-      }
-    } catch (e) {
-      // ignore
-    }
-  }, [recipe]);
-
-  useEffect(() => {
-    try {
-      localStorage.setItem("reframe-settings", JSON.stringify({
-        preset: recipe.preset,
-        quality: recipe.quality,
-        speed: recipe.speed,
-        customWidth: recipe.customWidth,
-        customHeight: recipe.customHeight
-      }));
-    } catch (e) {
-      // ignore
-    }
-  }, [recipe.preset, recipe.quality, recipe.speed, recipe.customWidth, recipe.customHeight]);
-
-  // Persist the full recipe (debounced)
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const timer = setTimeout(() => {
-      try {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(recipe));
-      } catch {
-        // ignore
-      }
-    }, 500);
-    return () => clearTimeout(timer);
-  }, [recipe]);
 
   const recommendedPreset = useMemo(() => {
     if (!videoMetadata) return null;
-    return getPresetById(suggestPreset(videoMetadata.width, videoMetadata.height)) ?? null;
+
+    return (
+      getPresetById(suggestPreset(videoMetadata.width, videoMetadata.height)) ??
+      null
+    );
   }, [videoMetadata]);
 
   const handleFileSelect = useCallback(async (selectedFile: File) => {
@@ -401,46 +373,36 @@ export function useVideoEditor() {
     setError(null);
     setFile(null);
     setVideoMetadata(null);
+
     if (!selectedFile.type.startsWith("video/")) {
       setFileError("Please upload a video file only.");
+
       return;
     }
 
     setFileError("");
 
-    // LAYER 0: Size check
     if (selectedFile.size > MAX_FILE_SIZE) {
-      setError(`Validation Failed: File too large. Maximum size is 2GB.`);
-      setStatus("error");
-      return;
-    }
+      setError("Validation Failed: File too large. Maximum size is 2GB.");
 
-    const validExtensions = ['.mp4', '.mov', '.avi', '.webm', '.mkv'];
-    const filename = selectedFile.name.toLowerCase();
-    const hasValidExtension = validExtensions.some(ext => filename.endsWith(ext));
-    if (!hasValidExtension) {
-      setError(`Layer 1 Validation Failed: Invalid file extension. Expected one of: ${validExtensions.join(', ')}`);
       setStatus("error");
-      return;
-    }
 
-    if (!selectedFile.type.startsWith("video/")) {
-      setError(`Layer 2 Validation Failed: Invalid MIME type. Expected video/*, got ${selectedFile.type || 'unknown'}`);
-      setStatus("error");
       return;
     }
 
     const isVideo = await verifyMagicBytes(selectedFile);
+
     if (!isVideo) {
-      setError("Layer 3 Validation Failed: Invalid file content. The file's magic bytes do not match known video formats.");
+      setError("Layer 3 Validation Failed: Invalid file content.");
+
       setStatus("error");
+
       return;
     }
 
     try {
       const { width, height, duration: dur } = await extractMetadata(selectedFile);
 
-      // Layer 5: Resolution check
       const dimensionCheck = validateDimensions(width, height);
       if (dimensionCheck === "blocked") {
         const suggested = getDownscaledDimensions(width, height);
@@ -452,37 +414,44 @@ export function useVideoEditor() {
         return;
       }
 
+      if (dimensionCheck === "warning") {
+        console.warn(`[Reframe] High resolution video detected (${width}×${height}). Export may be slow.`);
+      }
+
       setDuration(dur);
       setVideoMetadata({ width, height, duration: dur });
       setFile(selectedFile);
 
-      if (dimensionCheck === "warning") {
-        console.warn(`[Reframe] High resolution video detected (${width}×${height}). Export may be slow.`);
-      }
       setRecipe((prev) => {
         const suggestedPreset = suggestPreset(width, height);
         const shouldApplySuggestion = prev.preset === DEFAULT_RECIPE.preset;
-
         return {
           ...prev,
           trimStart: 0,
           trimEnd: null,
-          ...(shouldApplySuggestion ? { preset: suggestedPreset } : {}),
+          ...(shouldApplySuggestion && { preset: suggestedPreset }),
         };
       });
     } catch (err) {
-      setError(`Layer 4 Validation Failed: ${err instanceof Error ? err.message : "Unknown error"}`);
+      setError(
+        `Layer 4 Validation Failed: ${
+          err instanceof Error ? err.message : "Unknown error"
+        }`,
+      );
+
       setStatus("error");
     }
   }, []);
 
   const handleExport = useCallback(async () => {
     if (!file) return;
+
     if (status === "loading-engine" || status === "exporting") {
       return;
     }
 
     const validationError = validateRecipe(recipe, duration);
+
     if (validationError) {
       setError(validationError);
       setStatus("error");
@@ -490,7 +459,9 @@ export function useVideoEditor() {
     }
 
     const abortController = new AbortController();
+
     exportAbortControllerRef.current = abortController;
+
     exportCancelledRef.current = false;
 
     try {
@@ -524,32 +495,54 @@ export function useVideoEditor() {
           position: overlayPosition,
           size: overlaySize,
           opacity: overlayOpacity,
-        }
+        },
       );
+
       if (exportCancelledRef.current) return;
 
-      setResult({
+      const finalResult: ExportResult = {
         ...exportResult,
         exportDurationMs: Date.now() - startedAt,
+      };
+
+      setResult(finalResult);
+
+      const historyItem: ExportHistoryItem = {
+        ...finalResult,
+        id: crypto.randomUUID(),
+        filename: file.name,
+        exportedAt: Date.now(),
+      };
+
+      setExportHistory((prev) => {
+        const updated = [historyItem, ...prev];
+
+        if (updated.length > 5) {
+          const removed = updated.pop();
+
+          if (removed?.blobUrl) {
+            URL.revokeObjectURL(removed.blobUrl);
+          }
+        }
+
+        return updated;
       });
+
       setStatus("done");
-     }  catch (err) {
+    } catch (err) {
       if (exportCancelledRef.current) return;
 
       console.error("export failed:", err);
+
       if (err instanceof FFmpegLoadError) {
         setError(err.message);
-      } else if (err instanceof Error && err.message.includes('network')) {
-        setError('Network error. Check your internet connection and try again.');
-      } else if (err instanceof Error && err.message.includes('codec')) {
-        setError('This video format is not supported. Try converting to MP4 first.');
       } else {
-        setError('Export failed. Please try again or use a different video.');
+        setError("Export failed. Please try again or use a different video.");
       }
+
       setExportStartedAt(null);
       setStatus("error");
-    }
-    finally {
+    } finally {
       if (exportAbortControllerRef.current === abortController) {
         exportAbortControllerRef.current = null;
       }
@@ -570,19 +563,19 @@ export function useVideoEditor() {
     status,
   ]);
 
-
   useEffect(() => {
     if (status === "exporting") {
       document.title = `Exporting ${progress}% | Reframe`;
     } else if (status === "loading-engine") {
-      document.title = `Loading engine... | Reframe`;
+      document.title = "Loading engine... | Reframe";
     } else if (status === "done") {
-      document.title = `Export complete | Reframe`;
+      document.title = "Export complete | Reframe";
     } else if (file) {
       document.title = `Editing: ${file.name} | Reframe`;
     } else {
       document.title = DEFAULT_TITLE;
     }
+
     return () => {
       document.title = DEFAULT_TITLE;
     };
@@ -601,9 +594,10 @@ export function useVideoEditor() {
     };
 
     window.addEventListener("beforeunload", handler);
+
     return () => window.removeEventListener("beforeunload", handler);
   }, [status]);
-  
+
   useEffect(() => {
     const handleKeydown = (e: KeyboardEvent) => {
       if (
@@ -618,19 +612,22 @@ export function useVideoEditor() {
     };
 
     document.addEventListener("keydown", handleKeydown);
+
     return () => {
       document.removeEventListener("keydown", handleKeydown);
     };
   }, [file, status, handleExport]);
 
-  // M key: toggle audio mute — only when a file is loaded and focus isn't in a text field
   useEffect(() => {
     if (!file) return;
 
     const handleMuteShortcut = (e: KeyboardEvent) => {
-      if (e.key.toLowerCase() !== "m" || e.ctrlKey || e.metaKey || e.altKey) return;
+      if (e.key.toLowerCase() !== "m" || e.ctrlKey || e.metaKey || e.altKey) {
+        return;
+      }
 
       const target = e.target as HTMLElement;
+
       if (
         target.tagName === "INPUT" ||
         target.tagName === "TEXTAREA" ||
@@ -639,52 +636,73 @@ export function useVideoEditor() {
         return;
       }
 
-      setRecipe((prev) => ({ ...prev, keepAudio: !prev.keepAudio }));
+      setRecipe((prev) => ({
+        ...prev,
+        keepAudio: !prev.keepAudio,
+      }));
     };
 
     document.addEventListener("keydown", handleMuteShortcut);
+
     return () => {
       document.removeEventListener("keydown", handleMuteShortcut);
     };
   }, [file]);
 
-  useEffect(()=>{
-    return ()=>{
-      if(result?.blobUrl){
-        URL.revokeObjectURL(result.blobUrl);
-      }
-    }
-   },[result?.blobUrl])
-
   useEffect(() => {
     return () => {
+      if (result?.blobUrl) {
+        URL.revokeObjectURL(result.blobUrl);
+      }
+
+      exportHistory.forEach((item) => {
+        if (item.blobUrl) {
+          URL.revokeObjectURL(item.blobUrl);
+        }
+      });
+
       terminateFFmpeg();
     };
-  }, []);
+  }, [result, exportHistory]);
+
+  const clearExportHistory = useCallback(() => {
+    exportHistory.forEach((item) => {
+      if (item.blobUrl) {
+        URL.revokeObjectURL(item.blobUrl);
+      }
+    });
+
+    setExportHistory([]);
+  }, [exportHistory]);
 
   const resetSettings = useCallback(() => {
     setRecipe(DEFAULT_RECIPE);
+
     try {
       localStorage.removeItem(STORAGE_KEY);
-    } catch {
-      // ignore
-    }
+    } catch {}
   }, []);
 
   const cancelExport = useCallback(() => {
     exportCancelledRef.current = true;
+
     exportAbortControllerRef.current?.abort();
+
     exportAbortControllerRef.current = null;
+
     terminateFFmpeg();
+
     setStatus("idle");
     setProgress(0);
     setError(null);
     setExportStartedAt(null);
   }, []);
 
-
   const reset = useCallback(() => {
-    if (result?.blobUrl) URL.revokeObjectURL(result.blobUrl);
+    if (result?.blobUrl) {
+      URL.revokeObjectURL(result.blobUrl);
+    }
+
     setFile(null);
     setVideoMetadata(null);
     setDuration(0);
@@ -694,42 +712,51 @@ export function useVideoEditor() {
     setResult(null);
     setError(null);
     setExportStartedAt(null);
+
     try {
       localStorage.removeItem(STORAGE_KEY);
     } catch {
       // ignore
     }
-  }, [result]);
-
+  }, [result?.blobUrl]);
 
   useEffect(() => {
     localStorage.setItem("soundOnCompletion", String(recipe.soundOnCompletion));
   }, [recipe.soundOnCompletion]);
+
   const seekTo = useCallback((time: number) => {
-    if (videoRef.current) {
-      videoRef.current.currentTime = time;
-    }
-  }, []);
+  if (videoRef.current) {
+    videoRef.current.currentTime = time;
+  }
+
+  setCurrentTime(time);
+}, []);
+
   useEffect(() => {
     const video = videoRef.current;
     if (!video) return;
     const handleTimeUpdate = () => setCurrentTime(video.currentTime);
     video.addEventListener("timeupdate", handleTimeUpdate);
     return () => video.removeEventListener("timeupdate", handleTimeUpdate);
-  },[]);
+  }, []);
 
   const toggleSound = useCallback(() => {
-  updateRecipe({ soundOnCompletion: !recipe.soundOnCompletion });
-}, [recipe.soundOnCompletion, updateRecipe]);
+    updateRecipe({
+      soundOnCompletion: !recipe.soundOnCompletion,
+    });
+  }, [recipe.soundOnCompletion, updateRecipe]);
 
   return {
     file,
     duration,
+    currentTime,
     recipe,
     status,
     progress,
     exportStartedAt,
     result,
+    exportHistory,
+    clearExportHistory,
     error,
     videoRef,
     seekTo,
@@ -757,7 +784,6 @@ export function useVideoEditor() {
     overlayOpacity,
     setOverlayOpacity,
     recommendedPreset,
-    currentTime,
     toggleSound,
     // Phase 1 MVP: Multi-track timeline support
     multiTrackState,


### PR DESCRIPTION
## Description

Implemented an export history panel that allows users to re-download previous exports during the current browser session.

### Changes made

* Added in-memory `exportHistory` state inside `useVideoEditor.ts`
* Added support for storing up to 5 previous exports
* Created a new `ExportHistory.tsx` component
* Added a collapsible "Recent Exports" panel below the export result section
* Added metadata display for:

  * filename
  * format
  * file size
  * output dimensions
  * export timestamp
* Added "Download" button to re-trigger downloads using stored blob URLs
* Added "Clear History" button
* Implemented proper blob URL cleanup when:

  * history entries are evicted
  * history is cleared
* Added session-only history notice:

  * "History is cleared when you close or refresh the page"
* Updated UI styling to match the existing Reframe design system

### Testing

* Verified old exports remain downloadable after exporting new videos
* Verified history is limited to 5 entries
* Verified oldest export is removed automatically
* Verified "Clear History" removes all entries
* Verified history resets after page refresh
* Verified responsive layout on mobile view
* Verified `bun run lint`, `bunx tsc --noEmit`, and `bun run build` all pass successfully

Fixes #676

## Related Issue

Closes #676

## Type of Contribution

* [x] New feature
* [x] GSSoC contribution

## Participant Info

* GitHub username: imuniqueshiv
* Contribution level: Intermediate

## Screen Recording

Recording / Loom link:

https://github.com/user-attachments/assets/beae4fce-2569-4aa2-a241-7096d42ff26e

## Checklist

* [x] I have read the contribution guidelines
* [x] My changes follow the project structure
* [x] I have tested my changes in Chrome, Firefox, and Safari
* [x] `bun run lint` passes (no ESLint errors)
* [x] `bunx tsc --noEmit` passes (no TypeScript errors)
* [x] New interactive elements have `aria-label` / accessible names
* [x] No `console.log` statements left in
* [x] This PR is related to a valid issue
* [x] Screen recording attached above
