### PR TITLE
feat: shareable settings URL — encode current recipe in URL query params

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -19,7 +19,7 @@ import ImageOverlay from "./ImageOverlay"
 import { cn } from "@/lib/utils";
 import {
   Layers, Crop, Scissors, RotateCw, Volume2,
-  SlidersHorizontal, Zap, AlertTriangle, Github
+  SlidersHorizontal, Zap, AlertTriangle, Github, Copy
 } from "lucide-react";
 import OnboardingTour from "./OnboardingTour";
 
@@ -62,7 +62,16 @@ export default function VideoEditor() {
     recommendedPreset,
   } = useVideoEditor();
   const [copied, setCopied] = useState(false);
+  const [shareCopied, setShareCopied] = useState(false);
   const downloadRef = useRef<HTMLDivElement>(null);
+
+  const handleCopyLink = () => {
+    if (typeof window === "undefined") return;
+    navigator.clipboard.writeText(window.location.href).then(() => {
+      setShareCopied(true);
+      setTimeout(() => setShareCopied(false), 2000);
+    });
+  };
 
   useEffect(() => {
     if (status === "done" && downloadRef.current) {
@@ -336,7 +345,15 @@ export default function VideoEditor() {
                 <FramingControl recipe={recipe} onChange={updateRecipe} />
               </Section>
 
-              <div className="pt-2 flex justify-end">
+              <div className="pt-2 flex justify-between items-center">
+                <button
+                  type="button"
+                  onClick={handleCopyLink}
+                  className="flex items-center gap-1.5 text-xs font-heading font-bold uppercase tracking-widest text-film-500 hover:text-film-600 hover:opacity-100 transition-all cursor-pointer"
+                >
+                  <Copy size={12} />
+                  {shareCopied ? "Copied!" : "Copy Link"}
+                </button>
                 <button
                   type="button"
                   onClick={resetSettings}

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -157,24 +157,121 @@ export function useVideoEditor() {
     return next;
   });
 }, []);
+  const isValidValue = (key: keyof EditRecipe, val: any): boolean => {
+    switch (key) {
+      case "preset":
+        return typeof val === "string";
+      case "customWidth":
+        return typeof val === "number" && !isNaN(val) && val >= 16 && val <= 7680;
+      case "customHeight":
+        return typeof val === "number" && !isNaN(val) && val >= 16 && val <= 7680;
+      case "framing":
+        return val === "fit" || val === "fill";
+      case "trimStart":
+        return typeof val === "number" && !isNaN(val) && val >= 0;
+      case "trimEnd":
+        return val === null || (typeof val === "number" && !isNaN(val) && val >= 0);
+      case "rotate":
+        return val === 0 || val === 90 || val === 180 || val === 270;
+      case "speed":
+        return typeof val === "number" && !isNaN(val) && [0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 4].includes(val);
+      case "quality":
+        return typeof val === "number" && !isNaN(val) && val >= 18 && val <= 30;
+      case "format":
+        return val === "mp4" || val === "webm" || val === "mkv" || val === "gif";
+      case "brightness":
+        return typeof val === "number" && !isNaN(val) && val >= -1 && val <= 1;
+      case "contrast":
+        return typeof val === "number" && !isNaN(val) && val >= 0 && val <= 2;
+      case "saturation":
+        return typeof val === "number" && !isNaN(val) && val >= 0 && val <= 3;
+      default:
+        return true;
+    }
+  };
+
   useEffect(() => {
+    if (typeof window === "undefined") return;
     try {
-      const saved = localStorage.getItem("reframe-settings");
-      if (saved) {
-        const parsed = JSON.parse(saved);
-        setRecipe(prev => ({
-          ...prev,
-          preset: parsed.preset ?? prev.preset,
-          quality: parsed.quality ?? prev.quality,
-          speed: parsed.speed ?? prev.speed,
-          customWidth: parsed.customWidth ?? prev.customWidth,
-          customHeight: parsed.customHeight ?? prev.customHeight
-        }));
+      const params = new URLSearchParams(window.location.search);
+      const recipeKeys = Object.keys(DEFAULT_RECIPE) as Array<keyof EditRecipe>;
+      const hasRecipeParams = recipeKeys.some(key => params.has(key));
+
+      if (hasRecipeParams) {
+        const updatedPatch: Partial<EditRecipe> = {};
+        recipeKeys.forEach((key) => {
+          const paramVal = params.get(key);
+          if (paramVal !== null) {
+            const defaultType = typeof DEFAULT_RECIPE[key];
+            let parsedVal: any;
+
+            if (defaultType === "number") {
+              parsedVal = parseFloat(paramVal);
+            } else if (defaultType === "boolean") {
+              parsedVal = paramVal === "true";
+            } else {
+              parsedVal = paramVal === "null" ? null : paramVal;
+            }
+
+            if (isValidValue(key, parsedVal)) {
+              (updatedPatch as any)[key] = parsedVal;
+            }
+          }
+        });
+
+        if (Object.keys(updatedPatch).length > 0) {
+          setRecipe(prev => ({
+            ...prev,
+            ...updatedPatch
+          }));
+        }
+      } else {
+        const saved = localStorage.getItem("reframe-settings");
+        if (saved) {
+          const parsed = JSON.parse(saved);
+          setRecipe(prev => ({
+            ...prev,
+            preset: parsed.preset ?? prev.preset,
+            quality: parsed.quality ?? prev.quality,
+            speed: parsed.speed ?? prev.speed,
+            customWidth: parsed.customWidth ?? prev.customWidth,
+            customHeight: parsed.customHeight ?? prev.customHeight
+          }));
+        }
       }
     } catch (e) {
       // ignore
     }
   }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const params = new URLSearchParams();
+      const recipeKeys = Object.keys(DEFAULT_RECIPE) as Array<keyof EditRecipe>;
+
+      recipeKeys.forEach((key) => {
+        const currentVal = recipe[key];
+        const defaultVal = DEFAULT_RECIPE[key];
+
+        if (currentVal !== defaultVal) {
+          params.set(key, currentVal === null ? "null" : String(currentVal));
+        }
+      });
+
+      const newQuery = params.toString();
+      const currentQuery = window.location.search.replace(/^\?/, "");
+
+      if (newQuery !== currentQuery) {
+        const newUrl = newQuery
+          ? `${window.location.pathname}?${newQuery}`
+          : window.location.pathname;
+        window.history.replaceState(null, "", newUrl);
+      }
+    } catch (e) {
+      // ignore
+    }
+  }, [recipe]);
 
   useEffect(() => {
     try {


### PR DESCRIPTION
## Summary

Implements shareable export settings URLs by synchronizing the current `EditRecipe` state with URL query parameters.

This allows users to instantly share and restore editor configurations such as preset, quality, format, speed, framing, filters, and trim settings directly from the browser URL.

The implementation uses a lightweight client-side `URLSearchParams` + `window.history.replaceState` approach compatible with Next.js static export (`output: "export"`), avoiding dynamic rendering and Suspense boundary issues.

## Changes

### URL Synchronization

* Added URL query parameter parsing and restoration inside `src/hooks/useVideoEditor.ts`
* Added client-side synchronization of non-default recipe values back into the URL without navigation/reload
* Added validation helpers to safely parse and validate incoming query parameter values
* Falls back to `DEFAULT_RECIPE` for invalid or missing params
* Falls back to existing `localStorage` restoration only when no recipe-related URL params are present

### Shareable Links

* Added a new "Copy Link" button next to the "Reset all settings" action in `src/components/VideoEditor.tsx`
* Copies the current URL (including active non-default settings) to the clipboard
* Displays temporary `"Copied!"` confirmation feedback after successful copy

## Example

```txt
/?preset=vertical-9-16&quality=28&format=webm&speed=0.5
```

Opening the above URL restores the corresponding export configuration automatically.

## Technical Notes

* Uses browser-native `URLSearchParams`
* Uses `window.history.replaceState` for seamless URL updates
* Only serializes values that differ from `DEFAULT_RECIPE` to keep URLs short and human-readable
* Fully compatible with static export builds (`output: "export"`)
* No Suspense boundary or `useSearchParams()` dependency required

## Verification

Tested successfully in both development and production builds.

### Manual Verification

* Settings update the URL dynamically without page reload
* Shared URLs correctly restore editor state
* Invalid parameters safely fall back to defaults
* Copy Link button copies the active settings URL correctly
* `npm run build` completes successfully with no static export or dynamic rendering issues

## Screen Recording

A screen recording demonstrating:

* live URL synchronization
* restoring shared URLs
* Copy Link functionality
* successful local workflow (`npm run dev`)

https://github.com/user-attachments/assets/6bdae45d-98a7-4fff-9d42-792b306583ce




Closes #664.

