### PR TITLE
feat: show export progress steps #654

### DIFF
--- a/src/components/ExportOverlay.tsx
+++ b/src/components/ExportOverlay.tsx
@@ -7,6 +7,12 @@ import LottiePlayer from "./LottiePlayer";
 import spinnerAnim from "@/lib/lottie/spinner.json";
 import TipCarousel from "./TipCarousel";
 
+const exportSteps = [
+  { label: "Loading", status: "loading-engine" as const },
+  { label: "Exporting", status: "exporting" as const },
+  { label: "Done", status: "done" as const },
+];
+
 interface Props {
   status: ExportStatus;
   progress: number;
@@ -25,7 +31,9 @@ export default function ExportOverlay({ status, progress, exportStartedAt, onCan
   const visible = status === "loading-engine" || status === "exporting";
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const focusAnchorRef = useRef<HTMLDivElement | null>(null);
+  const activeStepIndex = exportSteps.findIndex((step) => step.status === status);
   const [elapsedMs, setElapsedMs] = useState(0);
+  const isLoading = status === "loading-engine";
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key === "Escape") {
@@ -76,8 +84,6 @@ export default function ExportOverlay({ status, progress, exportStartedAt, onCan
 
   if (!visible) return null;
 
-  const isLoading = status === "loading-engine";
-
   return (
     <FocusTrap
       active={visible}
@@ -114,10 +120,10 @@ export default function ExportOverlay({ status, progress, exportStartedAt, onCan
           </div>
           <div className="export-text">
             <h2 className="font-heading font-bold text-xl tracking-tight text-[var(--text)]">
-              {isLoading ? "Loading engine" : "Exporting"}
+              {status === "loading-engine" ? "Loading engine" : "Exporting"}
             </h2>
             <p className="text-sm text-[var(--muted)] mt-1">
-              {isLoading
+              {status === "loading-engine"
                 ? "Downloading the video engine. This only happens once."
                 : "Processing your video locally."}
             </p>
@@ -158,12 +164,10 @@ export default function ExportOverlay({ status, progress, exportStartedAt, onCan
                 >
                   Cancel Export
                 </button>
-                <p className="text-[var(--text)] text-xs">
-                  Press Escape to cancel
-                </p>
+                <p className="text-xs text-gray-500">Press Escape to cancel</p>
               </div>
-              )}
-            </div>
+            )}
+          </div>
         </div>
       </div>
     </FocusTrap>

--- a/src/components/ExportOverlay.tsx
+++ b/src/components/ExportOverlay.tsx
@@ -28,12 +28,13 @@ function formatElapsed(ms: number): string {
 }
 
 export default function ExportOverlay({ status, progress, exportStartedAt, onCancel }: Props) {
-  const visible = status === "loading-engine" || status === "exporting";
+  const [displayStatus, setDisplayStatus] = useState<ExportStatus>(status);
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const focusAnchorRef = useRef<HTMLDivElement | null>(null);
-  const activeStepIndex = exportSteps.findIndex((step) => step.status === status);
+  const visible = displayStatus === "loading-engine" || displayStatus === "exporting" || displayStatus === "done";
+  const activeStepIndex = exportSteps.findIndex((step) => step.status === displayStatus);
   const [elapsedMs, setElapsedMs] = useState(0);
-  const isLoading = status === "loading-engine";
+  const isLoading = displayStatus === "loading-engine";
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key === "Escape") {
@@ -62,13 +63,25 @@ export default function ExportOverlay({ status, progress, exportStartedAt, onCan
   }, [visible, handleKeyDown]);
 
   useEffect(() => {
+    if (status === "done") {
+      setDisplayStatus("done");
+      const timer = window.setTimeout(() => {
+        setDisplayStatus("idle");
+      }, 1200);
+      return () => window.clearTimeout(timer);
+    }
+
+    setDisplayStatus(status);
+  }, [status]);
+
+  useEffect(() => {
     if (!visible && previousFocusRef.current) {
       previousFocusRef.current.focus();
     }
   }, [visible]);
 
   useEffect(() => {
-    if (status !== "exporting" || !exportStartedAt) {
+    if (displayStatus !== "exporting" || !exportStartedAt) {
       setElapsedMs(0);
       return;
     }
@@ -80,7 +93,7 @@ export default function ExportOverlay({ status, progress, exportStartedAt, onCan
     updateElapsed();
     const timer = window.setInterval(updateElapsed, 1000);
     return () => window.clearInterval(timer);
-  }, [status, exportStartedAt]);
+  }, [displayStatus, exportStartedAt]);
 
   if (!visible) return null;
 
@@ -119,12 +132,46 @@ export default function ExportOverlay({ status, progress, exportStartedAt, onCan
             />
           </div>
           <div className="export-text">
+            <div className="flex items-center justify-center gap-2 text-[10px] font-heading font-semibold uppercase tracking-[0.28em] text-[var(--muted)] mb-4">
+              {exportSteps.map((step, index) => {
+                const isActive = index === activeStepIndex;
+                const isComplete = displayStatus === "done" || index < activeStepIndex;
+
+                return (
+                  <div
+                    key={step.status}
+                    className={[
+                      "flex items-center gap-2 transform transition-all duration-300",
+                      isActive ? "text-[var(--text)] scale-105" : "text-[var(--muted)] scale-100",
+                    ].join(" ")}
+                    aria-current={isActive ? "step" : undefined}
+                  >
+                    <span
+                      className={[
+                        "inline-flex h-6 min-w-6 items-center justify-center rounded-full border px-2 transition-all duration-300",
+                        isComplete
+                          ? "border-film-600 bg-film-600 text-white"
+                          : isActive
+                          ? "border-[var(--text)] bg-[var(--surface)] text-[var(--text)] ring-2 ring-film-600 ring-offset-2 ring-offset-[var(--bg)] animate-pulse scale-110 shadow-lg"
+                          : "border-[var(--border)] bg-[var(--surface)] text-[var(--muted)]",
+                      ].join(" ")}
+                    >
+                      {isComplete ? "✓" : index + 1}
+                    </span>
+                    <span className={isActive ? "font-semibold  animate-pulse scale-97" : undefined}>{step.label}</span>
+                    {index < exportSteps.length - 1 && <span className="text-[var(--border)]">/</span>}
+                  </div>
+                );
+              })}
+            </div>
             <h2 className="font-heading font-bold text-xl tracking-tight text-[var(--text)]">
-              {status === "loading-engine" ? "Loading engine" : "Exporting"}
+              {displayStatus === "loading-engine" ? "Loading engine" : displayStatus === "done" ? "Done" : "Exporting"}
             </h2>
             <p className="text-sm text-[var(--muted)] mt-1">
-              {status === "loading-engine"
+              {displayStatus === "loading-engine"
                 ? "Downloading the video engine. This only happens once."
+                : displayStatus === "done"
+                ? "Export complete. Your video is ready to download."
                 : "Processing your video locally."}
             </p>
             <p className="text-xs font-heading font-semibold text-film-600 mt-2 uppercase tracking-wide">
@@ -132,8 +179,10 @@ export default function ExportOverlay({ status, progress, exportStartedAt, onCan
             </p>
           </div>
           <span className="sr-only">
-            {status === "loading-engine"
+            {displayStatus === "loading-engine"
               ? `Loading video engine: ${progress}%`
+              : displayStatus === "done"
+              ? "Export complete"
               : `Exporting: ${progress}%, ${formatElapsed(elapsedMs)} elapsed`}
           </span>
             <div className="w-full space-y-2">
@@ -143,7 +192,7 @@ export default function ExportOverlay({ status, progress, exportStartedAt, onCan
                   aria-valuenow={progress}
                   aria-valuemin={0}
                   aria-valuemax={100}
-                  aria-label={isLoading ? "Engine download progress" : "Export progress"}
+                  aria-label={isLoading ? "Engine download progress" : displayStatus === "done" ? "Export complete" : "Export progress"}
                   className="h-full bg-film-600 rounded-full transition-all duration-300"
                   style={{ width: `${progress}%` }}
                 />
@@ -151,7 +200,7 @@ export default function ExportOverlay({ status, progress, exportStartedAt, onCan
               <div className="flex items-center justify-between gap-4 text-xs font-heading font-semibold text-[var(--muted)]">
                 <span>{progress}%</span>
                 {!isLoading && (
-                  <span>{formatElapsed(elapsedMs)} elapsed</span>
+                  <span>{displayStatus === "done" ? "Complete" : `${formatElapsed(elapsedMs)} elapsed`}</span>
                 )}
               </div>
               <TipCarousel />


### PR DESCRIPTION
## Description

Implemented a multi-step export progress indicator in the export overlay to provide users with clear feedback during the export lifecycle.

Changes made
Added a 3-step export phase indicator above the progress bar in src/components/ExportOverlay.tsx
Integrated with existing ExportStatus from src/lib/types.ts
Mapped export states to UI steps:
loading-engine → [1] Loading engine
exporting → [2] Processing
done → [3] Done

Added distinct visual states for:
Active step → highlighted with pulse/animation
Completed step → checkmark confirmation
Pending step → muted/inactive appearance
Ensured compatibility with both light and dark themes

Added accessibility improvements:
Screen-reader friendly labels
Proper semantic structure and accessible names

Closes #654 

## Type of Contribution
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [X] GSSoC contribution

## Participant Info
- GitHub username: @Prashant-kumar-8312
- Contribution level (Beginner/Intermediate/Advanced):Intermediate

## Screen Recording



https://github.com/user-attachments/assets/9934a76d-8380-4d75-9e18-5f2eb424404d


## Checklist
- [X] I have read the contribution guidelines
- [X] My changes follow the project structure
- [X] I have tested my changes in Chrome, Firefox, and Safari
- [X] `bun run lint` passes (no ESLint errors)
- [X] `bunx tsc --noEmit` passes (no TypeScript errors)
- [X] New interactive elements have `aria-label` / accessible names
- [X] No `console.log` statements left in
- [X] This PR is related to a valid issue
- [X] **Screen recording attached above** (required for UI/feature/design changes)
