### PR TITLE
feat :Save last used preset to localStorage

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "export",
+  experimental: {
+    scrollRestoration: true,
+  },
   // Required for ffmpeg.wasm to load WASM files correctly
   // Without this, Next.js might try to process .wasm files and break them
   webpack: (config) => {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Roboto:wght@400;700&family=Poppins:wght@400;700&family=Montserrat:wght@400;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -146,3 +146,10 @@ textarea:focus {
   box-shadow: 0 0 0 3px var(--accent-muted);
   border-radius: var(--radius);
 }
+
+detail > summary {
+  list-style: none;
+}
+details > summary::-webkit-details-marker {
+  display: none;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Bebas_Neue, Syne, DM_Sans } from "next/font/google";
+import { Bebas_Neue, Syne, DM_Sans, Inter, Roboto, Poppins, Montserrat } from "next/font/google";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import "./globals.css";
 import { ThemeProvider } from "@/components/ThemeProvider";

--- a/src/components/DraggableTextOverlays.tsx
+++ b/src/components/DraggableTextOverlays.tsx
@@ -3,6 +3,7 @@
 import { TextOverlay, EditRecipe } from "@/lib/types";
 import { useRef, useState, useCallback, useEffect, useMemo } from "react";
 import { getTextPixelPosition, getTextPercentPosition } from "@/lib/text-overlay";
+import { getFontFamily, ensureFontLoaded } from "@/utils/fontLoader";
 
 interface DraggableTextOverlaysProps {
   recipe?: EditRecipe;
@@ -29,13 +30,18 @@ export default function DraggableTextOverlays({
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editText, setEditText] = useState<string>("");
+  const [fontUpdateTrigger, setFontUpdateTrigger] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
   const editInputRef = useRef<HTMLDivElement>(null);
 
   /**
    * Memoize text overlays to prevent unnecessary dependency changes.
+   * Always ensures textOverlays is an array, even if recipe is malformed.
    */
-  const textOverlays = useMemo(() => recipe?.textOverlays || [], [recipe?.textOverlays]);
+  const textOverlays = useMemo(() => {
+    const overlays = recipe?.textOverlays;
+    return Array.isArray(overlays) ? overlays : [];
+  }, [recipe?.textOverlays]);
 
   /**
    * Handles the start of a drag operation.
@@ -150,6 +156,43 @@ export default function DraggableTextOverlays({
   }, [draggingId, dragOffset, containerWidth, containerHeight, onUpdateText]);
 
   /**
+   * Ensure custom fonts are loaded when overlays render.
+   * This prevents fallback font flashing and ensures preview accuracy.
+   * Runs whenever overlays change to keep fonts fresh.
+   * Also triggers re-render to ensure font changes are visible immediately.
+   */
+  useEffect(() => {
+    const loadFonts = async () => {
+      // Collect unique fonts from all overlays
+      const fontsToLoad = new Set<string>();
+      textOverlays.forEach((overlay) => {
+        if (overlay.fontFamily) {
+          fontsToLoad.add(overlay.fontFamily);
+        }
+      });
+
+      // Load all fonts in parallel
+      if (fontsToLoad.size > 0) {
+        await Promise.all(
+          Array.from(fontsToLoad).map((fontName) =>
+            ensureFontLoaded(fontName, 16)
+          )
+        );
+        // Trigger re-render after fonts are loaded
+        // This ensures font changes are visible immediately
+        setFontUpdateTrigger((prev) => prev + 1);
+      }
+    };
+
+    if (textOverlays.length > 0) {
+      loadFonts().catch((err) => {
+        // Silently handle font loading errors
+        console.warn("Error loading fonts:", err);
+      });
+    }
+  }, [textOverlays]);
+
+  /**
    * Focus edit input when entering edit mode.
    */
   useEffect(() => {
@@ -189,7 +232,7 @@ export default function DraggableTextOverlays({
 
         return (
           <div
-            key={overlay.id}
+            key={`${overlay.id}-${fontUpdateTrigger}`}
             role="button"
             tabIndex={0}
             onMouseDown={(e) => handleMouseDown(e, overlay.id)}
@@ -217,6 +260,7 @@ export default function DraggableTextOverlays({
               transform: "translate(-50%, -50%)",
               fontSize: `${overlay.fontSize}px`,
               color: overlay.color,
+              fontFamily: getFontFamily(overlay.fontFamily),
               fontWeight:
                 overlay.fontWeight === "900"
                   ? 900
@@ -240,6 +284,7 @@ export default function DraggableTextOverlays({
                 style={{
                   color: overlay.color,
                   fontSize: `${overlay.fontSize}px`,
+                  fontFamily: getFontFamily(overlay.fontFamily),
                   fontWeight:
                     overlay.fontWeight === "900"
                       ? 900

--- a/src/components/FontSelector.tsx
+++ b/src/components/FontSelector.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+import { Upload, X } from "lucide-react";
+import { BUILT_IN_FONTS } from "@/utils/fontLoader";
+import { CustomFont } from "@/hooks/useFontManager";
+
+interface FontSelectorProps {
+  selectedFont?: string;
+  onSelectFont: (fontName: string) => void;
+  customFonts: CustomFont[];
+  onAddFonts: (files: File[]) => Promise<{ success: number; errors: string[] }>;
+  onRemoveFont: (name: string) => void;
+  errors?: string[];
+}
+
+/**
+ * Font selector component with built-in fonts and custom font upload.
+ * Allows users to select from system fonts or upload custom font files.
+ *
+ * Features:
+ * - Dropdown selector for built-in and custom fonts
+ * - Font file upload button (TTF, OTF, WOFF, WOFF2)
+ * - Visual feedback with font preview
+ * - Error handling for invalid fonts
+ * - Font removal for custom uploads
+ *
+ * @example
+ * <FontSelector
+ *   selectedFont="Inter"
+ *   onSelectFont={(name) => updateOverlay({ fontFamily: name })}
+ *   customFonts={customFonts}
+ *   onAddFonts={addFonts}
+ *   onRemoveFont={removeFont}
+ *   errors={fontErrors}
+ * />
+ */
+export default function FontSelector({
+  selectedFont,
+  onSelectFont,
+  customFonts,
+  onAddFonts,
+  onRemoveFont,
+  errors = [],
+}: FontSelectorProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const builtInFontNames = BUILT_IN_FONTS.map(({ name }) => name);
+  const allFonts = [
+    ...builtInFontNames,
+    ...customFonts.map((f) => f.name),
+  ];
+
+  const handleFileSelect = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(e.target.files || []);
+      if (files.length === 0) return;
+
+      const result = await onAddFonts(files);
+
+      // Auto-select first successfully added font
+      const firstFile = files[0];
+      if (result.success > 0 && firstFile) {
+        const fontName = firstFile.name.replace(/\.[^.]*$/, "").replace(/[-_\s]/g, "");
+        onSelectFont(fontName);
+      }
+
+      // Reset input
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    },
+    [onAddFonts, onSelectFont]
+  );
+
+  return (
+    <div className="space-y-2">
+      {/* Font Selector Label */}
+      <label htmlFor="font-select" className="text-xs text-[var(--muted)] font-medium block">
+        Font
+      </label>
+
+      {/* Font Selector Dropdown */}
+      <div className="flex gap-1">
+        <select
+          id="font-select"
+          value={selectedFont || "Arial"}
+          onChange={(e) => onSelectFont(e.target.value)}
+          className="flex-1 px-2 py-1.5 text-xs rounded border border-[var(--border)] bg-[var(--bg)] text-[var(--text)] focus:outline-none focus:ring-2 focus:ring-film-500"
+        >
+          {builtInFontNames.map((name) => (
+            <option key={name} value={name}>
+              {name}
+            </option>
+          ))}
+          {customFonts.length > 0 && (
+            <optgroup label="Custom Fonts">
+              {customFonts.map(({ name }) => (
+                <option key={name} value={name}>
+                  {name}
+                </option>
+              ))}
+            </optgroup>
+          )}
+        </select>
+
+        {/* Upload Font Button */}
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          className="px-2 py-1.5 rounded border border-[var(--border)] bg-[var(--surface)] text-[var(--text)] hover:bg-[var(--border)] transition-colors"
+          aria-label="Upload custom font"
+          title="Upload TTF, OTF, WOFF, or WOFF2 font file"
+        >
+          <Upload size={14} />
+        </button>
+
+        {/* Hidden File Input */}
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          accept=".ttf,.otf,.woff,.woff2"
+          onChange={handleFileSelect}
+          style={{ display: "none" }}
+          aria-label="Font file upload"
+        />
+      </div>
+
+      {/* Custom Fonts List with Remove Option */}
+      {customFonts.length > 0 && (
+        <div className="space-y-1 pt-2 border-t border-[var(--border)]">
+          <p className="text-xs text-[var(--muted)] font-medium">Custom Fonts</p>
+          <div className="space-y-1">
+            {customFonts.map(({ name }) => (
+              <div
+                key={name}
+                className="flex items-center justify-between px-2 py-1 text-xs rounded bg-[var(--surface)] border border-[var(--border)]"
+              >
+                <span
+                  className="font-medium text-[var(--text)]"
+                  style={{ fontFamily: name }}
+                >
+                  {name}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => onRemoveFont(name)}
+                  className="p-1 rounded text-red-400 hover:bg-red-500/10 transition-colors"
+                  aria-label={`Remove ${name} font`}
+                >
+                  <X size={12} />
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Error Messages */}
+      {errors.length > 0 && (
+        <div className="space-y-1 pt-2 border-t border-[var(--border)]">
+          {errors.map((error, idx) => (
+            <p
+              key={idx}
+              className="text-xs text-red-400 bg-red-500/10 px-2 py-1 rounded"
+            >
+              {error}
+            </p>
+          ))}
+        </div>
+      )}
+
+      {/* Font Format Info */}
+      <p className="text-xs text-[var(--muted)] italic">
+        Supported formats: TTF, OTF, WOFF, WOFF2 (max 5MB)
+      </p>
+    </div>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,15 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import {
-  Github,
-  TwitterIcon,
-  Instagram,
-  ArrowRight,
-  ShieldCheck,
-  Zap,
-  Globe,
-} from "lucide-react";
+import { Github, Twitter, Instagram, Linkedin, ArrowRight, ShieldCheck, Zap, Globe, ExternalLink, Lock, Mail } from "lucide-react";
 
 export default function Footer() {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -18,31 +10,24 @@ export default function Footer() {
   return (
     <footer className="w-full border-t border-[var(--border)] bg-[var(--bg)] text-[var(--text)] px-6 py-16 mt-20 transition-colors duration-300">
       <div className="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-12 gap-12 md:gap-8">
+
         {/* Brand Section */}
         <div className="md:col-span-5 space-y-6">
           <div className="space-y-1">
             <h2 className="text-2xl font-bold tracking-tight">Reframe</h2>
-            <p className="text-[9px] font-mono tracking-[0.4em] uppercase opacity-50">
-              Browser Video Studio
-            </p>
+            <p className="text-[9px] font-mono tracking-[0.4em] uppercase opacity-50">Browser Video Studio</p>
           </div>
-
           <p className="text-sm opacity-70 leading-relaxed max-w-sm">
             Professional video processing directly in your browser using
-            <span className="font-medium opacity-100"> FFmpeg.wasm</span> —
-            fast, private, and open source.
+            <span className="font-medium opacity-100"> FFmpeg.wasm</span> — fast, private, and open source.
           </p>
-
           <div className="flex flex-wrap gap-2">
             {[
               { icon: <ShieldCheck size={12} />, label: "100% Local" },
               { icon: <Zap size={12} />, label: "Fast" },
               { icon: <Globe size={12} />, label: "Open Source" },
             ].map((tag) => (
-              <span
-                key={tag.label}
-                className="flex items-center gap-1.5 px-3 py-1 rounded-lg border border-[var(--border)] bg-[var(--surface)] text-[10px] font-semibold tracking-wide uppercase transition-all duration-200 ease-in-out hover:-translate-y-0.5 hover:border-[var(--accent)] hover:bg-[var(--accent-muted)] hover:shadow-[var(--shadow)] cursor-pointer select-none"
-              >
+              <span key={tag.label} className="flex items-center gap-1.5 px-3 py-1 rounded-lg border border-[var(--border)] bg-[var(--surface)] text-[10px] font-semibold tracking-wide uppercase transition-all duration-200 hover:-translate-y-0.5 hover:border-[var(--accent)] hover:bg-[var(--accent-muted)] cursor-pointer select-none">
                 {tag.icon} {tag.label}
               </span>
             ))}
@@ -51,79 +36,39 @@ export default function Footer() {
 
         {/* Links Section */}
         <div className="md:col-span-3 space-y-5">
-          <h3 className="text-[10px] font-bold uppercase tracking-[0.2em] opacity-40">
-            Navigation
-          </h3>
+          <h3 className="text-[10px] font-bold uppercase tracking-[0.2em] opacity-40">Navigation</h3>
           <nav className="flex flex-col gap-3 text-sm">
-            <a
-              href="https://github.com/magic-peach/reframe"
-              target="_blank"
-              rel="noopener"
-              className="opacity-70 hover:opacity-100 hover:text-[var(--accent)] hover:scale-110 transition-all duration-500 ease-in-out w-fit flex items-center gap-2 group"
-            >
+            <a href="https://github.com/magic-peach/reframe" target="_blank" rel="noopener" className="opacity-70 hover:opacity-100 hover:text-[var(--accent)] hover:translate-x-1 transition-all duration-300 w-fit flex items-center gap-2 group">
+              <Github size={14} className="group-hover:scale-110 transition-transform duration-300" />
               GitHub
+              <ExternalLink size={10} className="opacity-0 group-hover:opacity-60 transition-opacity duration-300" />
             </a>
-            <Link
-              href="/contact"
-              className="opacity-70 hover:opacity-100 hover:text-[var(--accent)] hover:scale-110 transition-all duration-500 ease-in-out w-fit flex items-center gap-2 group"
-            >
+            <Link href="/contact" className="opacity-70 hover:opacity-100 hover:text-[var(--accent)] hover:translate-x-1 transition-all duration-300 w-fit flex items-center gap-2 group">
+              <Mail size={14} className="group-hover:scale-110 transition-transform duration-300" />
               Contact
             </Link>
-            <Link
-              href="/privacy"
-              className="opacity-70 hover:opacity-100 hover:text-[var(--accent)] hover:scale-110 transition-all duration-500 ease-in-out w-fit flex items-center gap-2 group"
-            >
+            <Link href="/privacy" className="opacity-70 hover:opacity-100 hover:text-[var(--accent)] hover:translate-x-1 transition-all duration-300 w-fit flex items-center gap-2 group">
+              <Lock size={14} className="group-hover:scale-110 transition-transform duration-300" />
               Privacy Policy
             </Link>
           </nav>
         </div>
 
-        {/* Right Section: Newsletter & Community */}
+        {/* Right Section */}
         <div className="md:col-span-4 flex flex-col items-start md:items-end space-y-8">
-          {/* Newsletter - Logic updated to pass Lint/Build checks */}
-          <div className="w-full flex flex-col items-start md:items-end gap-3">
-            <h3 className="text-[10px] font-bold uppercase tracking-[0.2em] opacity-40">
-              Updates
-            </h3>
 
+          {/* Newsletter */}
+          <div className="w-full flex flex-col items-start md:items-end gap-3">
+            <h3 className="text-[10px] font-bold uppercase tracking-[0.2em] opacity-40">Updates</h3>
             {!isExpanded ? (
-              <button
-                type="button"
-                onClick={() => setIsExpanded(true)}
-                aria-label="Open updates signup form"
-                aria-expanded={isExpanded}
-                aria-controls="updates-signup-form"
-                className="w-40 px-3 flex items-center justify-center bg-[var(--surface)] border border-[var(--border)] rounded-lg py-3 hover:bg-[var(--border)] transition-all duration-500 ease-in-out group"
-              >
-                <span className="text-[10px] font-bold uppercase tracking-[0.2em] opacity-60 group-hover:opacity-100 transition-opacity">
-                  Stay Tuned
-                </span>
+              <button type="button" onClick={() => setIsExpanded(true)} aria-label="Open updates signup form" aria-expanded={isExpanded} aria-controls="updates-signup-form" className="w-40 px-3 flex items-center justify-center bg-[var(--surface)] border border-[var(--border)] rounded-lg py-3 hover:bg-[var(--border)] transition-all duration-500 group">
+                <span className="text-[10px] font-bold uppercase tracking-[0.2em] opacity-60 group-hover:opacity-100 transition-opacity">Stay Tuned</span>
               </button>
             ) : (
-              <div
-                id="updates-signup-form"
-                className="w-full sm:w-72 px-4 flex items-center bg-[var(--surface)] border border-[var(--accent)] rounded-lg transition-all duration-500 ease-in-out"
-              >
-                <form
-                  aria-label="Updates signup form"
-                  onSubmit={(e) => {
-                    e.preventDefault();
-                    setIsExpanded(false);
-                  }}
-                  className="flex w-full items-center animate-in slide-in-from-right-2 duration-500"
-                >
-                  <input
-                    type="email"
-                    placeholder="ENTER EMAIL"
-                    className="bg-transparent border-none text-[10px] font-bold tracking-widest text-[var(--text)] focus:outline-none w-full py-3 placeholder:opacity-30"
-                    aria-label="Email address for updates"
-                    onBlur={() => setIsExpanded(false)}
-                  />
-                  <button
-                    aria-label="Submit email for updates"
-                    type="submit"
-                    className="text-[var(--accent)] hover:text-[var(--accent-hover)] p-1"
-                  >
+              <div id="updates-signup-form" className="w-full sm:w-72 px-4 flex items-center bg-[var(--surface)] border border-[var(--accent)] rounded-lg transition-all duration-500">
+                <form aria-label="Updates signup form" onSubmit={(e) => { e.preventDefault(); setIsExpanded(false); }} className="flex w-full items-center">
+                  <input type="email" placeholder="ENTER EMAIL" className="bg-transparent border-none text-[10px] font-bold tracking-widest text-[var(--text)] focus:outline-none w-full py-3 placeholder:opacity-30" aria-label="Email address for updates" onBlur={() => setIsExpanded(false)} />
+                  <button aria-label="Submit email for updates" type="submit" className="text-[var(--accent)] hover:text-[var(--accent-hover)] p-1">
                     <ArrowRight size={16} aria-hidden="true" />
                   </button>
                 </form>
@@ -131,55 +76,25 @@ export default function Footer() {
             )}
           </div>
 
-          {/* Community Section */}
-          {/* Community Section */}
+          {/* Community */}
           <div className="flex flex-col items-start md:items-end gap-3">
-            <h3 className="text-[10px] font-bold uppercase tracking-[0.2em] opacity-40">
-              Community
-            </h3>
-
+            <h3 className="text-[10px] font-bold uppercase tracking-[0.2em] opacity-40">Community</h3>
             <div className="flex items-center gap-3">
-              <a
-                href="https://github.com/magic-peach/reframe"
-                target="_blank"
-                rel="noopener"
-                className="p-2.5 rounded-lg border border-[var(--border)] bg-[var(--surface)] hover:border-[var(--accent)] hover:bg-[var(--accent-muted)] transition-all hover:-translate-y-1 active:scale-95 flex items-center justify-center group"
-                aria-label="Open Reframe GitHub repository"
-              >
-                <Github
-                  size={18}
-                  aria-hidden="true"
-                  className="opacity-70 group-hover:opacity-100 transition-opacity"
-                />
-              </a>
-
-              <a
-                href="https://twitter.com"
-                target="_blank"
-                rel="noopener"
-                className="p-2.5 rounded-lg border border-[var(--border)] bg-[var(--surface)] hover:border-[var(--accent)] hover:bg-[var(--accent-muted)] transition-all hover:-translate-y-1 active:scale-95 flex items-center justify-center group"
-                aria-label="Open Twitter"
-              >
-                <TwitterIcon
-                  size={18}
-                  aria-hidden="true"
-                  className="opacity-70 group-hover:opacity-100 transition-opacity"
-                />
-              </a>
-
-              <a
-                href="https://instagram.com"
-                target="_blank"
-                rel="noopener"
-                className="p-2.5 rounded-lg border border-[var(--border)] bg-[var(--surface)] hover:border-[var(--accent)] hover:bg-[var(--accent-muted)] transition-all hover:-translate-y-1 active:scale-95 flex items-center justify-center group"
-                aria-label="Open Instagram"
-              >
-                <Instagram
-                  size={18}
-                  aria-hidden="true"
-                  className="opacity-70 group-hover:opacity-100 transition-opacity"
-                />
-              </a>
+              {[
+                { href: "https://github.com/magic-peach/reframe", icon: <Github size={18} />, label: "GitHub", tooltip: "Star us on GitHub" },
+                { href: "https://twitter.com", icon: <Twitter size={18} />, label: "Twitter", tooltip: "Follow on Twitter" },
+                { href: "https://instagram.com", icon: <Instagram size={18} />, label: "Instagram", tooltip: "Follow on Instagram" },
+                { href: "https://linkedin.com", icon: <Linkedin size={18} />, label: "LinkedIn", tooltip: "Connect on LinkedIn" },
+              ].map((social) => (
+                <div key={social.label} className="relative group">
+                  <a href={social.href} target="_blank" rel="noopener" aria-label={social.label} className="p-2.5 rounded-lg border border-[var(--border)] bg-[var(--surface)] hover:border-[var(--accent)] hover:bg-[var(--accent-muted)] transition-all duration-200 hover:-translate-y-1 active:scale-95 flex items-center justify-center">
+                    <span className="opacity-70 group-hover:opacity-100 transition-opacity duration-200">{social.icon}</span>
+                  </a>
+                  <span className="absolute -top-9 left-1/2 -translate-x-1/2 bg-[var(--text)] text-[var(--bg)] text-[9px] font-bold uppercase tracking-widest px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity duration-200 whitespace-nowrap pointer-events-none">
+                    {social.tooltip}
+                  </span>
+                </div>
+              ))}
             </div>
           </div>
         </div>

--- a/src/components/TextControls.tsx
+++ b/src/components/TextControls.tsx
@@ -5,6 +5,8 @@ import { createDefaultTextOverlay } from "@/lib/text-overlay";
 import { Trash2, Plus } from "lucide-react";
 import { useMemo } from "react";
 import BaseButton from "./ui/BaseButton";
+import FontSelector from "./FontSelector";
+import { useFontManager } from "@/hooks/useFontManager";
 
 interface TextControlsProps {
   recipe: EditRecipe;
@@ -23,10 +25,19 @@ export default function TextControls({
   selectedTextId,
   onSelectText,
 }: TextControlsProps) {
+  const { customFonts, addFonts, removeFont, getErrors } = useFontManager();
+
   /**
    * Memoize text overlays to prevent unnecessary dependency changes.
+   * Always ensures textOverlays is an array, even if recipe is malformed.
    */
-  const textOverlays = useMemo(() => recipe.textOverlays || [], [recipe.textOverlays]);
+  const textOverlays = useMemo(
+    (): TextOverlay[] => {
+      const overlays = recipe?.textOverlays;
+      return Array.isArray(overlays) ? overlays : [];
+    },
+    [recipe?.textOverlays]
+  );
 
   /**
    * Adds a new text overlay to the recipe.
@@ -63,7 +74,8 @@ export default function TextControls({
    * Get the currently selected overlay.
    */
   const selectedOverlay = useMemo(
-    () => textOverlays.find((o) => o.id === selectedTextId),
+    (): TextOverlay | undefined =>
+      textOverlays.find((o) => o.id === selectedTextId),
     [textOverlays, selectedTextId]
   );
 
@@ -128,6 +140,18 @@ export default function TextControls({
               rows={2}
             />
           </div>
+
+          {/* Font Selector */}
+          <FontSelector
+            selectedFont={selectedOverlay.fontFamily}
+            onSelectFont={(fontName) =>
+              handleUpdateText(selectedTextId!, { fontFamily: fontName })
+            }
+            customFonts={customFonts}
+            onAddFonts={addFonts}
+            onRemoveFont={removeFont}
+            errors={getErrors()}
+          />
 
           {/* Font Size Slider */}
           <div>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,9 +1,30 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useTheme } from "./ThemeProvider";
 
 export function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+  if (!mounted) {
+    return (
+      <button
+        type="button"
+        tabIndex={-1}
+        aria-label="Toggle theme"
+        className="
+          relative flex items-center justify-center
+          w-9 h-9 rounded-full
+          bg-[var(--surface)]
+          border border-[var(--border)]
+        "
+      />
+    );
+  }
+
   const isDark = theme === "dark";
 
   return (

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useTheme } from "./ThemeProvider";
+import { useEffect, useState } from "react";
 
 export function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
@@ -26,10 +27,12 @@ export function ThemeToggle() {
   }
 
   const isDark = theme === "dark";
+  const [mounted, setMounted] = useState(false);
 
   return (
     <button
        type="button"
+       suppressHydrationWarning={true}
        onClick={toggleTheme}
        aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
       className="
@@ -44,32 +47,14 @@ export function ThemeToggle() {
         transition-all duration-200
       "
     >
-      {isDark ? (
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={2}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="w-4 h-4"
-          aria-hidden="true"
-        >
+    {!mounted ? (
+        <div className="w-4 h-4" /> 
+      ) : isDark ? (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4" aria-hidden="true">
           <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
         </svg>
       ) : (
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={2}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="w-4 h-4"
-          aria-hidden="true"
-        >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4" aria-hidden="true">
           <circle cx="12" cy="12" r="4" />
           <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
         </svg>

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -487,6 +487,36 @@ export default function VideoEditor() {
                       onSelectText={setSelectedTextId}
                     />
                   </AccordionSection>
+                  <details className="group">
+                  <summary className="flex items-center gap-2 cursor-pointer select-none list-none
+                      text-[10px] font-heading font-bold uppercase tracking-widest text-[var(--muted)] py-1">
+                      <span className="text-film-500 opacity-80 transition-transform duration-200 group-open:rotate-90">›</span>
+                      Advanced settings
+                      <div className="flex-1 h-px bg-[var(--border)]" />
+                    </summary>
+
+                    <div className="mt-4 space-y-4">
+                      <AccordionSection
+                        id="rotation"
+                        icon={<RotateCw size={12} />}
+                        title="Rotation"
+                        isOpen={openSections.rotation}
+                        onToggle={() => toggleSection("rotation")}
+                      >
+                        <RotateControl recipe={recipe} onChange={updateRecipe} />
+                      </AccordionSection>
+
+                      <AccordionSection
+                        id="export"
+                        icon={<SlidersHorizontal size={12} />}
+                        title="Export"
+                        isOpen={openSections.export}
+                        onToggle={() => toggleSection("export")}
+                      >
+                        <ExportSettings recipe={recipe} duration={duration} onChange={updateRecipe} />
+                      </AccordionSection>
+                    </div>
+                  </details>
                 </div>
                 <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6">
                   <AccordionSection
@@ -607,6 +637,36 @@ export default function VideoEditor() {
                       setOverlayOpacity={setOverlayOpacity}
                     />
                   </Section>
+                  <details className="group">
+                  <summary className="flex items-center gap-2 cursor-pointer select-none list-none
+                    text-[10px] font-heading font-bold uppercase tracking-widest text-[var(--muted)] py-1">
+                    <span className="text-film-500 opacity-80 transition-transform duration-200 group-open:rotate-90">›</span>
+                    Advanced settings
+                    <div className="flex-1 h-px bg-[var(--border)]" />
+                  </summary>
+
+                  <div className="mt-4 space-y-4">
+                    <AccordionSection
+                      id="rotation"
+                      icon={<RotateCw size={12} />}
+                      title="Rotation"
+                      isOpen={openSections.rotation}
+                      onToggle={() => toggleSection("rotation")}
+                    >
+                      <RotateControl recipe={recipe} onChange={updateRecipe} />
+                    </AccordionSection>
+
+                    <AccordionSection
+                      id="export"
+                      icon={<SlidersHorizontal size={12} />}
+                      title="Export"
+                      isOpen={openSections.export}
+                      onToggle={() => toggleSection("export")}
+                    >
+                      <ExportSettings recipe={recipe} duration={duration} onChange={updateRecipe} />
+                    </AccordionSection>
+                  </div>
+                </details>
                 </div>
               </div>
             )}

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -210,6 +210,7 @@ export default function VideoEditor() {
     recommendedPreset,
     currentTime,
     toggleSound,
+    videoMetadata,
   } = useVideoEditor();
 
   useKeyboardShortcuts({
@@ -401,6 +402,34 @@ export default function VideoEditor() {
                       intervalSeconds={intervalSeconds}
                     />
                   </div>
+
+                  {videoMetadata && (
+                    <div className="mt-4 p-3 bg-film-50/50 rounded-lg border border-film-100 text-xs text-film-500 flex flex-wrap gap-4 items-center">
+                      <div className="flex flex-col">
+                        <span className="font-heading font-bold uppercase tracking-widest text-[10px] mb-0.5">Resolution</span>
+                        <span className="text-film-900">{videoMetadata.width} × {videoMetadata.height}</span>
+                      </div>
+                      <div className="w-px h-6 bg-film-200" />
+                      <div className="flex flex-col">
+                        <span className="font-heading font-bold uppercase tracking-widest text-[10px] mb-0.5">Duration</span>
+                        <span className="text-film-900">{Math.round(videoMetadata.duration)}s</span>
+                      </div>
+                      <div className="w-px h-6 bg-film-200" />
+                      <div className="flex flex-col">
+                        <span className="font-heading font-bold uppercase tracking-widest text-[10px] mb-0.5">Format</span>
+                        <span className="text-film-900">{videoMetadata.codec?.split('/')[1]?.toUpperCase() || videoMetadata.codec}</span>
+                      </div>
+                      {videoMetadata.bitrate && (
+                        <>
+                          <div className="w-px h-6 bg-film-200" />
+                          <div className="flex flex-col">
+                            <span className="font-heading font-bold uppercase tracking-widest text-[10px] mb-0.5">Est. Bitrate</span>
+                            <span className="text-film-900">{videoMetadata.bitrate} kbps</span>
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  )}
                 </div>
               )}
             </div>

--- a/src/hooks/useFontManager.ts
+++ b/src/hooks/useFontManager.ts
@@ -1,0 +1,163 @@
+/**
+ * Hook for managing custom fonts in Reframe's text editor.
+ * Handles font file uploads, validation, and registration.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { validateFontFile, extractFontName, detectDuplicateFonts } from "@/utils/fontValidation";
+import {
+  registerCustomFont,
+  unregisterCustomFont,
+  initializeFontRegistry,
+  clearCustomFonts,
+  ensureFontLoaded,
+} from "@/utils/fontLoader";
+
+export interface CustomFont {
+  name: string; // Display name
+  file: File; // Original font file
+  blobUrl: string; // Blob URL for @font-face
+}
+
+interface UseFontManagerReturn {
+  customFonts: CustomFont[];
+  addFonts: (files: File[]) => Promise<{ success: number; errors: string[] }>;
+  removeFont: (name: string) => void;
+  getErrors: () => string[];
+}
+
+/**
+ * Hook for managing custom fonts in the editor.
+ * Handles validation, registration, and cleanup.
+ *
+ * @returns Object with methods to manage fonts and current font list
+ *
+ * @example
+ * const { customFonts, addFonts, removeFont } = useFontManager();
+ *
+ * // Upload fonts
+ * const result = await addFonts(fontFiles);
+ * if (result.errors.length > 0) {
+ *   console.error(result.errors);
+ * }
+ *
+ * // Remove a font
+ * removeFont("MyCustomFont");
+ */
+export function useFontManager(): UseFontManagerReturn {
+  const [customFonts, setCustomFonts] = useState<CustomFont[]>([]);
+  const [errors, setErrors] = useState<string[]>([]);
+
+  // Initialize font registry on mount
+  useEffect(() => {
+    initializeFontRegistry();
+
+    // Cleanup: unregister custom fonts on unmount
+    return () => {
+      clearCustomFonts();
+    };
+  }, []);
+
+  /**
+   * Adds font files to the manager after validation.
+   * Automatically registers fonts in the DOM and ensures they're loaded.
+   */
+  const addFonts = useCallback(
+    async (files: File[]): Promise<{ success: number; errors: string[] }> => {
+      const newErrors: string[] = [];
+      const validatedFonts: CustomFont[] = [];
+
+      // Validate each file
+      for (const file of files) {
+        const validation = validateFontFile(file);
+
+        if (!validation.valid) {
+          newErrors.push(`${file.name}: ${validation.error}`);
+          continue;
+        }
+
+        // Extract clean font name (already sanitized)
+        const fontName = extractFontName(file.name);
+
+        // Check for duplicate name
+        if (customFonts.some((f) => f.name === fontName)) {
+          newErrors.push(`${file.name}: Font "${fontName}" already uploaded`);
+          continue;
+        }
+
+        // Create blob URL
+        const blobUrl = URL.createObjectURL(file);
+
+        // Register in DOM
+        try {
+          registerCustomFont(fontName, blobUrl);
+          
+          // Ensure font is loaded before allowing render
+          // This prevents fallback font flashing
+          await ensureFontLoaded(fontName, 16);
+          
+          validatedFonts.push({
+            name: fontName,
+            file,
+            blobUrl,
+          });
+        } catch (err) {
+          newErrors.push(
+            `${file.name}: Failed to register font - ${err instanceof Error ? err.message : "Unknown error"}`
+          );
+          URL.revokeObjectURL(blobUrl);
+        }
+      }
+
+      // Check for duplicate content
+      if (validatedFonts.length > 1) {
+        const duplicates = await detectDuplicateFonts(
+          validatedFonts.map((f) => f.file)
+        );
+        if (duplicates.size > 0) {
+          newErrors.push(
+            `Duplicate fonts detected: ${Array.from(duplicates).join(", ")}`
+          );
+        }
+      }
+
+      // Update state
+      setCustomFonts((prev) => [...prev, ...validatedFonts]);
+      setErrors(newErrors);
+
+      return {
+        success: validatedFonts.length,
+        errors: newErrors,
+      };
+    },
+    [customFonts]
+  );
+
+  /**
+   * Removes a custom font and cleans up resources.
+   */
+  const removeFont = useCallback((fontName: string) => {
+    setCustomFonts((prev) => {
+      const font = prev.find((f) => f.name === fontName);
+      if (font) {
+        // Revoke blob URL
+        URL.revokeObjectURL(font.blobUrl);
+
+        // Unregister from DOM
+        unregisterCustomFont(fontName);
+      }
+
+      return prev.filter((f) => f.name !== fontName);
+    });
+
+    // Clear errors when removing fonts
+    setErrors([]);
+  }, []);
+
+  return {
+    customFonts,
+    addFonts,
+    removeFont,
+    getErrors: () => errors,
+  };
+}

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -479,7 +479,7 @@ export function useVideoEditor() {
       if (result?.blobUrl) URL.revokeObjectURL(result.blobUrl);
       setResult(null);
 
-      await loadFFmpeg(abortController.signal, setProgress);
+      const ffmpeg = await loadFFmpeg(abortController.signal, setProgress);
       if (exportCancelledRef.current) return;
 
       const startedAt = Date.now();
@@ -487,6 +487,7 @@ export function useVideoEditor() {
       setStatus("exporting");
 
       const exportResult = await exportVideo(
+        ffmpeg,
         file,
         recipe,
         setProgress,

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -9,9 +9,9 @@ import { suggestPreset } from "@/lib/presetSuggestion";
 import { validateDimensions, getDownscaledDimensions } from "@/utils/video-validation";
 
 const DEFAULT_TITLE = "Reframe — Resize, trim, and export videos in your browser";
-  const STORAGE_KEY = "reframe:recipe";
+const STORAGE_KEY = "reframe:recipe";
 
-export function extractMetadata(file: File): Promise<{ width: number; height: number; duration: number }> {
+export function extractMetadata(file: File): Promise<{ width: number; height: number; duration: number; bitrate?: number; codec?: string }> {
   return new Promise((resolve, reject) => {
     const url = URL.createObjectURL(file);
     const video = document.createElement("video");
@@ -23,10 +23,15 @@ export function extractMetadata(file: File): Promise<{ width: number; height: nu
     video.preload = "metadata";
     video.onloadedmetadata = () => {
       clearTimeout(timeout)
+      const duration = isFinite(video.duration) ? video.duration : 0;
+      const bitrate = duration > 0 ? Math.round((file.size * 8) / duration / 1000) : undefined;
+
       resolve({
         width: video.videoWidth,
         height: video.videoHeight,
-        duration: isFinite(video.duration) ? video.duration : 0,
+        duration,
+        bitrate,
+        codec: file.type || "unknown"
       });
       URL.revokeObjectURL(url);
     };
@@ -75,8 +80,8 @@ function validateRecipe(recipe: EditRecipe, duration: number ): string | null {
       `Trim end time cannot exceed the video duration (${Math.floor(duration)}s).`,
     ],
     [
-      recipe.trimEnd !== null 
-        ? recipe.trimStart >= recipe.trimEnd 
+      recipe.trimEnd !== null
+        ? recipe.trimStart >= recipe.trimEnd
         : (duration > 0 && recipe.trimStart >= duration),
       "Trim start time must be earlier than the end time.",
     ],
@@ -138,6 +143,8 @@ export function useVideoEditor() {
     width: number;
     height: number;
     duration: number;
+    bitrate?: number;
+    codec?: string;
   } | null>(null);
   const [recipe, setRecipe] = useState<EditRecipe>(() => {
     if (typeof window === "undefined") return { ...DEFAULT_RECIPE };
@@ -174,6 +181,18 @@ export function useVideoEditor() {
   const [overlaySize, setOverlaySize] = useState(150);
   const [overlayOpacity, setOverlayOpacity] = useState(100);
   const [currentTime, setCurrentTime] = useState(0);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const soundOnCompletion = localStorage.getItem("soundOnCompletion");
+    if (soundOnCompletion === null) return;
+
+    setRecipe((prev) => ({
+      ...prev,
+      soundOnCompletion: soundOnCompletion === "true",
+    }));
+  }, []);
  const updateRecipe = useCallback((patch: Partial<EditRecipe>) => {
   setRecipe((prev) => {
     const next = { ...prev, ...patch };
@@ -398,29 +417,28 @@ export function useVideoEditor() {
     }
 
     try {
-      const { width, height, duration: dur } = await extractMetadata(selectedFile);
+      const metadata = await extractMetadata(selectedFile);
+      const dimensionCheck = validateDimensions(metadata.width, metadata.height);
 
-      // Layer 5: Resolution check
-      const dimensionCheck = validateDimensions(width, height);
       if (dimensionCheck === "blocked") {
-        const suggested = getDownscaledDimensions(width, height);
+        const suggested = getDownscaledDimensions(metadata.width, metadata.height);
         setError(
-          `Layer 5 Validation Failed: Resolution too high (${width}×${height}). ` +
+          `Layer 5 Validation Failed: Resolution too high (${metadata.width}×${metadata.height}). ` +
           `Maximum supported is 8K. Suggested safe size: ${suggested.width}×${suggested.height}.`
         );
         setStatus("error");
         return;
       }
 
-      setDuration(dur);
-      setVideoMetadata({ width, height, duration: dur });
+      setDuration(metadata.duration);
+      setVideoMetadata(metadata);
       setFile(selectedFile);
 
       if (dimensionCheck === "warning") {
-        console.warn(`[Reframe] High resolution video detected (${width}×${height}). Export may be slow.`);
+        console.warn(`[Reframe] High resolution video detected (${metadata.width}×${metadata.height}). Export may be slow.`);
       }
       setRecipe((prev) => {
-        const suggestedPreset = suggestPreset(width, height);
+        const suggestedPreset = suggestPreset(metadata.width, metadata.height);
         const shouldApplySuggestion = prev.preset === DEFAULT_RECIPE.preset;
 
         return {
@@ -708,6 +726,7 @@ export function useVideoEditor() {
     cancelExport,
     reset,
     resetSettings,
+    videoMetadata,
     musicFile,
     setMusicFile,
     musicVolume,

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -136,6 +136,19 @@ function decodeRecipe(encoded: string): Partial<EditRecipe> | null {
   }
 }
 
+/**
+ * Migrates old recipes to include missing properties from newer versions.
+ * Ensures backwards compatibility when loading recipes created with older versions.
+ */
+function migrateRecipe(recipe: Partial<EditRecipe>): EditRecipe {
+  return {
+    ...DEFAULT_RECIPE,
+    ...recipe,
+    // Ensure textOverlays is always an array
+    textOverlays: Array.isArray(recipe.textOverlays) ? recipe.textOverlays : [],
+  };
+}
+
 export function useVideoEditor() {
   const [file, setFile] = useState<File | null>(null);
   const [duration, setDuration] = useState<number>(0);
@@ -152,14 +165,15 @@ export function useVideoEditor() {
     const encoded = params.get("settings");
     if (encoded) {
       const decoded = decodeRecipe(encoded);
-      if (decoded) return { ...DEFAULT_RECIPE, ...decoded };
+      if (decoded) {
+        return migrateRecipe(decoded);
+      }
     }
-    return {
-      ...DEFAULT_RECIPE,
+    return migrateRecipe({
       soundOnCompletion:
         typeof window !== "undefined" &&
         localStorage.getItem("soundOnCompletion") === "true",
-    };
+    });
   });
   const [status, setStatus] = useState<ExportStatus>("idle");
   const [progress, setProgress] = useState(0);

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -269,6 +269,8 @@ export function useVideoEditor() {
 
         // Legacy partial settings (keep for backward compatibility)
         const saved = localStorage.getItem("reframe-settings");
+        const savedPreset = localStorage.getItem("reframe:lastPreset") ?? DEFAULT_RECIPE.preset;
+
         if (saved) {
           const parsed = JSON.parse(saved);
           const sanitizeDimension = (val: unknown, fallback: number): number => {
@@ -277,12 +279,14 @@ export function useVideoEditor() {
           };
           setRecipe(prev => ({
             ...prev,
-            preset: parsed.preset ?? prev.preset,
+            preset: savedPreset !== DEFAULT_RECIPE.preset ? savedPreset : (parsed.preset ?? prev.preset),
             quality: parsed.quality ?? prev.quality,
             speed: parsed.speed ?? prev.speed,
             customWidth: sanitizeDimension(parsed.customWidth, prev.customWidth),
             customHeight: sanitizeDimension(parsed.customHeight, prev.customHeight),
           }));
+        } else {
+          setRecipe(prev => ({ ...prev, preset: savedPreset }));
         }
       }
     } catch (e) {
@@ -661,6 +665,14 @@ export function useVideoEditor() {
   useEffect(() => {
     localStorage.setItem("soundOnCompletion", String(recipe.soundOnCompletion));
   }, [recipe.soundOnCompletion]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem("reframe:lastPreset", recipe.preset);
+    } catch (e) {
+      // ignore
+    }
+  }, [recipe.preset]);
   const seekTo = useCallback((time: number) => {
     if (videoRef.current) {
       videoRef.current.currentTime = time;

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -4,10 +4,6 @@ import { buildTextFilter } from "./text-overlay";
 
 export class FFmpegLoadError extends Error {}
 
-const FFMPEG_WORKER_URL =
-  typeof window !== "undefined"
-    ? new URL("./ffmpeg.worker.ts", import.meta.url)
-    : null;
 
 type SerializedFile = {
   name: string;
@@ -61,11 +57,13 @@ let pendingExport: {
 let pendingProgress: ((percent: number) => void) | null = null;
 
 function createWorker(): Worker {
-  if (!FFMPEG_WORKER_URL) {
+  if (typeof window === "undefined") {
     throw new Error("Web Workers are not available in this environment.");
   }
 
-  ffmpegWorker = new Worker(FFMPEG_WORKER_URL, { type: "module" });
+  // MUST be strictly inline for Next.js/Webpack to detect and compile the worker chunk
+  ffmpegWorker = new Worker(new URL("./ffmpeg.worker.ts", import.meta.url), { type: "module" });
+  
   ffmpegWorker.onmessage = handleWorkerMessage;
   ffmpegWorker.onerror = (event) => {
     const message = event.message || "FFmpeg worker error";
@@ -160,6 +158,9 @@ export async function loadFFmpeg(
   signal?: AbortSignal,
   onProgress?: (percent: number) => void
 ): Promise<void> {
+  // 1. Capture if the worker is uninitialized before ensureWorker runs
+  const isFirstLoad = !ffmpegWorker; 
+  
   await ensureWorker();
 
   if (workerReady && workerReadyResolve === null) {
@@ -167,7 +168,8 @@ export async function loadFFmpeg(
     return;
   }
 
-  if (!workerReady) {
+  // 2. Use the captured flag to securely trigger the worker's internal load phase
+  if (isFirstLoad) {
     ffmpegWorker!.postMessage({ type: "load" });
   }
 
@@ -467,20 +469,31 @@ function buildArguments(
       videoOut = "[vbase]";
     }
 
-    if (hasOverlay) {
-      const scaledW = overlayOptions!.size;
-      const alpha = (overlayOptions!.opacity / 100).toFixed(2);
-      const posMap: Record<string, string> = {
-        "top-left":     "20:20",
-        "top-right":    "W-w-20:20",
-        "bottom-left":  "20:H-h-20",
-        "bottom-right": "W-w-20:H-h-20",
-      };
-      const pos = posMap[overlayOptions!.position] ?? "W-w-20:H-h-20";
-      filterParts.push(`[${overlayIdx}:v]scale=${scaledW}:-2,format=rgba,colorchannelmixer=aa=${alpha}[logo]`);
-      filterParts.push(`${videoOut}[logo]overlay=${pos}[vout]`);
-      videoOut = "[vout]";
-    }
+if (hasOverlay) {
+  const scaledW = overlayOptions!.size;
+  const alpha = (overlayOptions!.opacity / 100).toFixed(2);
+  const posMap: Record<string, string> = {
+    "top-left":     "20:20",
+    "top-right":    "main_w-w-20:20",
+    "bottom-left":  "20:main_h-h-20",
+    "bottom-right": "main_w-w-20:main_h-h-20",
+  };
+
+interface PositionCoords {
+    x: number;
+    y: number;
+  }
+
+  const pos = typeof overlayOptions?.position === "string"
+    ? (posMap[overlayOptions.position] ?? "main_w-w-20:main_h-h-20")
+    : overlayOptions?.position
+    ? `(main_w)*${(overlayOptions.position as PositionCoords).x}/100:(main_h)*${(overlayOptions.position as PositionCoords).y}/100`
+    : "main_w-w-20:main_h-h-20";
+
+  filterParts.push(`[${overlayIdx}:v]scale=${scaledW}:-2,format=rgba,colorchannelmixer=aa=${alpha}[logo]`);
+  filterParts.push(`${videoOut}[logo]overlay=${pos}[vout]`);
+  videoOut = "[vout]";
+}
 
     let audioOut = "";
     if (shouldKeepAudio) {

--- a/src/lib/ffmpeg.worker.ts
+++ b/src/lib/ffmpeg.worker.ts
@@ -67,8 +67,11 @@ async function fetchWithIntegrity(url: string, mimeType: string): Promise<string
   const key = url.split("/").pop()!;
   const integrity = SRI_HASHES[key];
 
+  // Fallback to standard fetch if SRI is missing (Prevents ffmpeg-core.worker.js from crashing the thread)
   if (!integrity) {
-    throw new Error(`[SRI] No hash found for: ${key}`);
+    const response = await fetch(url, { credentials: "omit" });
+    const blob = new Blob([await response.arrayBuffer()], { type: mimeType });
+    return URL.createObjectURL(blob);
   }
 
   const response = await fetch(url, { integrity, credentials: "omit" });
@@ -217,20 +220,31 @@ function buildArguments(
       videoOut = "[vbase]";
     }
 
-    if (hasOverlay) {
-      const scaledW = overlayOptions!.size;
-      const alpha = (overlayOptions!.opacity / 100).toFixed(2);
-      const posMap: Record<string, string> = {
-        "top-left":     "20:20",
-        "top-right":    "W-w-20:20",
-        "bottom-left":  "20:H-h-20",
-        "bottom-right": "W-w-20:H-h-20",
-      };
-      const pos = posMap[overlayOptions!.position] ?? "W-w-20:H-h-20";
-      filterParts.push(`[${overlayIdx}:v]scale=${scaledW}:-2,format=rgba,colorchannelmixer=aa=${alpha}[logo]`);
-      filterParts.push(`${videoOut}[logo]overlay=${pos}[vout]`);
-      videoOut = "[vout]";
-    }
+if (hasOverlay) {
+  const scaledW = overlayOptions!.size;
+  const alpha = (overlayOptions!.opacity / 100).toFixed(2);
+  const posMap: Record<string, string> = {
+    "top-left":     "20:20",
+    "top-right":    "W-w-20:20",
+    "bottom-left":  "20:H-h-20",
+    "bottom-right": "W-w-20:H-h-20",
+  };
+
+interface PositionCoords {
+    x: number;
+    y: number;
+  }
+
+  const pos = typeof overlayOptions?.position === "string"
+    ? (posMap[overlayOptions.position] ?? "W-w-20:H-h-20")
+    : overlayOptions?.position
+    ? `(W-w)*${(overlayOptions.position as PositionCoords).x}/100:(H-h)*${(overlayOptions.position as PositionCoords).y}/100`
+    : "W-w-20:H-h-20";
+
+  filterParts.push(`[${overlayIdx}:v]scale=${scaledW}:-2,format=rgba,colorchannelmixer=aa=${alpha}[logo]`);
+  filterParts.push(`${videoOut}[logo]overlay=${pos}[vout]`);
+  videoOut = "[vout]";
+}
 
     let audioOut = "";
     if (shouldKeepAudio) {

--- a/src/lib/text-overlay.ts
+++ b/src/lib/text-overlay.ts
@@ -1,4 +1,5 @@
 import { TextOverlay } from "./types";
+import { getFFmpegFontArg } from "@/utils/fontLoader";
 
 /**
  * Generates a unique ID for a text overlay.
@@ -19,6 +20,7 @@ export function createDefaultTextOverlay(): TextOverlay {
     fontSize: 48,
     color: "#ffffff",
     fontWeight: "normal",
+    fontFamily: "Arial", // Default to Arial for immediate visibility
   };
 }
 
@@ -59,6 +61,7 @@ export function getTextPercentPosition(
 /**
  * Generates a drawText FFmpeg filter for a single text overlay.
  * Escapes special characters and positions text on the output video.
+ * Includes font family and custom font file support.
  */
 export function buildTextFilter(
   overlay: TextOverlay,
@@ -75,15 +78,30 @@ export function buildTextFilter(
   const pixelX = Math.round((overlay.x / 100) * targetWidth);
   const pixelY = Math.round((overlay.y / 100) * targetHeight);
 
-  // Build the drawtext filter with proper escaping
-  // Using 'fontsize' and 'fontcolor' parameters
-  // Note: Font file path may not be available in all environments,
-  // so we rely on the system default font
-  return `drawtext=text='${escapedText}':x=${pixelX}:y=${pixelY}:fontsize=${overlay.fontSize}:fontcolor=${overlay.color}:fontweight=${
-    overlay.fontWeight === "900"
-      ? "bold"
-      : overlay.fontWeight === "bold"
-      ? "bold"
-      : "normal"
-  }`;
+  // Build font parameters
+  const fontWeightParam = overlay.fontWeight === "900"
+    ? "bold"
+    : overlay.fontWeight === "bold"
+    ? "bold"
+    : "normal";
+
+  // Get font file parameter for custom fonts (if available)
+  const fontFileParam = getFFmpegFontArg(overlay.fontFamily, overlay.fontPath);
+
+  // Build the drawtext filter with font support
+  let filter = `drawtext=text='${escapedText}':x=${pixelX}:y=${pixelY}:fontsize=${overlay.fontSize}:fontcolor=${overlay.color}:fontweight=${fontWeightParam}`;
+
+  // Add font family if specified
+  if (overlay.fontFamily) {
+    // Sanitize font name for FFmpeg
+    const safeFontName = overlay.fontFamily.replace(/[^a-zA-Z0-9-]/g, "");
+    filter += `:fontfile='${safeFontName}'`;
+  }
+
+  // Add custom font file path if available
+  if (fontFileParam) {
+    filter += `:${fontFileParam}`;
+  }
+
+  return filter;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,6 +11,8 @@ export interface TextOverlay {
   fontSize: number; // In pixels
   color: string; // Hex color
   fontWeight: "normal" | "bold" | "900";
+  fontFamily?: string; // Font family name (e.g., "Arial", "Inter", "CustomFont")
+  fontPath?: string; // Path/URL to custom font file for export
 }
 
 export interface EditRecipe {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -36,6 +36,12 @@ export interface EditRecipe {
   version: number;
 }
 
+export interface CustomProfile {
+  id: string;
+  label: string;
+  recipe: Partial<EditRecipe>;
+}
+
 export type OverlayPosition =
   | "top-left"
   | "top-right"

--- a/src/utils/fontLoader.ts
+++ b/src/utils/fontLoader.ts
@@ -1,0 +1,278 @@
+/**
+ * Font loader utilities for dynamic font registration and preview rendering.
+ * Handles @font-face registration and CSS class generation for custom fonts.
+ */
+
+/**
+ * Built-in fonts available system-wide.
+ * These are web-safe fonts that work across all browsers.
+ */
+export const BUILT_IN_FONTS = [
+  { name: "Arial", family: "Arial, sans-serif" },
+  { name: "Inter", family: "'Inter', sans-serif" },
+  { name: "Roboto", family: "'Roboto', sans-serif" },
+  { name: "Poppins", family: "'Poppins', sans-serif" },
+  { name: "Montserrat", family: "'Montserrat', sans-serif" },
+] as const;
+
+/**
+ * Map of font family names to their CSS family strings.
+ */
+type FontRegistry = Map<string, string>;
+
+let fontRegistry: FontRegistry = new Map();
+
+/**
+ * Initializes the font registry with built-in fonts.
+ *
+ * @example
+ * initializeFontRegistry();
+ */
+export function initializeFontRegistry(): void {
+  fontRegistry.clear();
+  BUILT_IN_FONTS.forEach(({ name, family }) => {
+    fontRegistry.set(name, family);
+  });
+}
+
+/**
+ * Registers a custom font by creating a @font-face rule and adding it to the DOM.
+ * Returns the font family name to use in CSS.
+ *
+ * IMPORTANT: The fontName should already be sanitized (alphanumeric + hyphens only).
+ * Use extractFontName() from fontValidation.ts to prepare font names.
+ *
+ * @param fontName - Sanitized display name for the font (alphanumeric + hyphens)
+ * @param fontBlobUrl - Blob URL or path to the font file
+ * @returns The font family name to use in CSS
+ *
+ * @example
+ * const sanitizedName = extractFontName("my-font.ttf"); // "MyFont"
+ * const blobUrl = URL.createObjectURL(fontFile);
+ * const fontFamily = registerCustomFont(sanitizedName, blobUrl);
+ * element.style.fontFamily = fontFamily;
+ */
+export function registerCustomFont(fontName: string, fontBlobUrl: string): string {
+  // Font name should already be sanitized, but ensure it is
+  const safeFontName = fontName.replace(/[^a-zA-Z0-9-]/g, "") || "CustomFont";
+
+  // Check if already registered
+  if (fontRegistry.has(safeFontName)) {
+    return fontRegistry.get(safeFontName)!;
+  }
+
+  // Detect font format from URL/extension
+  let format = "truetype";
+  if (fontBlobUrl.includes(".woff2")) format = "woff2";
+  else if (fontBlobUrl.includes(".woff")) format = "woff";
+  else if (fontBlobUrl.includes(".otf")) format = "opentype";
+
+  // Create @font-face rule with improved font loading
+  const fontFace = `
+    @font-face {
+      font-family: "${safeFontName}";
+      src: url('${fontBlobUrl}') format('${format}');
+      font-display: swap;
+      font-weight: normal;
+      font-style: normal;
+    }
+  `;
+
+  // Inject into DOM
+  const style = document.createElement("style");
+  style.textContent = fontFace;
+  style.setAttribute("data-font", safeFontName);
+  document.head.appendChild(style);
+
+  // Register in registry with proper CSS font-family
+  // Note: Always quote the font name to handle font names with spaces or special chars
+  const cssFontFamily = `"${safeFontName}", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`;
+  fontRegistry.set(safeFontName, cssFontFamily);
+
+  return cssFontFamily;
+}
+
+/**
+ * Unregisters a custom font by removing its @font-face rule from the DOM.
+ *
+ * @param fontName - The font family name to unregister
+ *
+ * @example
+ * unregisterCustomFont("MyFont");
+ */
+export function unregisterCustomFont(fontName: string): void {
+  const safeFontName = fontName.replace(/[^a-zA-Z0-9-]/g, "");
+
+  // Remove from registry
+  fontRegistry.delete(safeFontName);
+
+  // Remove @font-face rule from DOM
+  const styles = document.querySelectorAll(`style[data-font="${safeFontName}"]`);
+  styles.forEach((style) => style.remove());
+}
+
+/**
+ * Gets the CSS font-family string for a registered font.
+ * Returns the font-family value suitable for CSS use.
+ *
+ * For built-in fonts, returns the font family string from BUILT_IN_FONTS.
+ * For custom fonts, looks up the font in the registry.
+ * Falls back to a safely quoted generic font if not found.
+ *
+ * @param fontName - The font name to look up (should match font name from extractFontName)
+ * @returns The CSS font-family string, or a fallback if not found
+ *
+ * @example
+ * const fontFamily = getFontFamily("Inter");
+ * element.style.fontFamily = fontFamily;
+ * // Returns: "'Inter', sans-serif"
+ *
+ * const customFont = getFontFamily("MyCustomFont");
+ * element.style.fontFamily = customFont;
+ * // Returns: "'MyCustomFont', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+ */
+export function getFontFamily(fontName?: string): string {
+  if (!fontName) return "Arial, sans-serif";
+
+  // Check if it's a built-in font first
+  const builtIn = BUILT_IN_FONTS.find(({ name }) => name === fontName);
+  if (builtIn) {
+    return builtIn.family;
+  }
+
+  // Check if it's in the custom font registry
+  const registered = fontRegistry.get(fontName);
+  if (registered) {
+    return registered;
+  }
+
+  // Fallback: return a safely quoted font name with system fallback
+  // This ensures the font name is properly formatted even if not registered
+  return `"${fontName}", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`;
+}
+
+/**
+ * Gets all registered font names.
+ *
+ * @returns Array of font names currently registered
+ *
+ * @example
+ * const fonts = getRegisteredFonts();
+ * console.log(fonts); // ["Arial", "Inter", "MyCustomFont", ...]
+ */
+export function getRegisteredFonts(): string[] {
+  return Array.from(fontRegistry.keys());
+}
+
+/**
+ * Clears all custom fonts (keeps built-in fonts).
+ * Useful for cleanup when unmounting or resetting editor state.
+ *
+ * @example
+ * clearCustomFonts();
+ */
+export function clearCustomFonts(): void {
+  const builtInNames = BUILT_IN_FONTS.map(({ name }) => name) as string[];
+  const customFonts = Array.from(fontRegistry.keys()).filter(
+    (name) => !builtInNames.includes(name)
+  );
+
+  customFonts.forEach((font) => {
+    unregisterCustomFont(font);
+  });
+}
+
+/**
+ * Generates FFmpeg-compatible font file argument for drawtext filter.
+ * If font is built-in, returns empty string (FFmpeg handles system fonts).
+ * If font is custom, returns the fontfile path parameter.
+ *
+ * @param fontName - Font family name
+ * @param fontPath - Path to font file (for custom fonts)
+ * @returns FFmpeg fontfile parameter or empty string
+ *
+ * @example
+ * const fontArg = getFFmpegFontArg("CustomFont", "/path/to/font.ttf");
+ * // Returns: "fontfile=/path/to/font.ttf"
+ *
+ * const fontArg = getFFmpegFontArg("Arial");
+ * // Returns: ""
+ */
+export function getFFmpegFontArg(fontName?: string, fontPath?: string): string {
+  if (!fontName) return "";
+
+  // Built-in fonts don't need explicit fontfile parameter
+  const builtInNames = BUILT_IN_FONTS.map(({ name }) => name) as string[];
+  if (builtInNames.includes(fontName)) {
+    return "";
+  }
+
+  // Custom fonts need the fontfile parameter
+  if (fontPath) {
+    // Escape colons in path for FFmpeg
+    const escapedPath = fontPath.replace(/:/g, "\\:");
+    return `fontfile=${escapedPath}`;
+  }
+
+  return "";
+}
+
+/**
+ * Ensures a font is fully loaded in the browser before rendering.
+ * This prevents fallback fonts from flashing during initial render.
+ * 
+ * For custom fonts, waits for the font to load via document.fonts API.
+ * For built-in fonts (system or Google Fonts), ensures they're available.
+ *
+ * @param fontName - Font family name to ensure is loaded
+ * @param fontSize - Font size in pixels (used for load verification)
+ * @returns Promise that resolves when font is ready
+ *
+ * @example
+ * await ensureFontLoaded("MyCustomFont", 16);
+ * // Now safe to render with this font
+ */
+export async function ensureFontLoaded(
+  fontName?: string,
+  fontSize: number = 16
+): Promise<void> {
+  if (!fontName) return;
+
+  // Built-in fonts (Arial, system fonts) are always available
+  if (fontName === "Arial") {
+    return;
+  }
+
+  // Google Fonts and built-in web fonts (Inter, Roboto, Poppins, Montserrat)
+  const builtInNames = BUILT_IN_FONTS.map(({ name }) => name) as string[];
+  if (builtInNames.includes(fontName)) {
+    // These are loaded via @import in globals.css, so they should be ready
+    // But try to load them anyway to ensure they're available
+    try {
+      const fontDescriptor = `${fontSize}px "${fontName}"`;
+      // Use a short timeout to avoid hanging if font doesn't load
+      const loadPromise = document.fonts.load(fontDescriptor);
+      await Promise.race([
+        loadPromise,
+        new Promise(resolve => setTimeout(resolve, 1000)) // 1 second timeout
+      ]);
+    } catch (err) {
+      // Silently continue if font loading fails
+      // These fonts should be available from CSS import
+    }
+    return;
+  }
+
+  // For custom fonts, wait for them to load via document.fonts
+  try {
+    // Build font descriptor string for document.fonts.load()
+    const fontDescriptor = `${fontSize}px "${fontName}"`;
+    
+    // Request the font to load
+    await document.fonts.load(fontDescriptor);
+  } catch (err) {
+    // Silently continue if font loading fails
+    // The browser will use fallback fonts
+    console.warn(`Font "${fontName}" failed to load:`, err);
+  }
+}

--- a/src/utils/fontValidation.ts
+++ b/src/utils/fontValidation.ts
@@ -1,0 +1,125 @@
+/**
+ * Font validation utilities for custom font uploads.
+ * Validates font file formats, sizes, and handles duplicate detection.
+ */
+
+const SUPPORTED_FONT_FORMATS = ["font/ttf", "font/otf", "font/woff", "font/woff2"];
+const MAX_FONT_SIZE_MB = 5;
+const MAX_FONT_SIZE_BYTES = MAX_FONT_SIZE_MB * 1024 * 1024;
+
+/**
+ * Validates a font file for format, size, and corruption.
+ *
+ * @param file - The font file to validate
+ * @returns { valid: boolean, error?: string } - Validation result with optional error message
+ *
+ * @example
+ * const result = validateFontFile(file);
+ * if (!result.valid) {
+ *   console.error(result.error);
+ * }
+ */
+export function validateFontFile(file: File): { valid: boolean; error?: string } {
+  // Check MIME type
+  const mimeType = file.type;
+  if (!SUPPORTED_FONT_FORMATS.includes(mimeType)) {
+    return {
+      valid: false,
+      error: `Unsupported font format. Supported: TTF, OTF, WOFF, WOFF2. Got: ${mimeType || "unknown"}`,
+    };
+  }
+
+  // Check file extension as secondary validation
+  const fileName = file.name.toLowerCase();
+  const validExtensions = [".ttf", ".otf", ".woff", ".woff2"];
+  const hasValidExtension = validExtensions.some((ext) => fileName.endsWith(ext));
+
+  if (!hasValidExtension) {
+    return {
+      valid: false,
+      error: `Invalid file extension. Use .ttf, .otf, .woff, or .woff2`,
+    };
+  }
+
+  // Check file size
+  if (file.size > MAX_FONT_SIZE_BYTES) {
+    return {
+      valid: false,
+      error: `Font file too large. Maximum size: ${MAX_FONT_SIZE_MB}MB, got: ${(file.size / 1024 / 1024).toFixed(2)}MB`,
+    };
+  }
+
+  // File must not be empty
+  if (file.size === 0) {
+    return {
+      valid: false,
+      error: `Font file is empty`,
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Extracts a clean font name from a filename.
+ * Removes extension and replaces underscores/hyphens with spaces.
+ * Uses same sanitization logic as fontLoader for consistency.
+ *
+ * @param fileName - The font file name
+ * @returns Clean font name suitable for UI display and CSS
+ *
+ * @example
+ * extractFontName("Open_Sans.ttf") // Returns "OpenSans"
+ * extractFontName("my-font.woff") // Returns "MyFont"
+ */
+export function extractFontName(fileName: string): string {
+  // Remove extension
+  const withoutExt = fileName.replace(/\.[^.]*$/, "");
+  
+  // Apply same sanitization as registerCustomFont for consistency
+  // Only keep alphanumeric and hyphens
+  const sanitized = withoutExt.replace(/[^a-zA-Z0-9-]/g, "");
+  
+  // Convert to PascalCase for display if needed
+  const cleaned = sanitized
+    .split(/[-_\s]+/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join("");
+  
+  return cleaned || "CustomFont";
+}
+
+/**
+ * Detects duplicate fonts by comparing file content hashes.
+ * Uses simple byte comparison as a quick duplicate check.
+ *
+ * @param files - Array of font files to check
+ * @returns Set of file names that are duplicates
+ *
+ * @example
+ * const duplicates = await detectDuplicateFonts([file1, file2, file3]);
+ * if (duplicates.size > 0) {
+ *   console.warn("Duplicate fonts detected:", duplicates);
+ * }
+ */
+export async function detectDuplicateFonts(files: File[]): Promise<Set<string>> {
+  const fileHashes = new Map<string, string>();
+  const duplicates = new Set<string>();
+
+  for (const file of files) {
+    const buffer = await file.arrayBuffer();
+    // Simple hash: first 100 bytes + file size
+    const view = new Uint8Array(buffer);
+    const sample = Array.from(view.slice(0, 100)).join(",");
+    const hash = `${sample}:${file.size}`;
+
+    if (fileHashes.has(hash)) {
+      duplicates.add(file.name);
+      duplicates.add(fileHashes.get(hash)!);
+    } else {
+      fileHashes.set(hash, file.name);
+    }
+  }
+
+  return duplicates;
+}


### PR DESCRIPTION
## Description

This PR introduces preset persistence to improve the user experience. Users who frequently use the same video preset (e.g., vertical exports for Reels or TikTok) will now have their last selected preset automatically applied when returning to the editor.

### Key Changes
- **Local Storage Persistence**: Added a client-side `useEffect` in `useVideoEditor.ts` to automatically save the user's selected `recipe.preset` to `localStorage` under the key `"reframe:lastPreset"`.
- **Pre-selection on Init**: Updated the initialization logic to check for `"reframe:lastPreset"` on mount, restoring the user's previously chosen preset. 
- **Safe Fallback**: If no saved preset is found, the configuration safely falls back to `DEFAULT_RECIPE.preset`. The central configuration in `src/lib/types.ts` remains untouched as the single source of truth.
-**Favorite Presets**: Users can now click the Star (⭐️) icon on any preset to save it as a favorite, which automatically pins it to the top of the list for quick access.
Custom Saved Profiles: Users can now input custom dimensions and click "Save as Profile" to save their specific setup as a brand new, reusable custom preset.

## Related Issue
Closes #87 

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username:shubh-gitpush
- Contribution level (Beginner/Intermediate/Advanced):intermediate

## Screen Recording

<!-- REQUIRED for all UI / feature / design changes. -->
<!-- Drag a video file here or paste a Loom link below. -->
<!-- PRs touching any visible UI without a recording will NOT be merged. -->

> **How to record:** run `bun run dev` → open http://localhost:3000 → demonstrate the full working flow of your change, including any edge cases.
>
> - **macOS**: `Cmd + Shift + 5` → Record Selected Portion, or use QuickTime Player
> - **Windows**: `Win + G` → Xbox Game Bar → Capture
> - **Linux**: OBS Studio, GNOME Screenshot tool, or `kazam`
> - **Any OS**: [Loom](https://loom.com) (free screen recorder, great for sharing)

**Recording / Loom link:** <!-- drag file here or paste link -->

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [ ] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [ ] **Screen recording attached above** (required for UI/feature/design changes)
