### PR TITLE
fix: ThumbnailStrip active frame indicator now tracks playback position

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -120,6 +120,7 @@ export default function VideoEditor() {
     overlaySize, setOverlaySize,
     overlayOpacity, setOverlayOpacity,
     recommendedPreset,
+    currentTime,
   } = useVideoEditor();
   const [copied, setCopied] = useState(false);
   const [shareCopied, setShareCopied] = useState(false);
@@ -208,7 +209,7 @@ export default function VideoEditor() {
                     <ThumbnailStrip
                       videoSrc={videoSrc}
                       duration={duration}
-                      currentTime={videoRef.current?.currentTime ?? 0}
+                      currentTime={currentTime}
                       trimStart={recipe.trimStart ?? 0}
                       trimEnd={recipe.trimEnd ?? duration}
                       onSeek={seekTo}

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -146,7 +146,7 @@ export function useVideoEditor() {
   const [overlayPosition, setOverlayPosition] = useState<OverlayPosition>("bottom-right");
   const [overlaySize, setOverlaySize] = useState(150);
   const [overlayOpacity, setOverlayOpacity] = useState(100);
-
+  const [currentTime, setCurrentTime] = useState(0);
  const updateRecipe = useCallback((patch: Partial<EditRecipe>) => {
   setRecipe((prev) => {
     const next = { ...prev, ...patch };
@@ -565,7 +565,13 @@ export function useVideoEditor() {
       videoRef.current.currentTime = time;
     }
   }, []);
-
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    const handleTimeUpdate = () => setCurrentTime(video.currentTime);
+    video.addEventListener("timeupdate", handleTimeUpdate);
+    return () => video.removeEventListener("timeupdate", handleTimeUpdate);
+  });
   return {
     file,
     duration,
@@ -600,5 +606,6 @@ export function useVideoEditor() {
     overlayOpacity,
     setOverlayOpacity,
     recommendedPreset,
+    currentTime,
   };
 }

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -571,7 +571,7 @@ export function useVideoEditor() {
     const handleTimeUpdate = () => setCurrentTime(video.currentTime);
     video.addEventListener("timeupdate", handleTimeUpdate);
     return () => video.removeEventListener("timeupdate", handleTimeUpdate);
-  });
+  },[]);
   return {
     file,
     duration,

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -628,7 +628,6 @@ export function useVideoEditor() {
     video.addEventListener("timeupdate", handleTimeUpdate);
     return () => video.removeEventListener("timeupdate", handleTimeUpdate);
   },[]);
-  });
 
   const toggleSound = useCallback(() => {
   updateRecipe({ soundOnCompletion: !recipe.soundOnCompletion });


### PR DESCRIPTION
## Description
The ThumbnailStrip active frame indicator was permanently stuck on the first frame (0:00) regardless of video playback position. Fixed by tracking `currentTime` as reactive state in `useVideoEditor` using a `timeupdate` event listener, and passing it down to `ThumbnailStrip` instead of reading directly from `videoRef.current`.

## Related Issue
Closes #630

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] GSSoC contribution

## Participant Info
- GitHub username: @Kr1491 
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Screen Recording
## Before
https://github.com/user-attachments/assets/efaabd4b-696b-4da5-955f-9443d2af7382
## After
https://github.com/user-attachments/assets/bdac74bc-2c84-416b-9392-409d585493d9

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [ ] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)