### PR TITLE
``` feat: surface Ctrl+Enter / ⌘Enter keyboard shortcut hint below the Export button ```

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -144,6 +144,7 @@ export default function VideoEditor() {
   }, [status]);
 
   const isProcessing = status === "loading-engine" || status === "exporting";
+  const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
 
   const videoSrc = useMemo(
     () => (file ? URL.createObjectURL(file) : null),
@@ -448,9 +449,15 @@ export default function VideoEditor() {
                   : "bg-[var(--border)] text-[var(--muted)] opacity-40 cursor-not-allowed"
               )}
             >
-              <Zap size={20} className={cn(file && !isProcessing && "animate-pulse")} />
+             <Zap size={20} className={cn(file && !isProcessing && "animate-pulse")} />
               {isProcessing ? "PROCESSING" : "EXPORT"}
             </button>
+
+            {file && !isProcessing && (
+              <p className="text-xs text-center font-mono text-[var(--muted)] opacity-50 mt-1">
+                {isMac ? "⌘" : "Ctrl"} + Enter to export
+              </p>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What does this PR do?
Surfaces the existing `Ctrl+Enter` (or `⌘ Enter` on Mac) keyboard shortcut
for exporting in the UI so users can actually discover and use it.

## Problem
`useVideoEditor.ts` already listens for `Ctrl+Enter` / `Cmd+Enter` to trigger
`handleExport`, but there was no hint, tooltip, or label anywhere in the UI.
This made it a completely invisible feature.

## Solution
- Added a one-line `isMac` detection using `navigator.platform`
- Rendered a small `<p>` hint below the Export button in `VideoEditor.tsx`
- The hint only appears when a file is loaded and no export is in progress,
  so it never clutters the idle or processing states
- Uses existing CSS variables (`--muted`) and `font-mono` to match the
  design language of the rest of the app

## Files Changed
- `src/components/VideoEditor.tsx`

## Related Issue
Closes #845 

Please add the labels for GSSoC