### PR TITLE
feat: persist editor settings to localStorage (#656)

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -1,13 +1,14 @@
 "use client";
 
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
-import { EditRecipe, ExportResult, ExportStatus, MAX_FILE_SIZE, OverlayPosition } from "@/lib/types";
+import { EditRecipe, ExportResult, ExportStatus, MAX_FILE_SIZE, OverlayPosition, isValidRecipe } from "@/lib/types";
 import { DEFAULT_RECIPE, SPEED_STEPS } from "@/lib/constants";
 import { getPresetById } from "@/lib/presets";
 import { loadFFmpeg, exportVideo, terminateFFmpeg, FFmpegLoadError } from "@/lib/ffmpeg";
 import { suggestPreset } from "@/lib/presetSuggestion";
 
 const DEFAULT_TITLE = "Reframe — Resize, trim, and export videos in your browser";
+  const STORAGE_KEY = "reframe:recipe";
 
 export function extractMetadata(file: File): Promise<{ width: number; height: number; duration: number }> {
   return new Promise((resolve, reject) => {
@@ -226,6 +227,21 @@ export function useVideoEditor() {
           }));
         }
       } else {
+        // Try full recipe restore first (new key)
+        try {
+          const raw = localStorage.getItem(STORAGE_KEY);
+          if (raw) {
+            const parsed = JSON.parse(raw);
+            if (isValidRecipe(parsed)) {
+              setRecipe(parsed);
+              return;
+            }
+          }
+        } catch {
+          // ignore parse/validation errors and fall back to legacy
+        }
+
+        // Legacy partial settings (keep for backward compatibility)
         const saved = localStorage.getItem("reframe-settings");
         if (saved) {
           const parsed = JSON.parse(saved);
@@ -286,6 +302,19 @@ export function useVideoEditor() {
       // ignore
     }
   }, [recipe.preset, recipe.quality, recipe.speed, recipe.customWidth, recipe.customHeight]);
+
+  // Persist the full recipe (debounced)
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const timer = setTimeout(() => {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(recipe));
+      } catch {
+        // ignore
+      }
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [recipe]);
 
   const recommendedPreset = useMemo(() => {
     if (!videoMetadata) return null;
@@ -518,6 +547,11 @@ export function useVideoEditor() {
 
   const resetSettings = useCallback(() => {
     setRecipe(DEFAULT_RECIPE);
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // ignore
+    }
   }, []);
 
   const cancelExport = useCallback(() => {
@@ -541,6 +575,11 @@ export function useVideoEditor() {
     setProgress(0);
     setResult(null);
     setError(null);
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // ignore
+    }
   }, [result]);
 
   useEffect(() => {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,5 @@
 import type { EditRecipe } from "./types"
+import { RECIPE_VERSION } from "./types"
 
 export const SPEED_STEPS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 4] as const;
 
@@ -20,4 +21,5 @@ export const DEFAULT_RECIPE: EditRecipe = {
   stabilization: false,
   soundOnCompletion: false,
   normalizeAudio: false,
+  version: RECIPE_VERSION,
 };

--- a/src/lib/exportEstimate.test.ts
+++ b/src/lib/exportEstimate.test.ts
@@ -1,5 +1,6 @@
 import { estimateExportSize, formatEstimatedSize } from "./exportEstimate";
 import { EditRecipe } from "./types";
+import { describe, test, expect } from "vitest";
 
 // Minimal recipe factory — only the fields estimateExportSize cares about
 function makeRecipe(overrides: Partial<EditRecipe> = {}): EditRecipe {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,5 @@
+export const RECIPE_VERSION = 1;
+
 export interface EditRecipe {
   preset: string;
   customWidth: number;
@@ -16,6 +18,7 @@ export interface EditRecipe {
   contrast: number;
   saturation: number;
   soundOnCompletion: boolean;
+  version: number;
 }
 
 export type OverlayPosition =
@@ -82,6 +85,7 @@ export const DEFAULT_RECIPE: EditRecipe = {
   contrast: 0,
   saturation: 0,
   soundOnCompletion: false,
+  version: RECIPE_VERSION,
 };
 
 export const MAX_FILE_SIZE =
@@ -89,3 +93,29 @@ export const MAX_FILE_SIZE =
 
 export const WARNING_FILE_SIZE =
   500 * 1024 * 1024; // 500MB
+
+export function isValidRecipe(value: unknown): value is EditRecipe {
+  if (!value || typeof value !== "object") return false;
+  const v = value as any;
+
+  if (typeof v.version !== "number" || v.version !== RECIPE_VERSION) return false;
+  if (typeof v.preset !== "string") return false;
+  if (typeof v.customWidth !== "number" || !isFinite(v.customWidth)) return false;
+  if (typeof v.customHeight !== "number" || !isFinite(v.customHeight)) return false;
+  if (v.framing !== "fit" && v.framing !== "fill") return false;
+  if (typeof v.trimStart !== "number" || !isFinite(v.trimStart)) return false;
+  if (!(v.trimEnd === null || (typeof v.trimEnd === "number" && isFinite(v.trimEnd)))) return false;
+  if (![0, 90, 180, 270].includes(v.rotate)) return false;
+  if (typeof v.keepAudio !== "boolean") return false;
+  if (typeof v.normalizeAudio !== "boolean") return false;
+  if (typeof v.speed !== "number" || !isFinite(v.speed)) return false;
+  if (typeof v.quality !== "number" || !isFinite(v.quality)) return false;
+  if (!["mp4", "webm", "mkv", "gif"].includes(v.format)) return false;
+  if (typeof v.stabilization !== "boolean") return false;
+  if (typeof v.brightness !== "number" || !isFinite(v.brightness)) return false;
+  if (typeof v.contrast !== "number" || !isFinite(v.contrast)) return false;
+  if (typeof v.saturation !== "number" || !isFinite(v.saturation)) return false;
+  if (typeof v.soundOnCompletion !== "boolean") return false;
+
+  return true;
+}


### PR DESCRIPTION
## Description
Saves the current EditRecipe to localStorage whenever it changes and restores it on page load so settings survive page refreshes.

- Storage key: `reframe:recipe`
- Save: debounced useEffect (500ms) on recipe changes to avoid thrashing
- Restore: reads and validates shape + version on mount, falls back to DEFAULT_RECIPE if invalid/missing
- Reset: clears both state and localStorage

Files changed:
- `src/lib/types.ts` — added RECIPE_VERSION, version field to EditRecipe, isValidRecipe() type guard
- `src/lib/constants.ts` — added version: RECIPE_VERSION to DEFAULT_RECIPE
- `src/hooks/useVideoEditor.ts` — restore on mount, debounced save, clear on reset

## Related Issue
Closes #656

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: Pranav-IIITM
- Contribution level: Intermediate

## Screen Recording

https://github.com/user-attachments/assets/fb65677e-ad2c-4499-a182-bd1009b6164f


## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [ ] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)