### PR TITLE
feat(export-history): add session export history for last 5 exports

### DIFF
--- a/src/components/ExportHistory.tsx
+++ b/src/components/ExportHistory.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { formatBytes } from "@/lib/utils";
+import { ExportHistoryItem } from "@/lib/types";
+import { Download, Clock3, AlertTriangle } from "lucide-react";
+
+interface Props {
+  history: ExportHistoryItem[];
+  onDownload: (item: ExportHistoryItem) => void;
+}
+
+export default function ExportHistory({ history, onDownload }: Props) {
+  if (!history.length) {
+    return (
+      <div className="p-5 bg-[var(--surface)] rounded-xl border border-[var(--border)] text-sm text-[var(--muted)]">
+        No export history yet. Once you export a video, the last 5 exports will appear here.
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-5 bg-[var(--surface)] rounded-xl border border-[var(--border)] space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-heading font-semibold uppercase tracking-widest text-[var(--muted)]">
+            Export history
+          </p>
+          <p className="text-[13px] text-[var(--text)]">Last {history.length} exports in this session</p>
+        </div>
+        <span className="inline-flex items-center gap-1 text-[var(--muted)] text-xs uppercase tracking-[0.2em]">
+          <Clock3 size={14} /> Session
+        </span>
+      </div>
+
+      <div className="space-y-3">
+        {history.map((item) => (
+          <div key={item.id} className="border border-[var(--border)] rounded-2xl p-3 bg-[var(--bg)]">
+            <div className="flex items-center justify-between gap-3">
+              <div className="space-y-1">
+                <p className="text-sm font-semibold text-[var(--text)]">
+                  {item.format.toUpperCase()} • {formatBytes(item.size)}
+                </p>
+                <p className="text-xs text-[var(--muted)]">
+                  {item.width} × {item.height} • {new Date(item.createdAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+                </p>
+              </div>
+              <button
+                type="button"
+                disabled={!item.blobUrl}
+                onClick={() => onDownload(item)}
+                className="inline-flex items-center gap-2 rounded-full border px-3 py-2 text-xs font-semibold transition-colors disabled:cursor-not-allowed disabled:border-[var(--border)] disabled:text-[var(--muted)] disabled:bg-[var(--surface)]"
+              >
+                <Download size={14} />
+                {item.blobUrl ? "Download" : "Unavailable"}
+              </button>
+            </div>
+            {item.usedFallback && (
+              <div className="mt-2 inline-flex items-center gap-2 rounded-full bg-yellow-50 px-3 py-1 text-[11px] font-medium text-yellow-800">
+                <AlertTriangle size={14} /> WebM fallback used
+              </div>
+            )}
+            {item.warning && !item.usedFallback && (
+              <p className="mt-2 text-[11px] text-yellow-800">{item.warning}</p>
+            )}
+            {item.warning && item.usedFallback && (
+              <p className="mt-2 text-[11px] text-yellow-800">{item.warning}</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -15,11 +15,14 @@ import FormatSelector from "./FormatSelector";
 import ExportSettings from "./ExportSettings";
 import ExportOverlay from "./ExportOverlay";
 import DownloadResult from "./DownloadResult";
+import ExportHistory from "./ExportHistory";
+import ImageOverlay from "./ImageOverlay"
 import { cn } from "@/lib/utils";
 import {
   Layers, Crop, Scissors, RotateCw, Volume2,
   SlidersHorizontal, Zap, AlertTriangle, Github
 } from "lucide-react";
+import OnboardingTour from "./OnboardingTour";
 
 interface SectionProps {
   icon: React.ReactNode;
@@ -48,11 +51,18 @@ function Section({ icon, title, children, delay = 0 }: SectionProps) {
 
 export default function VideoEditor() {
   const {
-    file, duration, recipe, status, progress,
+   file, duration, recipe, status, progress,
     result, error, updateRecipe,
     handleFileSelect, fileError, handleExport, cancelExport, reset, resetSettings,
     videoRef,
     seekTo,
+    overlayFile, setOverlayFile,
+    overlayPosition, setOverlayPosition,
+    overlaySize, setOverlaySize,
+    overlayOpacity, setOverlayOpacity,
+    exportHistory,
+    downloadHistoryItem,
+    recommendedPreset,
   } = useVideoEditor();
   const [copied, setCopied] = useState(false);
   const downloadRef = useRef<HTMLDivElement>(null);
@@ -83,6 +93,7 @@ export default function VideoEditor() {
   return (
     <div className="min-h-screen relative flex flex-col" style={{ background: "var(--bg)" }}>
       <ExportOverlay status={status} progress={progress} onCancel={cancelExport} />
+      <OnboardingTour />
 
       <div aria-live="polite" aria-atomic="true" className="sr-only">
         {status === "exporting" && `Exporting video: ${progress}%`}
@@ -109,9 +120,9 @@ export default function VideoEditor() {
 
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-5">
 
-          <div className="space-y-4">
+          <div className="space-y-4 min-w-0">
             <div className="bg-[var(--surface)] rounded-xl p-5 border border-[var(--border)] animate-fade-in">
-              <FileUpload onFileSelect={handleFileSelect} currentFile={file} fileError={fileError} />
+              <FileUpload onFileSelect={handleFileSelect} currentFile={file} fileError={fileError} duration={duration} />
 
               {!file && (
               <div className="text-center text-[var(--muted)] py-6">
@@ -142,7 +153,7 @@ export default function VideoEditor() {
               <p className="text-[var(--warning)] text-sm">
                 ⚠️ Large file - processing may take several minutes
               </p>
-            )}      
+            )}
             {file && (
               <div className={cn(
                 "grid grid-cols-1 sm:grid-cols-2 gap-4",
@@ -158,115 +169,105 @@ export default function VideoEditor() {
                 </div>
                 <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6">
                   <Section icon={<Volume2 size={12} />} title="Audio & Speed" delay={150}>
-                  <Section
-  icon={<SlidersHorizontal size={12} />}
-  title="Adjustments"
-  delay={175}
->
-  <div className="space-y-5">
-
-    {/* Brightness */}
-    <div className="space-y-2">
-      <div className="flex items-center justify-between text-sm">
-        <label htmlFor="brightness-slider">Brightness</label>
-
-        <button
-          type="button"
-          onClick={() => updateRecipe({ brightness: 0 })}
-          className="text-film-500 hover:underline"
-        >
-          Reset
-        </button>
-      </div>
-
-      <input
-        id="brightness-slider"
-        type="range"
-        min="-1"
-        max="1"
-        step="0.1"
-        value={recipe.brightness}
-        onChange={(e) =>
-          updateRecipe({
-            brightness: Number(e.target.value),
-          })
-        }
-        aria-label="Adjust brightness"
-        className="w-full"
-      />
-    </div>
-
-    {/* Contrast */}
-    <div className="space-y-2">
-      <div className="flex items-center justify-between text-sm">
-        <label htmlFor="contrast-slider">Contrast</label>
-
-        <button
-          type="button"
-          onClick={() => updateRecipe({ contrast: 1 })}
-          className="text-film-500 hover:underline"
-        >
-          Reset
-        </button>
-      </div>
-
-      <input
-        id="contrast-slider"
-        type="range"
-        min="0"
-        max="2"
-        step="0.1"
-        value={recipe.contrast}
-        onChange={(e) =>
-          updateRecipe({
-            contrast: Number(e.target.value),
-          })
-        }
-        aria-label="Adjust contrast"
-        className="w-full"
-      />
-    </div>
-
-    {/* Saturation */}
-    <div className="space-y-2">
-      <div className="flex items-center justify-between text-sm">
-        <label htmlFor="saturation-slider">Saturation</label>
-
-        <button
-          type="button"
-          onClick={() => updateRecipe({ saturation: 1 })}
-          className="text-film-500 hover:underline"
-        >
-          Reset
-        </button>
-      </div>
-
-      <input
-        id="saturation-slider"
-        type="range"
-        min="0"
-        max="3"
-        step="0.1"
-        value={recipe.saturation}
-        onChange={(e) =>
-          updateRecipe({
-            saturation: Number(e.target.value),
-          })
-        }
-        aria-label="Adjust saturation"
-        className="w-full"
-      />
-    </div>
-
-  </div>
-</Section>
                     <AudioSpeedControl recipe={recipe} onChange={updateRecipe} />
+                  </Section>
+                  <Section
+                    icon={<SlidersHorizontal size={12} />}
+                    title="Adjustments"
+                    delay={175}
+                  >
+                    <div className="space-y-5">
+                      {/* Brightness */}
+                      <div className="space-y-2">
+                        <div className="flex items-center justify-between text-xs">
+                          <label htmlFor="brightness-slider">Brightness</label>
+                          <button
+                            type="button"
+                            onClick={() => updateRecipe({ brightness: 0 })}
+                            className="text-film-500 hover:underline"
+                          >
+                            Reset
+                          </button>
+                        </div>
+                        <input
+                          id="brightness-slider"
+                          type="range"
+                          min="-1"
+                          max="1"
+                          step="0.1"
+                          value={recipe.brightness}
+                          onChange={(e) => updateRecipe({ brightness: Number(e.target.value) })}
+                          aria-label="Adjust brightness"
+                          className="w-full"
+                        />
+                      </div>
+                      {/* Contrast */}
+                      <div className="space-y-2">
+                        <div className="flex items-center justify-between text-xs">
+                          <label htmlFor="contrast-slider">Contrast</label>
+                          <button
+                            type="button"
+                            onClick={() => updateRecipe({ contrast: 1 })}
+                            className="text-film-500 hover:underline"
+                          >
+                            Reset
+                          </button>
+                        </div>
+                        <input
+                          id="contrast-slider"
+                          type="range"
+                          min="0"
+                          max="2"
+                          step="0.1"
+                          value={recipe.contrast}
+                          onChange={(e) => updateRecipe({ contrast: Number(e.target.value) })}
+                          aria-label="Adjust contrast"
+                          className="w-full"
+                        />
+                      </div>
+                      {/* Saturation */}
+                      <div className="space-y-2">
+                        <div className="flex items-center justify-between text-xs">
+                          <label htmlFor="saturation-slider">Saturation</label>
+                          <button
+                            type="button"
+                            onClick={() => updateRecipe({ saturation: 1 })}
+                            className="text-film-500 hover:underline"
+                          >
+                            Reset
+                          </button>
+                        </div>
+                        <input
+                          id="saturation-slider"
+                          type="range"
+                          min="0"
+                          max="3"
+                          step="0.1"
+                          value={recipe.saturation}
+                          onChange={(e) => updateRecipe({ saturation: Number(e.target.value) })}
+                          aria-label="Adjust saturation"
+                          className="w-full"
+                        />
+                      </div>
+                    </div>
                   </Section>
                   <Section icon={<SlidersHorizontal size={12} />} title="Output format" delay={190}>
                     <FormatSelector recipe={recipe} onChange={updateRecipe} />
                   </Section>
                   <Section icon={<SlidersHorizontal size={12} />} title="Export quality" delay={200}>
-                    <ExportSettings recipe={recipe} onChange={updateRecipe} />
+                    <ExportSettings recipe={recipe} duration={duration} onChange={updateRecipe} />
+                  </Section>
+                  <Section icon={<Layers size={12} />} title="Image overlay" delay={120}>
+                    <ImageOverlay
+                      overlayFile={overlayFile}
+                      setOverlayFile={setOverlayFile}
+                      overlayPosition={overlayPosition}
+                      setOverlayPosition={setOverlayPosition}
+                      overlaySize={overlaySize}
+                      setOverlaySize={setOverlaySize}
+                      overlayOpacity={overlayOpacity}
+                      setOverlayOpacity={setOverlayOpacity}
+                    />
                   </Section>
                 </div>
               </div>
@@ -309,7 +310,7 @@ export default function VideoEditor() {
 
             {status === "done" && result && (
               <div role="status" className="animate-fade-in" ref={downloadRef}>
-                <DownloadResult result={result} onReset={reset} />
+                <DownloadResult result={result} onReset={reset} soundOnCompletion={recipe.soundOnCompletion} />
               </div>
             )}
           </div>
@@ -320,6 +321,13 @@ export default function VideoEditor() {
           )}>
             <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6 animate-fade-in" style={{ animationDelay: "50ms" }}>
               <Section icon={<Layers size={12} />} title="Output size">
+                {recommendedPreset && (
+                  <div className="mb-4 rounded-2xl border border-film-200 bg-film-50 p-3 text-sm text-film-700">
+                    <p>
+                      We detected a {recommendedPreset.label.replace(/\s/g, "")} video → Recommended: {recommendedPreset.platform.split("·")[0].trim()} ({recommendedPreset.label.replace(/\s/g, "")})
+                    </p>
+                  </div>
+                )}
                 <PresetSelector recipe={recipe} onChange={updateRecipe} />
               </Section>
 
@@ -339,6 +347,7 @@ export default function VideoEditor() {
             </div>
 
             <button
+              id="export-button"
               type="button"
               onClick={handleExport}
               disabled={!file || isProcessing}
@@ -355,6 +364,11 @@ export default function VideoEditor() {
               <Zap size={20} className={cn(file && !isProcessing && "animate-pulse")} />
               {isProcessing ? "PROCESSING" : "EXPORT"}
             </button>
+            {exportHistory.length > 0 && (
+              <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 animate-fade-in" style={{ animationDelay: "75ms" }}>
+                <ExportHistory history={exportHistory} onDownload={downloadHistoryItem} />
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -15,6 +15,7 @@ import FormatSelector from "./FormatSelector";
 import ExportSettings from "./ExportSettings";
 import ExportOverlay from "./ExportOverlay";
 import DownloadResult from "./DownloadResult";
+import ExportHistory from "./ExportHistory";
 import ImageOverlay from "./ImageOverlay"
 import { cn } from "@/lib/utils";
 import {
@@ -59,6 +60,8 @@ export default function VideoEditor() {
     overlayPosition, setOverlayPosition,
     overlaySize, setOverlaySize,
     overlayOpacity, setOverlayOpacity,
+    exportHistory,
+    downloadHistoryItem,
     recommendedPreset,
   } = useVideoEditor();
   const [copied, setCopied] = useState(false);
@@ -361,6 +364,11 @@ export default function VideoEditor() {
               <Zap size={20} className={cn(file && !isProcessing && "animate-pulse")} />
               {isProcessing ? "PROCESSING" : "EXPORT"}
             </button>
+            {exportHistory.length > 0 && (
+              <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 animate-fade-in" style={{ animationDelay: "75ms" }}>
+                <ExportHistory history={exportHistory} onDownload={downloadHistoryItem} />
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
-import { EditRecipe, ExportResult, ExportStatus, MAX_FILE_SIZE, OverlayPosition } from "@/lib/types";
+import { EditRecipe, ExportHistoryItem, ExportResult, ExportStatus, MAX_FILE_SIZE, OverlayPosition } from "@/lib/types";
 import { DEFAULT_RECIPE, SPEED_STEPS } from "@/lib/constants";
 import { getPresetById } from "@/lib/presets";
 import { loadFFmpeg, exportVideo, terminateFFmpeg, FFmpegLoadError } from "@/lib/ffmpeg";
@@ -131,6 +131,8 @@ export function useVideoEditor() {
   const [status, setStatus] = useState<ExportStatus>("idle");
   const [progress, setProgress] = useState(0);
   const [result, setResult] = useState<ExportResult | null>(null);
+  const [exportHistory, setExportHistory] = useState<ExportHistoryItem[]>([]);
+  const exportHistoryRef = useRef<ExportHistoryItem[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [fileError, setFileError] = useState("");
   const exportAbortControllerRef = useRef<AbortController | null>(null);
@@ -147,8 +149,85 @@ export function useVideoEditor() {
   const [overlaySize, setOverlaySize] = useState(150);
   const [overlayOpacity, setOverlayOpacity] = useState(100);
 
+  const HISTORY_KEY = "reframe-export-history";
+  const MAX_HISTORY_ITEMS = 5;
+
+  const buildHistoryId = () => `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+  const loadExportHistory = useCallback(() => {
+    if (typeof window === "undefined") return [] as ExportHistoryItem[];
+    try {
+      const stored = sessionStorage.getItem(HISTORY_KEY);
+      if (!stored) return [];
+      return JSON.parse(stored) as Omit<ExportHistoryItem, "blobUrl">[];
+    } catch {
+      return [];
+    }
+  }, []);
+
+  const persistExportHistory = useCallback((history: ExportHistoryItem[]) => {
+    if (typeof window === "undefined") return;
+    try {
+      const serialized = history.map(({ blobUrl, ...rest }) => rest);
+      sessionStorage.setItem(HISTORY_KEY, JSON.stringify(serialized));
+    } catch {
+      // ignore storage errors
+    }
+  }, []);
+
+  const addExportHistoryItem = useCallback((exportResult: ExportResult) => {
+    const item: ExportHistoryItem = {
+      id: buildHistoryId(),
+      createdAt: new Date().toISOString(),
+      format: exportResult.format,
+      size: exportResult.size,
+      width: exportResult.width,
+      height: exportResult.height,
+      usedFallback: exportResult.usedFallback,
+      warning: exportResult.warning,
+      blobUrl: exportResult.blobUrl,
+    };
+    setExportHistory((previous) => {
+      const next = [item, ...previous];
+      const droppedItems = next.slice(MAX_HISTORY_ITEMS);
+      droppedItems.forEach((dropped) => {
+        if (dropped.blobUrl) {
+          URL.revokeObjectURL(dropped.blobUrl);
+        }
+      });
+      const trimmed = next.slice(0, MAX_HISTORY_ITEMS);
+      persistExportHistory(trimmed);
+      return trimmed;
+    });
+  }, [persistExportHistory]);
+
+  useEffect(() => {
+    setExportHistory(loadExportHistory());
+  }, [loadExportHistory]);
+
+  useEffect(() => {
+    exportHistoryRef.current = exportHistory;
+  }, [exportHistory]);
+
+  useEffect(() => {
+    return () => {
+      exportHistoryRef.current.forEach((item) => {
+        if (item.blobUrl) {
+          URL.revokeObjectURL(item.blobUrl);
+        }
+      });
+    };
+  }, []);
+
   const updateRecipe = useCallback((patch: Partial<EditRecipe>) => {
-    setRecipe((prev) => ({ ...prev, ...patch }));
+    setRecipe((prev) => {
+      const next = { ...prev, ...patch };
+      // GIF has no audio — force keepAudio off
+      if (next.format === "gif") {
+        next.keepAudio = false;
+      }
+      return next;
+    });
   }, []);
 
   useEffect(() => {
@@ -304,6 +383,7 @@ export function useVideoEditor() {
       if (exportCancelledRef.current) return;
 
       setResult(exportResult);
+      addExportHistoryItem(exportResult);
       setStatus("done");
      }  catch (err) {
       if (exportCancelledRef.current) return;
@@ -325,7 +405,7 @@ export function useVideoEditor() {
         exportAbortControllerRef.current = null;
       }
     }
-  }, [file, recipe, result, status, overlayFile, overlayPosition, overlaySize, overlayOpacity, duration]);
+  }, [file, recipe, result, status, overlayFile, overlayPosition, overlaySize, overlayOpacity, duration, addExportHistoryItem, loopMusic, musicFile, musicVolume, originalAudioVolume]);
 
 
   useEffect(() => {
@@ -402,6 +482,16 @@ export function useVideoEditor() {
     setError(null);
   }, []);
 
+  const downloadHistoryItem = useCallback((item: ExportHistoryItem) => {
+    if (!item.blobUrl) return;
+    const anchor = document.createElement("a");
+    anchor.href = item.blobUrl;
+    anchor.download = `reframe_${item.width}x${item.height}.${item.format}`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+  }, []);
+
 
   const reset = useCallback(() => {
     if (result?.blobUrl) URL.revokeObjectURL(result.blobUrl);
@@ -471,6 +561,8 @@ export function useVideoEditor() {
     setOverlaySize,
     overlayOpacity,
     setOverlayOpacity,
+    exportHistory,
+    downloadHistoryItem,
     recommendedPreset,
   };
 }

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -1,9 +1,11 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
-import { EditRecipe, ExportResult, ExportStatus, MAX_FILE_SIZE } from "@/lib/types";
-import { DEFAULT_RECIPE } from "@/lib/constants";
+import { useState, useCallback, useEffect, useRef, useMemo } from "react";
+import { EditRecipe, ExportHistoryItem, ExportResult, ExportStatus, MAX_FILE_SIZE, OverlayPosition } from "@/lib/types";
+import { DEFAULT_RECIPE, SPEED_STEPS } from "@/lib/constants";
+import { getPresetById } from "@/lib/presets";
 import { loadFFmpeg, exportVideo, terminateFFmpeg, FFmpegLoadError } from "@/lib/ffmpeg";
+import { suggestPreset } from "@/lib/presetSuggestion";
 
 const DEFAULT_TITLE = "Reframe — Resize, trim, and export videos in your browser";
 
@@ -60,34 +62,224 @@ function verifyMagicBytes(file: File): Promise<boolean> {
   });
 }
 
+function validateRecipe(recipe: EditRecipe, duration: number ): string | null {
+  const validations: Array<[boolean, string]> = [
+    [
+      recipe.trimStart < 0,
+      "Trim start time cannot be less than 0 seconds.",
+    ],
+    [
+      recipe.trimEnd !== null && recipe.trimEnd > duration,
+      `Trim end time cannot exceed the video duration (${Math.floor(duration)}s).`,
+    ],
+    [
+      recipe.trimStart >= (recipe.trimEnd ?? duration),
+      "Trim start time must be earlier than the end time.",
+    ],
+    [
+      recipe.preset === "custom" && (recipe.customWidth < 16 || recipe.customWidth > 7680),
+      "Width must be between 16px and 7680px.",
+    ],
+    [
+      recipe.preset === "custom" && (recipe.customHeight < 16 || recipe.customHeight > 7680),
+      "Height must be between 16px and 7680px.",
+    ],
+    [
+      !(SPEED_STEPS as readonly number[]).includes(recipe.speed),
+      "Please select a valid playback speed.",
+    ],
+    [
+      recipe.quality < 18 || recipe.quality > 30,
+      "Quality must be between 18 and 30.",
+    ],
+    [
+      recipe.brightness < -1 || recipe.brightness > 1,
+      "Brightness must be between -1 and 1.",
+    ],
+
+    [
+      recipe.contrast < 0 || recipe.contrast > 2,
+      "Contrast must be between 0 and 2.",
+    ],
+
+    [
+      recipe.saturation < 0 || recipe.saturation > 3,
+      "Saturation must be between 0 and 3.",
+    ],
+  ];
+
+  return (
+    validations.find(([condition]) => condition)?.[1] ??
+    null
+  );
+}
+
 export function useVideoEditor() {
   const [file, setFile] = useState<File | null>(null);
   const [duration, setDuration] = useState<number>(0);
-  const [recipe, setRecipe] = useState<EditRecipe>(DEFAULT_RECIPE);
+  const [videoMetadata, setVideoMetadata] = useState<{
+    width: number;
+    height: number;
+    duration: number;
+  } | null>(null);
+  const [recipe, setRecipe] = useState({
+    ...DEFAULT_RECIPE,
+    soundOnCompletion:
+      typeof window !== "undefined" &&
+      localStorage.getItem("soundOnCompletion") === "true",
+  });
   const [status, setStatus] = useState<ExportStatus>("idle");
   const [progress, setProgress] = useState(0);
   const [result, setResult] = useState<ExportResult | null>(null);
+  const [exportHistory, setExportHistory] = useState<ExportHistoryItem[]>([]);
+  const exportHistoryRef = useRef<ExportHistoryItem[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [fileError, setFileError] = useState("");
   const exportAbortControllerRef = useRef<AbortController | null>(null);
   const exportCancelledRef = useRef(false);
   const videoRef = useRef<HTMLVideoElement>(null);
 
-  const updateRecipe = useCallback((patch: Partial<EditRecipe>) => {
-    setRecipe((prev) => ({ ...prev, ...patch }));
+  const [musicFile, setMusicFile] = useState<File | null>(null);
+  const [musicVolume, setMusicVolume] = useState(70);
+  const [originalAudioVolume, setOriginalAudioVolume] = useState(40);
+  const [loopMusic, setLoopMusic] = useState(false);
+
+  const [overlayFile, setOverlayFile] = useState<File | null>(null);
+  const [overlayPosition, setOverlayPosition] = useState<OverlayPosition>("bottom-right");
+  const [overlaySize, setOverlaySize] = useState(150);
+  const [overlayOpacity, setOverlayOpacity] = useState(100);
+
+  const HISTORY_KEY = "reframe-export-history";
+  const MAX_HISTORY_ITEMS = 5;
+
+  const buildHistoryId = () => `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+  const loadExportHistory = useCallback(() => {
+    if (typeof window === "undefined") return [] as ExportHistoryItem[];
+    try {
+      const stored = sessionStorage.getItem(HISTORY_KEY);
+      if (!stored) return [];
+      return JSON.parse(stored) as Omit<ExportHistoryItem, "blobUrl">[];
+    } catch {
+      return [];
+    }
   }, []);
+
+  const persistExportHistory = useCallback((history: ExportHistoryItem[]) => {
+    if (typeof window === "undefined") return;
+    try {
+      const serialized = history.map(({ blobUrl, ...rest }) => rest);
+      sessionStorage.setItem(HISTORY_KEY, JSON.stringify(serialized));
+    } catch {
+      // ignore storage errors
+    }
+  }, []);
+
+  const addExportHistoryItem = useCallback((exportResult: ExportResult) => {
+    const item: ExportHistoryItem = {
+      id: buildHistoryId(),
+      createdAt: new Date().toISOString(),
+      format: exportResult.format,
+      size: exportResult.size,
+      width: exportResult.width,
+      height: exportResult.height,
+      usedFallback: exportResult.usedFallback,
+      warning: exportResult.warning,
+      blobUrl: exportResult.blobUrl,
+    };
+    setExportHistory((previous) => {
+      const next = [item, ...previous];
+      const droppedItems = next.slice(MAX_HISTORY_ITEMS);
+      droppedItems.forEach((dropped) => {
+        if (dropped.blobUrl) {
+          URL.revokeObjectURL(dropped.blobUrl);
+        }
+      });
+      const trimmed = next.slice(0, MAX_HISTORY_ITEMS);
+      persistExportHistory(trimmed);
+      return trimmed;
+    });
+  }, [persistExportHistory]);
+
+  useEffect(() => {
+    setExportHistory(loadExportHistory());
+  }, [loadExportHistory]);
+
+  useEffect(() => {
+    exportHistoryRef.current = exportHistory;
+  }, [exportHistory]);
+
+  useEffect(() => {
+    return () => {
+      exportHistoryRef.current.forEach((item) => {
+        if (item.blobUrl) {
+          URL.revokeObjectURL(item.blobUrl);
+        }
+      });
+    };
+  }, []);
+
+  const updateRecipe = useCallback((patch: Partial<EditRecipe>) => {
+    setRecipe((prev) => {
+      const next = { ...prev, ...patch };
+      // GIF has no audio — force keepAudio off
+      if (next.format === "gif") {
+        next.keepAudio = false;
+      }
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem("reframe-settings");
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        setRecipe(prev => ({
+          ...prev,
+          preset: parsed.preset ?? prev.preset,
+          quality: parsed.quality ?? prev.quality,
+          speed: parsed.speed ?? prev.speed,
+          customWidth: parsed.customWidth ?? prev.customWidth,
+          customHeight: parsed.customHeight ?? prev.customHeight
+        }));
+      }
+    } catch (e) {
+      // ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem("reframe-settings", JSON.stringify({
+        preset: recipe.preset,
+        quality: recipe.quality,
+        speed: recipe.speed,
+        customWidth: recipe.customWidth,
+        customHeight: recipe.customHeight
+      }));
+    } catch (e) {
+      // ignore
+    }
+  }, [recipe.preset, recipe.quality, recipe.speed, recipe.customWidth, recipe.customHeight]);
+
+  const recommendedPreset = useMemo(() => {
+    if (!videoMetadata) return null;
+    return getPresetById(suggestPreset(videoMetadata.width, videoMetadata.height)) ?? null;
+  }, [videoMetadata]);
 
   const handleFileSelect = useCallback(async (selectedFile: File) => {
     setResult(null);
     setStatus("idle");
     setError(null);
     setFile(null);
+    setVideoMetadata(null);
     if (!selectedFile.type.startsWith("video/")) {
-    setFileError("Please upload a video file only.");
-    return;
-  }
+      setFileError("Please upload a video file only.");
+      return;
+    }
 
-  setFileError("");
+    setFileError("");
 
     // LAYER 0: Size check
     if (selectedFile.size > MAX_FILE_SIZE) {
@@ -119,10 +311,21 @@ export function useVideoEditor() {
     }
 
     try {
-      const { duration: dur } = await extractMetadata(selectedFile);
+      const { width, height, duration: dur } = await extractMetadata(selectedFile);
       setDuration(dur);
+      setVideoMetadata({ width, height, duration: dur });
       setFile(selectedFile);
-      setRecipe((prev) => ({ ...prev, trimStart: 0, trimEnd: null }));
+      setRecipe((prev) => {
+        const suggestedPreset = suggestPreset(width, height);
+        const shouldApplySuggestion = prev.preset === DEFAULT_RECIPE.preset;
+
+        return {
+          ...prev,
+          trimStart: 0,
+          trimEnd: null,
+          ...(shouldApplySuggestion ? { preset: suggestedPreset } : {}),
+        };
+      });
     } catch (err) {
       setError(`Layer 4 Validation Failed: ${err instanceof Error ? err.message : "Unknown error"}`);
       setStatus("error");
@@ -132,6 +335,13 @@ export function useVideoEditor() {
   const handleExport = useCallback(async () => {
     if (!file) return;
     if (status === "loading-engine" || status === "exporting") {
+      return;
+    }
+
+    const validationError = validateRecipe(recipe, duration);
+    if (validationError) {
+      setError(validationError);
+      setStatus("error");
       return;
     }
 
@@ -156,11 +366,24 @@ export function useVideoEditor() {
         file,
         recipe,
         setProgress,
-        abortController.signal
+        abortController.signal,
+        {
+          file: musicFile,
+          musicVolume,
+          originalAudioVolume,
+          loopMusic,
+        },
+        {
+          file: overlayFile,
+          position: overlayPosition,
+          size: overlaySize,
+          opacity: overlayOpacity,
+        }
       );
       if (exportCancelledRef.current) return;
 
       setResult(exportResult);
+      addExportHistoryItem(exportResult);
       setStatus("done");
      }  catch (err) {
       if (exportCancelledRef.current) return;
@@ -182,10 +405,17 @@ export function useVideoEditor() {
         exportAbortControllerRef.current = null;
       }
     }
-  }, [file, recipe, result, status]);
+  }, [file, recipe, result, status, overlayFile, overlayPosition, overlaySize, overlayOpacity, duration, addExportHistoryItem, loopMusic, musicFile, musicVolume, originalAudioVolume]);
+
 
   useEffect(() => {
-    if (file) {
+    if (status === "exporting") {
+      document.title = `Exporting ${progress}% | Reframe`;
+    } else if (status === "loading-engine") {
+      document.title = `Loading engine... | Reframe`;
+    } else if (status === "done") {
+      document.title = `Export complete | Reframe`;
+    } else if (file) {
       document.title = `Editing: ${file.name} | Reframe`;
     } else {
       document.title = DEFAULT_TITLE;
@@ -193,8 +423,24 @@ export function useVideoEditor() {
     return () => {
       document.title = DEFAULT_TITLE;
     };
-  }, [file]);
+  }, [status, progress, file]);
 
+  useEffect(() => {
+    const shouldWarn =
+      status === "exporting" ||
+      status === "loading-engine" ||
+      status === "done";
+
+    if (!shouldWarn) return;
+
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+    };
+
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [status]);
+  
   useEffect(() => {
     const handleKeydown = (e: KeyboardEvent) => {
       if (
@@ -236,10 +482,21 @@ export function useVideoEditor() {
     setError(null);
   }, []);
 
+  const downloadHistoryItem = useCallback((item: ExportHistoryItem) => {
+    if (!item.blobUrl) return;
+    const anchor = document.createElement("a");
+    anchor.href = item.blobUrl;
+    anchor.download = `reframe_${item.width}x${item.height}.${item.format}`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+  }, []);
+
 
   const reset = useCallback(() => {
     if (result?.blobUrl) URL.revokeObjectURL(result.blobUrl);
     setFile(null);
+    setVideoMetadata(null);
     setDuration(0);
     setRecipe(DEFAULT_RECIPE);
     setStatus("idle");
@@ -262,6 +519,9 @@ export function useVideoEditor() {
     return () => clearInterval(interval);
   }, [status]);
 
+  useEffect(() => {
+    localStorage.setItem("soundOnCompletion", String(recipe.soundOnCompletion));
+  }, [recipe.soundOnCompletion]);
   const seekTo = useCallback((time: number) => {
     if (videoRef.current) {
       videoRef.current.currentTime = time;
@@ -285,5 +545,24 @@ export function useVideoEditor() {
     cancelExport,
     reset,
     resetSettings,
+    musicFile,
+    setMusicFile,
+    musicVolume,
+    setMusicVolume,
+    originalAudioVolume,
+    setOriginalAudioVolume,
+    loopMusic,
+    setLoopMusic,
+    overlayFile,
+    setOverlayFile,
+    overlayPosition,
+    setOverlayPosition,
+    overlaySize,
+    setOverlaySize,
+    overlayOpacity,
+    setOverlayOpacity,
+    exportHistory,
+    downloadHistoryItem,
+    recommendedPreset,
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,6 +14,27 @@ export interface EditRecipe {
   brightness: number;
   contrast: number;
   saturation: number;
+  soundOnCompletion: boolean;
+}
+
+export type OverlayPosition =
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right";
+
+export interface ImageOverlayOptions {
+  file: File | null;
+  position: OverlayPosition;
+  size: number;
+  opacity: number;
+}
+
+export interface BackgroundMusicOptions {
+  file: File | null;
+  musicVolume: number;
+  originalAudioVolume: number;
+  loopMusic: boolean;
 }
 
 export interface ExportResult {
@@ -24,6 +45,19 @@ export interface ExportResult {
   format: "mp4" | "webm" | "mkv";
 }
 
+export interface ExportHistoryItem {
+  id: string;
+  createdAt: string;
+  format: "mp4" | "webm" | "mkv" | "gif";
+  size: number;
+  width: number;
+  height: number;
+  usedFallback?: boolean;
+  warning?: string;
+  /** In-memory object URL for the current page session only */
+  blobUrl?: string;
+}
+
 export type ExportStatus =
   | "idle"
   | "loading-engine"
@@ -31,8 +65,38 @@ export type ExportStatus =
   | "done"
   | "error";
 
+export const SPEED_STEPS = [
+  0.25,
+  0.5,
+  0.75,
+  1,
+  1.25,
+  1.5,
+  2,
+  4,
+] as const;
+
+export const DEFAULT_RECIPE: EditRecipe = {
+  preset: "vertical-9-16",
+  customWidth: 1920,
+  customHeight: 1080,
+  framing: "fit",
+  trimStart: 0,
+  trimEnd: null,
+  rotate: 0,
+  keepAudio: true,
+  speed: 1,
+  quality: 23,
+  format: "mp4",
+  stabilization: false,
+  brightness: 0,
+  contrast: 0,
+  saturation: 0,
+  soundOnCompletion: false,
+};
+
 export const MAX_FILE_SIZE =
-  2 * 1024 * 1024 * 1024; // 2GB
+  2 * 1024 * 1024 * 1024;
 
 export const WARNING_FILE_SIZE =
   500 * 1024 * 1024; // 500MB

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -45,6 +45,19 @@ export interface ExportResult {
   format: "mp4" | "webm" | "mkv";
 }
 
+export interface ExportHistoryItem {
+  id: string;
+  createdAt: string;
+  format: "mp4" | "webm" | "mkv" | "gif";
+  size: number;
+  width: number;
+  height: number;
+  usedFallback?: boolean;
+  warning?: string;
+  /** In-memory object URL for the current page session only */
+  blobUrl?: string;
+}
+
 export type ExportStatus =
   | "idle"
   | "loading-engine"


### PR DESCRIPTION
Adds a session export history panel that stores the last 5 exports and allows re-downloading them.

- New `ExportHistory` component
- Persisted history in sessionStorage
- Cleans up stale blob URLs to prevent memory leaks
- Displays fallback warning metadata for WebM fallback exports