### PR TITLE
feat: add hover effects to footer feature badges

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -33,7 +33,7 @@ export default function Footer() {
               { icon: <Zap size={12}/>, label: "Fast" },
               { icon: <Globe size={12}/>, label: "Open Source" }
             ].map((tag) => (
-              <span key={tag.label} className="flex items-center gap-1.5 px-3 py-1 rounded-lg border border-[var(--border)] bg-[var(--surface)] text-[10px] font-semibold tracking-wide uppercase">
+              <span key={tag.label} className="flex items-center gap-1.5 px-3 py-1 rounded-lg border border-[var(--border)] bg-[var(--surface)] text-[10px] font-semibold tracking-wide uppercase transition-all duration-200 ease-in-out hover:-translate-y-0.5 hover:border-[var(--accent)] hover:shadow-[0_0_10px_rgba(255,255,255,0.08)] cursor-pointer select-none">
                 {tag.icon} {tag.label}
               </span>
             ))}


### PR DESCRIPTION
## Description
Adds subtle interactive hover styles to the `100% LOCAL`, `FAST`, and `OPEN SOURCE` badges in `Footer.tsx` using Tailwind utility classes only. The badges previously had no visual response on hover, making them feel static despite resembling interactive UI components.

Changes made to `src/components/Footer.tsx`:
- `transition-all duration-200 ease-in-out` for smooth animation
- `hover:-translate-y-0.5` for a slight lift effect
- `hover:border-[var(--accent)]` to highlight with the design system accent color
- `hover:shadow-[0_0_10px_rgba(255,255,255,0.08)]` for a subtle glow
- `cursor-pointer` and `select-none` for better UX

No click handlers or `href` attributes were added — badges remain non-interactive beyond the visual feedback.

## Related Issue
Closes #806

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: @Pranav-IIITM
- Contribution level: Beginner

## Screen Recording

https://github.com/user-attachments/assets/e5d5ea12-79ce-4409-afcb-4c40c6c0054b



## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)