### PR TITLE
feat: add asynchronous audio waveform canvas rendering to trim timeline

### DIFF
--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -4,19 +4,25 @@ import { EditRecipe } from "@/lib/types";
 import { useState, useEffect } from "react";
 import { AlertCircle } from "lucide-react";
 import { formatDuration } from "@/lib/utils";
+import { useAudioWaveform } from "@/hooks/useAudioWaveform";
+import WaveformCanvas from "@/components/WaveformCanvas";
 
 interface Props {
   recipe: EditRecipe;
   onChange: (patch: Partial<EditRecipe>) => void;
   duration: number;
+  file: File | null;
 }
 
-export default function TrimControl({ recipe, onChange, duration }: Props) {
+export default function TrimControl({ recipe, onChange, duration, file }: Props) {
   const [invalidStart, setStart] = useState(false);
   const [invalidEnd, setEnd] = useState(false);
   const [startErrorMsg, setStartErrorMsg] = useState("");
   const [endErrorMsg, setEndErrorMsg] = useState("");
   const [startInput, setStartInput] = useState(recipe.trimStart.toString());
+
+  const { waveform, isLoading: waveformLoading } = useAudioWaveform(file);
+  const hasAudio = waveform.length > 0;
 
   useEffect(() => {
     setStartInput(recipe.trimStart.toString());
@@ -113,6 +119,17 @@ export default function TrimControl({ recipe, onChange, duration }: Props) {
 
   return (
     <div id="trim-control" className="space-y-3">
+      {/* Waveform — shown while loading or when file is present */}
+      {(file && (waveformLoading || hasAudio)) && (
+        <div className="relative w-full rounded-md overflow-hidden bg-[var(--surface)]">
+          <WaveformCanvas
+            samples={waveform}
+            loading={waveformLoading}
+            hasAudio={hasAudio}
+          />
+        </div>
+      )}
+
       <div className="flex gap-3">
         <div className="flex-1">
           <label

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -50,7 +50,7 @@ function Section({ icon, title, children, delay = 0 }: SectionProps) {
 
 export default function VideoEditor() {
   const {
-   file, duration, recipe, status, progress,
+    file, duration, recipe, status, progress,
     result, error, updateRecipe,
     handleFileSelect, fileError, handleExport, cancelExport, reset, resetSettings,
     videoRef,
@@ -122,10 +122,10 @@ export default function VideoEditor() {
               <FileUpload onFileSelect={handleFileSelect} currentFile={file} fileError={fileError} duration={duration} />
 
               {!file && (
-              <div className="text-center text-[var(--muted)] py-6">
-                <p>Upload a video to get started</p>
-                <p className="text-sm">Supports MP4, MOV, WebM and more</p>
-              </div>
+                <div className="text-center text-[var(--muted)] py-6">
+                  <p>Upload a video to get started</p>
+                  <p className="text-sm">Supports MP4, MOV, WebM and more</p>
+                </div>
               )}
 
               {file && (
@@ -162,6 +162,7 @@ export default function VideoEditor() {
                       recipe={recipe}
                       onChange={updateRecipe}
                       duration={duration}
+                      file={file} 
                     />
                   </Section>
                   <Section icon={<RotateCw size={12} />} title="Rotate" delay={100}>

--- a/src/components/WaveformCanvas.tsx
+++ b/src/components/WaveformCanvas.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+interface Props {
+  samples: number[];
+  loading: boolean;
+  hasAudio: boolean;
+}
+
+// Reads a CSS variable from :root, falling back to a default
+function getCssVar(name: string, fallback: string): string {
+  if (typeof window === "undefined") return fallback;
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
+}
+
+export default function WaveformCanvas({ samples, loading, hasAudio }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio ?? 1;
+    const { width, height } = canvas.getBoundingClientRect();
+
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    ctx.scale(dpr, dpr);
+    ctx.clearRect(0, 0, width, height);
+
+    const midY = height / 2;
+
+    // Read theme colour from :root — falls back to a visible purple
+    const accentColor = getCssVar("--film-500", "#8b5cf6");
+
+    if (!hasAudio || samples.length === 0) {
+      // Flat centre line for silent videos
+      ctx.beginPath();
+      ctx.strokeStyle = accentColor;
+      ctx.globalAlpha = 0.4;
+      ctx.lineWidth = 1.5;
+      ctx.moveTo(0, midY);
+      ctx.lineTo(width, midY);
+      ctx.stroke();
+      return;
+    }
+
+    const barWidth = width / samples.length;
+    ctx.fillStyle = accentColor;
+    ctx.globalAlpha = 0.7;
+
+    for (let i = 0; i < samples.length; i++) {
+      const amplitude = samples[i];
+      const barHeight = Math.max(amplitude * (height * 0.92), 1.5);
+      const x = i * barWidth;
+      const y = midY - barHeight / 2;
+      ctx.fillRect(x, y, Math.max(barWidth - 0.5, 0.5), barHeight);
+    }
+  }, [samples, loading, hasAudio]);
+
+  if (loading) {
+    return (
+      <div
+        aria-label="Loading waveform"
+        className="w-full h-16 rounded-md overflow-hidden bg-[var(--surface)] relative border border-[var(--border)]"
+      >
+        <div className="absolute inset-0 flex items-center gap-px px-2">
+          {Array.from({ length: 48 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex-1 rounded-sm bg-film-500 opacity-20 animate-pulse"
+              style={{
+                height: `${18 + Math.sin(i * 0.6) * 14 + Math.cos(i * 1.1) * 10}%`,
+                animationDelay: `${(i * 25) % 500}ms`,
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-label={hasAudio ? "Audio waveform" : "No audio track"}
+      aria-hidden={!hasAudio}
+      className="w-full h-16 rounded-md border border-[var(--border)] bg-[var(--surface)]"
+    />
+  );
+}


### PR DESCRIPTION
# Audio Waveform Visualisation in Trim Control

## Description
Adds a real-time audio waveform display inside the trim control panel, making it significantly easier to identify speech, music beats, and silence when setting trim points.

### Changes Made

* **`src/components/WaveformCanvas.tsx`** (new): Canvas-based waveform renderer. Draws normalised amplitude bars centred on the midline using the project's `--film-500` theme colour, resolved from `:root` so it works correctly in both light and dark mode. Renders a flat centre line for videos with no audio track. Displays an animated bar skeleton while decoding is in progress.

* **`src/components/TrimControl.tsx`**: Added `file: File | null` prop. Calls the existing `useAudioWaveform` hook and renders `<WaveformCanvas>` above the Start/End inputs whenever a file is loaded. The waveform area is only mounted while loading or when audio is present — silent videos do not show an empty box.

## Related Issue
Closes #667

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: Vagventure
- Contribution level (Beginner/Intermediate/Advanced): Advanced

## Screen Recording
**Recording / Loom link:**

https://github.com/user-attachments/assets/17a97eb1-b7a8-41d0-8ad0-e2745a139b00

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)
