### PR TITLE
fix: wire up validateDimensions to enforce 8K resolution guard in handleFileSelect

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -6,6 +6,7 @@ import { DEFAULT_RECIPE, SPEED_STEPS } from "@/lib/constants";
 import { getPresetById } from "@/lib/presets";
 import { loadFFmpeg, exportVideo, terminateFFmpeg, FFmpegLoadError } from "@/lib/ffmpeg";
 import { suggestPreset } from "@/lib/presetSuggestion";
+import { validateDimensions, getDownscaledDimensions } from "@/utils/video-validation";
 
 const DEFAULT_TITLE = "Reframe — Resize, trim, and export videos in your browser";
 
@@ -336,9 +337,26 @@ export function useVideoEditor() {
 
     try {
       const { width, height, duration: dur } = await extractMetadata(selectedFile);
+
+      // Layer 5: Resolution check
+      const dimensionCheck = validateDimensions(width, height);
+      if (dimensionCheck === "blocked") {
+        const suggested = getDownscaledDimensions(width, height);
+        setError(
+          `Layer 5 Validation Failed: Resolution too high (${width}×${height}). ` +
+          `Maximum supported is 8K. Suggested safe size: ${suggested.width}×${suggested.height}.`
+        );
+        setStatus("error");
+        return;
+      }
+
       setDuration(dur);
       setVideoMetadata({ width, height, duration: dur });
       setFile(selectedFile);
+
+      if (dimensionCheck === "warning") {
+        console.warn(`[Reframe] High resolution video detected (${width}×${height}). Export may be slow.`);
+      }
       setRecipe((prev) => {
         const suggestedPreset = suggestPreset(width, height);
         const shouldApplySuggestion = prev.preset === DEFAULT_RECIPE.preset;


### PR DESCRIPTION
## What does this PR do?
Wires up the previously dead `validateDimensions` and `getDownscaledDimensions`
utility functions in `src/utils/video-validation.ts`.

## Problem
Both functions were exported but never imported or called anywhere, so the
intended 8K resolution guard was completely inactive. Users uploading 8K+
videos would proceed to export with no warning, likely crashing the browser
tab or triggering a silent FFmpeg OOM failure.

## Solution
- Import `validateDimensions` and `getDownscaledDimensions` in `useVideoEditor.ts`
- Call `validateDimensions` immediately after `extractMetadata` resolves
- **Blocked (8K+):** set an error with the detected resolution and a suggested
  safe downscaled size computed by `getDownscaledDimensions`
- **Warning (4K+):** log a console warning (UI banner can follow in a separate PR)

## Files Changed
- `src/hooks/useVideoEditor.ts`

## Related Issue
Closes #844

Please put the appropriate labels so that I can get the points for GSSoC