### PR TITLE
feat: add hover animation to Star on GitHub button

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,8 @@ export default function Home() {
         href="https://github.com/magic-peach/reframe"
         target="_blank"
         rel="noopener noreferrer"
-        className="hidden min-[300px]:flex fixed top-4 right-16 z-50 items-center gap-1.5 px-3 py-1.5 rounded-lg border border-[var(--border)] bg-[var(--surface)] text-[10px] font-heading font-semibold uppercase tracking-wider hover:bg-opacity-90 transition-all"      >
+        className="hidden min-[300px]:flex fixed top-4 right-16 z-50 items-center gap-1.5 px-3 py-1.5 rounded-lg border border-[var(--border)] bg-[var(--surface)] text-[10px] font-heading font-semibold uppercase tracking-wider transition-all duration-200 ease-in-out hover:scale-105 hover:shadow-[0_0_10px_rgba(255,255,255,0.15)] hover:bg-white/10"
+      >
         ⭐ Star on GitHub
       </a>
 


### PR DESCRIPTION
## Description
Added a subtle hover animation to the "Star on GitHub" button in the top-right navbar. 
The button now scales up slightly, shows a soft glow, and transitions to a light background 
on hover — improving interactivity and visual polish without disrupting the existing dark theme.

## Related Issue
Closes #808

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: @Pranav-IIITM
- Contribution level: Beginner

## Screen Recording
> Run `bun run dev` → open http://localhost:3000 → hover over the "Star on GitHub" button 
> in the top-right corner to demonstrate the animation.


https://github.com/user-attachments/assets/a6215000-19d4-4569-931f-a0bc13a8708b

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)