### PR TITLE
feat: add interactive dual-thumb timeline range slider with live video scrubbing

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -11,7 +11,7 @@ export function ThemeToggle() {
   }, []);
 
   const isDark = theme === "dark";
-  
+
   if (!mounted) {
     return (
       <button
@@ -30,10 +30,10 @@ export function ThemeToggle() {
 
   return (
     <button
-       type="button"
-       suppressHydrationWarning={true}
-       onClick={toggleTheme}
-       aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      type="button"
+      suppressHydrationWarning={true}
+      onClick={toggleTheme}
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
       className="
         relative flex items-center justify-center
         w-9 h-9 rounded-full
@@ -46,14 +46,34 @@ export function ThemeToggle() {
         transition-all duration-200
       "
     >
-    {!mounted ? (
-        <div className="w-4 h-4" /> 
+      {!mounted ? (
+        <div className="w-4 h-4" />
       ) : isDark ? (
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4" aria-hidden="true">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="w-4 h-4"
+          aria-hidden="true"
+        >
           <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
         </svg>
       ) : (
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4" aria-hidden="true">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="w-4 h-4"
+          aria-hidden="true"
+        >
           <circle cx="12" cy="12" r="4" />
           <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
         </svg>

--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { EditRecipe } from "@/lib/types";
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, type PointerEvent } from "react";
 import { AlertCircle } from "lucide-react";
 import { formatDuration } from "@/lib/utils";
 import { useAudioWaveform } from "@/hooks/useAudioWaveform";
@@ -14,16 +14,16 @@ interface Props {
   onChange: (patch: Partial<EditRecipe>) => void;
   duration: number;
   file: File | null;
+  seekTo?: (time: number) => void;
 }
 
-export default function TrimControl({ recipe, onChange, duration, file }: Props) {
+export default function TrimControl({ recipe, onChange, duration, file, seekTo}: Props) {
   const [invalidStart, setStart] = useState(false);
   const [invalidEnd, setEnd] = useState(false);
   const [startErrorMsg, setStartErrorMsg] = useState("");
   const [endErrorMsg, setEndErrorMsg] = useState("");
-  const [startInput, setStartInput] = useState(
-    recipe.trimStart.toString()
-  );
+  const [startInput, setStartInput] = useState(recipe.trimStart.toString());
+  const [draggingThumb, setDraggingThumb] = useState<"start" | "end" | null>(null);
 
   const { waveform, isLoading: waveformLoading } = useAudioWaveform(file);
   const hasAudio = waveform.length > 0;
@@ -32,8 +32,60 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
     setStartInput(recipe.trimStart.toString());
   }, [recipe.trimStart]);
 
-  const clipLength =
-    (recipe.trimEnd ?? duration) - recipe.trimStart;
+  const clipLength = (recipe.trimEnd ?? duration) - recipe.trimStart;
+  const trimEndValue = recipe.trimEnd ?? duration;
+  const startPercent = duration > 0 ? Math.min(100, Math.max(0, (recipe.trimStart / duration) * 100)) : 0;
+  const endPercent = duration > 0 ? Math.min(100, Math.max(0, (trimEndValue / duration) * 100)) : 100;
+
+  const updateTrimFromPointer = (
+    event: PointerEvent<HTMLDivElement>,
+    thumb: "start" | "end",
+  ) => {
+    if (duration <= 0) {
+      return;
+    }
+
+    const rect = event.currentTarget.getBoundingClientRect();
+    const percent = Math.min(1, Math.max(0, (event.clientX - rect.left) / rect.width));
+    const newValue = percent * duration;
+
+    if (thumb === "start") {
+      handleStart(newValue.toString());
+      seekTo?.(newValue);
+    } else {
+      handleEnd(newValue.toString());
+      seekTo?.(newValue);
+    }
+  };
+
+  const handleTrackPointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    const thumb = (event.target as HTMLElement).closest("[data-thumb]")?.getAttribute("data-thumb");
+
+    if (thumb !== "start" && thumb !== "end") {
+      return;
+    }
+
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    setDraggingThumb(thumb);
+    updateTrimFromPointer(event, thumb);
+  };
+
+  const handleTrackPointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    if (!draggingThumb) {
+      return;
+    }
+
+    updateTrimFromPointer(event, draggingThumb);
+  };
+
+  const handleTrackPointerUp = (event: PointerEvent<HTMLDivElement>) => {
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+
+    setDraggingThumb(null);
+  };
 
   const trackRef = useRef<HTMLDivElement>(null);
   const dragging = useRef<"start" | "end" | null>(null);
@@ -57,39 +109,38 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
     }
   }, [xToSeconds, duration, recipe.trimStart, recipe.trimEnd, onChange]);
 
- useEffect(() => {
-  const onMove = (e: MouseEvent | TouchEvent) => {
-    let clientX: number;
+  useEffect(() => {
+    const onMove = (e: MouseEvent | TouchEvent) => {
+      let clientX: number;
 
-    if ("touches" in e) {
-      const touch = e.touches[0];
+      if ("touches" in e) {
+        const touch = e.touches[0];
+        if (!touch) return;
+        clientX = touch.clientX;
+      } else {
+        clientX = e.clientX;
+      }
 
-      if (!touch) return;
+      applyDrag(clientX);
+    };
 
-      clientX = touch.clientX;
-    } else {
-      clientX = e.clientX;
-    }
+    const onUp = () => {
+      dragging.current = null;
+    };
 
-    applyDrag(clientX);
-  };
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+    document.addEventListener("touchmove", onMove);
+    document.addEventListener("touchend", onUp);
 
-  const onUp = () => {
-    dragging.current = null;
-  };
+    return () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+      document.removeEventListener("touchmove", onMove);
+      document.removeEventListener("touchend", onUp);
+    };
+  }, [applyDrag]);
 
-  document.addEventListener("mousemove", onMove);
-  document.addEventListener("mouseup", onUp);
-  document.addEventListener("touchmove", onMove);
-  document.addEventListener("touchend", onUp);
-
-  return () => {
-    document.removeEventListener("mousemove", onMove);
-    document.removeEventListener("mouseup", onUp);
-    document.removeEventListener("touchmove", onMove);
-    document.removeEventListener("touchend", onUp);
-  };
-}, [applyDrag]);
   const handleStart = (val: string) => {
     setStartInput(val);
 
@@ -177,62 +228,43 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
 
   return (
     <div id="trim-control" className="space-y-3">
-      {duration > 0 && (
+      {/* Waveform — shown while loading or when file is present */}
+      {(file && (waveformLoading || hasAudio)) && (
         <div
-          role="toolbar"
-          aria-label="Trim timeline"
-          ref={trackRef}
-          className="relative h-6 flex items-center cursor-pointer select-none"
-          onClick={(e) => {
-            if (dragging.current) return;
-            const s = xToSeconds(e.clientX);
-            onChange({ trimStart: s });
-          }}
-          onKeyDown={(e) => {
-            if (e.key === "ArrowLeft") onChange({ trimStart: Math.max(0, recipe.trimStart - 0.1) });
-            if (e.key === "ArrowRight") onChange({ trimStart: Math.min((recipe.trimEnd ?? duration) - 0.1, recipe.trimStart + 0.1) });
-          }}
+          className="relative w-full rounded-md overflow-hidden bg-[var(--surface)] touch-none"
+          onPointerDown={handleTrackPointerDown}
+          onPointerMove={handleTrackPointerMove}
+          onPointerUp={handleTrackPointerUp}
+          onPointerCancel={handleTrackPointerUp}
         >
-          <div className="absolute inset-x-0 h-1.5 rounded-full bg-[var(--border)]" />
-          <div
-            className="absolute h-1.5 rounded-full bg-film-400 opacity-60"
-            style={{
-              left: `${(recipe.trimStart / duration) * 100}%`,
-              right: `${((duration - (recipe.trimEnd ?? duration)) / duration) * 100}%`,
-            }}
+          <WaveformCanvas
+            samples={waveform}
+            loading={waveformLoading}
+            hasAudio={hasAudio}
           />
-          <div
-            role="slider"
-            aria-label="Trim start"
-            aria-valuenow={recipe.trimStart}
-            aria-valuemin={0}
-            aria-valuemax={duration}
-            tabIndex={0}
-            className="absolute w-4 h-4 rounded-full bg-white border-2 border-film-400 shadow cursor-grab active:cursor-grabbing -translate-x-1/2 focus:outline-none focus:ring-2 focus:ring-film-400"
-            style={{ left: `${(recipe.trimStart / duration) * 100}%` }}
-            onMouseDown={() => { dragging.current = "start"; }}
-            onTouchStart={() => { dragging.current = "start"; }}
-            onKeyDown={(e) => {
-              if (e.key === "ArrowLeft") onChange({ trimStart: Math.max(0, recipe.trimStart - 0.1) });
-              if (e.key === "ArrowRight") onChange({ trimStart: Math.min((recipe.trimEnd ?? duration) - 0.1, recipe.trimStart + 0.1) });
-            }}
-          />
-          <div
-            role="slider"
-            aria-label="Trim end"
-            aria-valuenow={recipe.trimEnd ?? duration}
-            aria-valuemin={0}
-            aria-valuemax={duration}
-            tabIndex={0}
-            className="absolute w-4 h-4 rounded-full bg-white border-2 border-film-400 shadow cursor-grab active:cursor-grabbing -translate-x-1/2 focus:outline-none focus:ring-2 focus:ring-film-400"
-            style={{ left: `${((recipe.trimEnd ?? duration) / duration) * 100}%` }}
-            onMouseDown={() => { dragging.current = "end"; }}
-            onTouchStart={() => { dragging.current = "end"; }}
-            onKeyDown={(e) => {
-              if (e.key === "ArrowLeft") onChange({ trimEnd: Math.max(recipe.trimStart + 0.1, (recipe.trimEnd ?? duration) - 0.1) });
-              if (e.key === "ArrowRight") onChange({ trimEnd: Math.min(duration, (recipe.trimEnd ?? duration) + 0.1) });
-            }}
-          />
+          {duration > 0 && (
+            <div className="pointer-events-none absolute inset-0">
+              <div className="absolute left-0 right-0 top-1/2 h-px -translate-y-1/2 bg-[var(--border)]/45" />
+              <div
+                className="absolute top-1/2 h-2 -translate-y-1/2 rounded-full bg-film-400/15 transition-all duration-200 ease-in-out"
+                style={{ left: `${startPercent}%`, width: `${Math.max(0, endPercent - startPercent)}%` }}
+              />
+              <button
+                type="button"
+                data-thumb="start"
+                aria-label="Drag trim start handle"
+                className={`pointer-events-auto absolute top-1/2 h-6 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full border bg-white/20 dark:bg-black/20 border-white/30 dark:border-white/10 shadow-md backdrop-blur-sm transition-all duration-200 ease-in-out hover:scale-105 active:scale-95 ${draggingThumb === "start" ? "shadow-[0_0_0_4px_rgba(255,191,87,0.14)]" : ""}`}
+                style={{ left: `${startPercent}%` }}
+              />
+              <button
+                type="button"
+                data-thumb="end"
+                aria-label="Drag trim end handle"
+                className={`pointer-events-auto absolute top-1/2 h-6 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full border bg-white/20 dark:bg-black/20 border-white/30 dark:border-white/10 shadow-md backdrop-blur-sm transition-all duration-200 ease-in-out hover:scale-105 active:scale-95 ${draggingThumb === "end" ? "shadow-[0_0_0_4px_rgba(255,191,87,0.14)]" : ""}`}
+                style={{ left: `${endPercent}%` }}
+              />
+            </div>
+          )}
         </div>
       )}
       <div className="flex gap-3">
@@ -326,5 +358,3 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
     </div>
   );
 }
-
-

--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -15,9 +15,12 @@ interface Props {
   duration: number;
   file: File | null;
   seekTo?: (time: number) => void;
+  videoRef: React.RefObject<HTMLVideoElement | null>; // Add this
 }
 
-export default function TrimControl({ recipe, onChange, duration, file, seekTo}: Props) {
+
+
+export default function TrimControl({ recipe, onChange, duration, file, seekTo, videoRef}: Props) {
   const [invalidStart, setStart] = useState(false);
   const [invalidEnd, setEnd] = useState(false);
   const [startErrorMsg, setStartErrorMsg] = useState("");
@@ -28,6 +31,37 @@ export default function TrimControl({ recipe, onChange, duration, file, seekTo}:
   const { waveform, isLoading: waveformLoading } = useAudioWaveform(file);
   const hasAudio = waveform.length > 0;
 
+  const [frames, setFrames] = useState<string[]>([]);
+
+useEffect(() => {
+  const video = videoRef.current;
+  if (!video || frames.length > 0) return;
+
+  const captureFrames = async () => {
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    const frameList: string[] = [];
+    const steps = 10;
+    
+    // Temporarily ensure video is ready
+    if (video.readyState < 2) await new Promise(r => video.addEventListener('loadedmetadata', r, {once: true}));
+
+    for (let i = 0; i < steps; i++) {
+      video.currentTime = (i / (steps - 1)) * video.duration;
+      await new Promise(r => setTimeout(r, 150)); 
+      if (ctx) {
+        canvas.width = 100;
+        canvas.height = 64;
+        ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+        frameList.push(canvas.toDataURL("image/jpeg", 0.6));
+      }
+    }
+    setFrames(frameList);
+  };
+
+  captureFrames();
+}, [videoRef, frames.length]);
+
   useEffect(() => {
     setStartInput(recipe.trimStart.toString());
   }, [recipe.trimStart]);
@@ -37,13 +71,11 @@ export default function TrimControl({ recipe, onChange, duration, file, seekTo}:
   const startPercent = duration > 0 ? Math.min(100, Math.max(0, (recipe.trimStart / duration) * 100)) : 0;
   const endPercent = duration > 0 ? Math.min(100, Math.max(0, (trimEndValue / duration) * 100)) : 100;
 
-  const updateTrimFromPointer = (
+const updateTrimFromPointer = (
     event: PointerEvent<HTMLDivElement>,
     thumb: "start" | "end",
   ) => {
-    if (duration <= 0) {
-      return;
-    }
+    if (duration <= 0) return;
 
     const rect = event.currentTarget.getBoundingClientRect();
     const percent = Math.min(1, Math.max(0, (event.clientX - rect.left) / rect.width));
@@ -51,10 +83,13 @@ export default function TrimControl({ recipe, onChange, duration, file, seekTo}:
 
     if (thumb === "start") {
       handleStart(newValue.toString());
-      seekTo?.(newValue);
     } else {
       handleEnd(newValue.toString());
-      seekTo?.(newValue);
+    }
+    
+    // NEW: Force the preview to sync immediately to the new time
+    if (seekTo) {
+      seekTo(newValue);
     }
   };
 
@@ -229,40 +264,39 @@ export default function TrimControl({ recipe, onChange, duration, file, seekTo}:
   return (
     <div id="trim-control" className="space-y-3">
       {/* Waveform — shown while loading or when file is present */}
-      {(file && (waveformLoading || hasAudio)) && (
+      {/* Static Frame Strip across the Trim Bar */}
+      {file && (
         <div
-          className="relative w-full rounded-md overflow-hidden bg-[var(--surface)] touch-none"
+          className="relative w-full h-16 rounded-md overflow-hidden bg-neutral-900 touch-none border border-[var(--border)]"
           onPointerDown={handleTrackPointerDown}
           onPointerMove={handleTrackPointerMove}
           onPointerUp={handleTrackPointerUp}
           onPointerCancel={handleTrackPointerUp}
         >
-          <WaveformCanvas
-            samples={waveform}
-            loading={waveformLoading}
-            hasAudio={hasAudio}
-          />
+          {/* Static Frame Strip */}
+          <div className="absolute inset-0 flex h-full">
+            {frames.length > 0 ? (
+              frames.map((src, i) => (
+                <div 
+                  key={i} 
+                  className="h-full flex-1 border-r border-black/20 bg-cover bg-center"
+                  style={{ backgroundImage: `url(${src})` }}
+                />
+              ))
+            ) : (
+              <div className="w-full h-full animate-pulse bg-neutral-800" />
+            )}
+          </div>
+
+          {/* Selection Overlay (Handles) */}
           {duration > 0 && (
             <div className="pointer-events-none absolute inset-0">
-              <div className="absolute left-0 right-0 top-1/2 h-px -translate-y-1/2 bg-[var(--border)]/45" />
-              <div
-                className="absolute top-1/2 h-2 -translate-y-1/2 rounded-full bg-film-400/15 transition-all duration-200 ease-in-out"
-                style={{ left: `${startPercent}%`, width: `${Math.max(0, endPercent - startPercent)}%` }}
+              <div 
+                className="absolute top-0 h-full bg-film-400/30 border-y border-film-400" 
+                style={{ left: `${startPercent}%`, width: `${Math.max(0, endPercent - startPercent)}%` }} 
               />
-              <button
-                type="button"
-                data-thumb="start"
-                aria-label="Drag trim start handle"
-                className={`pointer-events-auto absolute top-1/2 h-6 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full border bg-white/20 dark:bg-black/20 border-white/30 dark:border-white/10 shadow-md backdrop-blur-sm transition-all duration-200 ease-in-out hover:scale-105 active:scale-95 ${draggingThumb === "start" ? "shadow-[0_0_0_4px_rgba(255,191,87,0.14)]" : ""}`}
-                style={{ left: `${startPercent}%` }}
-              />
-              <button
-                type="button"
-                data-thumb="end"
-                aria-label="Drag trim end handle"
-                className={`pointer-events-auto absolute top-1/2 h-6 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full border bg-white/20 dark:bg-black/20 border-white/30 dark:border-white/10 shadow-md backdrop-blur-sm transition-all duration-200 ease-in-out hover:scale-105 active:scale-95 ${draggingThumb === "end" ? "shadow-[0_0_0_4px_rgba(255,191,87,0.14)]" : ""}`}
-                style={{ left: `${endPercent}%` }}
-              />
+              <button data-thumb="start" className="pointer-events-auto absolute top-0 h-full w-3 -translate-x-1/2 bg-white shadow-lg cursor-ew-resize" style={{ left: `${startPercent}%` }} />
+              <button data-thumb="end" className="pointer-events-auto absolute top-0 h-full w-3 -translate-x-1/2 bg-white shadow-lg cursor-ew-resize" style={{ left: `${endPercent}%` }} />
             </div>
           )}
         </div>

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -483,7 +483,8 @@ return () => {
                       recipe={recipe}
                       onChange={updateRecipe}
                       duration={duration}
-                      file={file}
+                      file={file} 
+                      seekTo={seekTo}
                     />
                   </AccordionSection>
 

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -444,18 +444,6 @@ return () => {
                     onSelectText={setSelectedTextId}
                     onUpdateText={handleUpdateTextOverlay}
                   />
-
-                  <div className="mt-3">
-                    <ThumbnailStrip
-                      videoSrc={videoSrc}
-                      duration={duration}
-                      currentTime={currentTime}
-                      trimStart={recipe.trimStart ?? 0}
-                      trimEnd={recipe.trimEnd ?? duration}
-                      onSeek={seekTo}
-                      intervalSeconds={intervalSeconds}
-                    />
-                  </div>
                 </div>
               )}
             </div>
@@ -485,6 +473,7 @@ return () => {
                       duration={duration}
                       file={file} 
                       seekTo={seekTo}
+                      videoRef={videoRef}
                     />
                   </AccordionSection>
 

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -304,33 +304,40 @@ export function useVideoEditor() {
     }
   }, []);
 
-  useEffect(() => {
+useEffect(() => {
     if (typeof window === "undefined") return;
-    try {
-      const params = new URLSearchParams();
-      const recipeKeys = Object.keys(DEFAULT_RECIPE) as Array<keyof EditRecipe>;
 
-      recipeKeys.forEach((key) => {
-        const currentVal = recipe[key];
-        const defaultVal = DEFAULT_RECIPE[key];
+    // Debounce the URL update to prevent history.replaceState security errors
+    // when dragging sliders rapidly (max 100 calls per 10s browser limit)
+    const timeoutId = setTimeout(() => {
+      try {
+        const params = new URLSearchParams();
+        const recipeKeys = Object.keys(DEFAULT_RECIPE) as Array<keyof EditRecipe>;
 
-        if (currentVal !== defaultVal) {
-          params.set(key, currentVal === null ? "null" : String(currentVal));
+        recipeKeys.forEach((key) => {
+          const currentVal = recipe[key];
+          const defaultVal = DEFAULT_RECIPE[key];
+
+          if (currentVal !== defaultVal) {
+            params.set(key, currentVal === null ? "null" : String(currentVal));
+          }
+        });
+
+        const newQuery = params.toString();
+        const currentQuery = window.location.search.replace(/^\?/, "");
+
+        if (newQuery !== currentQuery) {
+          const newUrl = newQuery
+            ? `${window.location.pathname}?${newQuery}`
+            : window.location.pathname;
+          window.history.replaceState(null, "", newUrl);
         }
-      });
-
-      const newQuery = params.toString();
-      const currentQuery = window.location.search.replace(/^\?/, "");
-
-      if (newQuery !== currentQuery) {
-        const newUrl = newQuery
-          ? `${window.location.pathname}?${newQuery}`
-          : window.location.pathname;
-        window.history.replaceState(null, "", newUrl);
+      } catch (e) {
+        // ignore
       }
-    } catch (e) {
-      // ignore
-    }
+    }, 500); // 500ms delay
+
+    return () => clearTimeout(timeoutId);
   }, [recipe]);
 
   useEffect(() => {

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -1,9 +1,13 @@
-import { EditRecipe, ExportResult, BackgroundMusicOptions, ImageOverlayOptions } from "./types";
+import {
+  EditRecipe,
+  ExportResult,
+  BackgroundMusicOptions,
+  ImageOverlayOptions,
+} from "./types";
 import { getPresetById } from "./presets";
 import { buildTextFilter } from "./text-overlay";
 
 export class FFmpegLoadError extends Error {}
-
 
 type SerializedFile = {
   name: string;
@@ -62,8 +66,10 @@ function createWorker(): Worker {
   }
 
   // MUST be strictly inline for Next.js/Webpack to detect and compile the worker chunk
-  ffmpegWorker = new Worker(new URL("./ffmpeg.worker.ts", import.meta.url), { type: "module" });
-  
+  ffmpegWorker = new Worker(new URL("./ffmpeg.worker.ts", import.meta.url), {
+    type: "module",
+  });
+
   ffmpegWorker.onmessage = handleWorkerMessage;
   ffmpegWorker.onerror = (event) => {
     const message = event.message || "FFmpeg worker error";
@@ -156,11 +162,11 @@ async function ensureWorker() {
 
 export async function loadFFmpeg(
   signal?: AbortSignal,
-  onProgress?: (percent: number) => void
+  onProgress?: (percent: number) => void,
 ): Promise<void> {
   // 1. Capture if the worker is uninitialized before ensureWorker runs
-  const isFirstLoad = !ffmpegWorker; 
-  
+  const isFirstLoad = !ffmpegWorker;
+
   await ensureWorker();
 
   if (workerReady && workerReadyResolve === null) {
@@ -201,7 +207,9 @@ export async function loadFFmpeg(
 
 function cancelPendingExport(reason?: unknown) {
   if (pendingExport) {
-    pendingExport.reject(reason ?? new DOMException("Export cancelled", "AbortError"));
+    pendingExport.reject(
+      reason ?? new DOMException("Export cancelled", "AbortError"),
+    );
     pendingExport = null;
   }
   pendingProgress = null;
@@ -213,7 +221,7 @@ export async function exportVideo(
   onProgress: (percent: number) => void,
   signal?: AbortSignal,
   musicOptions?: BackgroundMusicOptions,
-  overlayOptions?: ImageOverlayOptions
+  overlayOptions?: ImageOverlayOptions,
 ): Promise<ExportResult> {
   await loadFFmpeg(signal, onProgress);
 
@@ -286,7 +294,7 @@ export async function exportVideo(
       overlayFile: overlayFilePayload,
       overlayOptions: sanitizedOverlayOptions,
     } as WorkerExportRequest,
-    transfers
+    transfers,
   );
 
   try {
@@ -325,7 +333,11 @@ function buildSessionId(): string {
   return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
-export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number): string {
+export function buildVideoFilter(
+  recipe: EditRecipe,
+  targetW: number,
+  targetH: number,
+): string {
   const filters: string[] = [];
 
   if (recipe.trimStart > 0 || recipe.trimEnd !== null) {
@@ -348,12 +360,12 @@ export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: n
   if (recipe.framing === "fit") {
     filters.push(
       `scale=${targetW}:${targetH}:force_original_aspect_ratio=decrease`,
-      `pad=${targetW}:${targetH}:(ow-iw)/2:(oh-ih)/2:color=black`
+      `pad=${targetW}:${targetH}:(ow-iw)/2:(oh-ih)/2:color=black`,
     );
   } else {
     filters.push(
       `scale=${targetW}:${targetH}:force_original_aspect_ratio=increase`,
-      `crop=${targetW}:${targetH}`
+      `crop=${targetW}:${targetH}`,
     );
   }
 
@@ -373,13 +385,11 @@ export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: n
   }
 
   const needsEq =
-    recipe.brightness !== 0 ||
-    recipe.contrast !== 1 ||
-    recipe.saturation !== 1;
+    recipe.brightness !== 0 || recipe.contrast !== 1 || recipe.saturation !== 1;
 
   if (needsEq) {
     filters.push(
-      `eq=brightness=${recipe.brightness}:contrast=${recipe.contrast}:saturation=${recipe.saturation}`
+      `eq=brightness=${recipe.brightness}:contrast=${recipe.contrast}:saturation=${recipe.saturation}`,
     );
   }
 
@@ -392,7 +402,10 @@ export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: n
   return filters.join(",");
 }
 
-export function buildAudioFilter(speed: number, normalizeAudio: boolean): string {
+export function buildAudioFilter(
+  speed: number,
+  normalizeAudio: boolean,
+): string {
   if (speed <= 0) return "";
   const filters: string[] = [];
 
@@ -436,11 +449,13 @@ function buildArguments(
   overlayInputName: string,
   overlayOptions: ImageOverlayOptions | undefined,
   hasOriginalAudio: boolean,
-  videoDuration: number
+  videoDuration: number,
 ): string[] {
   const vf = buildVideoFilter(recipe, targetW, targetH);
   const audioTrim = hasOriginalAudio ? buildAudioTrimFilter(recipe) : "";
-  const audioSpeed = hasOriginalAudio ? buildAudioFilter(recipe.speed, recipe.normalizeAudio ?? false) : "";
+  const audioSpeed = hasOriginalAudio
+    ? buildAudioFilter(recipe.speed, recipe.normalizeAudio ?? false)
+    : "";
   const afParts = [audioTrim, audioSpeed].filter(Boolean);
   const af = afParts.join(",");
 
@@ -458,7 +473,8 @@ function buildArguments(
   }
 
   const needsFilterComplex = hasOverlay || hasMusicTrack;
-  const shouldKeepAudio = recipe.keepAudio && (hasOriginalAudio || hasMusicTrack);
+  const shouldKeepAudio =
+    recipe.keepAudio && (hasOriginalAudio || hasMusicTrack);
 
   if (needsFilterComplex) {
     const filterParts: string[] = [];
@@ -469,44 +485,45 @@ function buildArguments(
       videoOut = "[vbase]";
     }
 
-if (hasOverlay) {
-  const scaledW = overlayOptions!.size;
-  const alpha = (overlayOptions!.opacity / 100).toFixed(2);
-  const posMap: Record<string, string> = {
-    "top-left":     "20:20",
-    "top-right":    "main_w-w-20:20",
-    "bottom-left":  "20:main_h-h-20",
-    "bottom-right": "main_w-w-20:main_h-h-20",
-  };
+    if (hasOverlay) {
+      const scaledW = overlayOptions!.size;
+      const alpha = (overlayOptions!.opacity / 100).toFixed(2);
+      const posMap: Record<string, string> = {
+        "top-left": "20:20",
+        "top-right": "main_w-w-20:20",
+        "bottom-left": "20:main_h-h-20",
+        "bottom-right": "main_w-w-20:main_h-h-20",
+      };
 
-interface PositionCoords {
-    x: number;
-    y: number;
-  }
+      const pos =
+        typeof overlayOptions?.position === "string"
+          ? (posMap[overlayOptions.position] ?? "W-w-20:H-h-20")
+          : overlayOptions?.position
+            ? `(W-w)*${(overlayOptions.position as any).x}/100:(H-h)*${(overlayOptions.position as any).y}/100`
+            : "W-w-20:H-h-20";
 
-  const pos = typeof overlayOptions?.position === "string"
-    ? (posMap[overlayOptions.position] ?? "main_w-w-20:main_h-h-20")
-    : overlayOptions?.position
-    ? `(main_w)*${(overlayOptions.position as PositionCoords).x}/100:(main_h)*${(overlayOptions.position as PositionCoords).y}/100`
-    : "main_w-w-20:main_h-h-20";
-
-  filterParts.push(`[${overlayIdx}:v]scale=${scaledW}:-2,format=rgba,colorchannelmixer=aa=${alpha}[logo]`);
-  filterParts.push(`${videoOut}[logo]overlay=${pos}[vout]`);
-  videoOut = "[vout]";
-}
+      filterParts.push(
+        `[${overlayIdx}:v]scale=${scaledW}:-2,format=rgba,colorchannelmixer=aa=${alpha}[logo]`,
+      );
+      filterParts.push(`${videoOut}[logo]overlay=${pos}[vout]`);
+      videoOut = "[vout]";
+    }
 
     let audioOut = "";
     if (shouldKeepAudio) {
       if (hasMusicTrack) {
         const musicVol = (musicOptions!.musicVolume / 100).toFixed(2);
         if (hasOriginalAudio) {
-          const origVol  = (musicOptions!.originalAudioVolume / 100).toFixed(2);
-          const origChain = afParts.length > 0
-            ? `[0:a]${afParts.join(",")},volume=${origVol}[orig]`
-            : `[0:a]volume=${origVol}[orig]`;
+          const origVol = (musicOptions!.originalAudioVolume / 100).toFixed(2);
+          const origChain =
+            afParts.length > 0
+              ? `[0:a]${afParts.join(",")},volume=${origVol}[orig]`
+              : `[0:a]volume=${origVol}[orig]`;
           filterParts.push(origChain);
           filterParts.push(`[${musicIdx}:a]volume=${musicVol}[music]`);
-          filterParts.push(`[orig][music]amix=inputs=2:duration=first:dropout_transition=0[aout]`);
+          filterParts.push(
+            `[orig][music]amix=inputs=2:duration=first:dropout_transition=0[aout]`,
+          );
           audioOut = "[aout]";
         } else {
           filterParts.push(`[${musicIdx}:a]volume=${musicVol}[aout]`);
@@ -541,18 +558,39 @@ interface PositionCoords {
 
   if (format === "webm") {
     args.push(
-      "-c:v", "libvpx-vp9",
-      "-b:v", "0",
-      "-crf", String(recipe.quality),
-      "-cpu-used", "4",
-      "-deadline", "realtime"
+      "-c:v",
+      "libvpx-vp9",
+      "-b:v",
+      "0",
+      "-crf",
+      String(recipe.quality),
+      "-cpu-used",
+      "4",
+      "-deadline",
+      "realtime",
     );
     if (shouldKeepAudio) args.push("-c:a", "libopus");
   } else if (format === "mkv") {
-    args.push("-c:v", "libx264", "-crf", String(recipe.quality), "-preset", "ultrafast");
+    args.push(
+      "-c:v",
+      "libx264",
+      "-crf",
+      String(recipe.quality),
+      "-preset",
+      "ultrafast",
+    );
     if (shouldKeepAudio) args.push("-c:a", "aac", "-b:a", "128k");
   } else {
-    args.push("-c:v", "libx264", "-crf", String(recipe.quality), "-preset", "ultrafast", "-movflags", "+faststart");
+    args.push(
+      "-c:v",
+      "libx264",
+      "-crf",
+      String(recipe.quality),
+      "-preset",
+      "ultrafast",
+      "-movflags",
+      "+faststart",
+    );
     if (shouldKeepAudio) args.push("-c:a", "aac", "-b:a", "128k");
   }
 

--- a/src/lib/ffmpeg.worker.ts
+++ b/src/lib/ffmpeg.worker.ts
@@ -1,14 +1,22 @@
 import { FFmpeg } from "@ffmpeg/ffmpeg";
 import { toBlobURL } from "@ffmpeg/util";
-import { EditRecipe, BackgroundMusicOptions, ImageOverlayOptions } from "./types";
+import {
+  EditRecipe,
+  BackgroundMusicOptions,
+  ImageOverlayOptions,
+} from "./types";
 import { getPresetById } from "./presets";
 import { buildTextFilter } from "./text-overlay";
 
-const CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd";
-const MT_CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core-mt@0.12.6/dist/esm";
+const CORE_BASE_URL =
+  "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd";
+const MT_CORE_BASE_URL =
+  "https://cdn.jsdelivr.net/npm/@ffmpeg/core-mt@0.12.6/dist/esm";
 const SRI_HASHES: Record<string, string> = {
-  "ffmpeg-core.js":   "sha384-sKfkiFtvUk+vexk+0EUhEh366190/4WpgUAsUvaxEfyg7+E1Zt5Y5hrsU808g8Q9",
-  "ffmpeg-core.wasm": "sha384-U1VDhkPYrM3wTCT4/vjSpSsKqG/UjljYrYCI4hBSJ02svbCkxuCi6U6u/peg5vpW",
+  "ffmpeg-core.js":
+    "sha384-sKfkiFtvUk+vexk+0EUhEh366190/4WpgUAsUvaxEfyg7+E1Zt5Y5hrsU808g8Q9",
+  "ffmpeg-core.wasm":
+    "sha384-U1VDhkPYrM3wTCT4/vjSpSsKqG/UjljYrYCI4hBSJ02svbCkxuCi6U6u/peg5vpW",
 };
 
 type SerializedFile = {
@@ -35,7 +43,11 @@ type CancelRequest = { type: "cancel" };
 
 type TerminateRequest = { type: "terminate" };
 
-type WorkerCommand = LoadRequest | ExportRequest | CancelRequest | TerminateRequest;
+type WorkerCommand =
+  | LoadRequest
+  | ExportRequest
+  | CancelRequest
+  | TerminateRequest;
 
 type ProgressPayload = { type: "progress"; percent: number };
 
@@ -56,14 +68,22 @@ type ErrorPayload = { type: "error"; id?: string; message: string };
 
 type CancelledPayload = { type: "cancelled"; id?: string };
 
-type WorkerResponse = ProgressPayload | ReadyPayload | ResultPayload | ErrorPayload | CancelledPayload;
+type WorkerResponse =
+  | ProgressPayload
+  | ReadyPayload
+  | ResultPayload
+  | ErrorPayload
+  | CancelledPayload;
 
 let ffmpeg: FFmpeg | null = null;
 let ffmpegLoaded = false;
 let activeExportAbortController: AbortController | null = null;
 let activeExportId: string | null = null;
 
-async function fetchWithIntegrity(url: string, mimeType: string): Promise<string> {
+async function fetchWithIntegrity(
+  url: string,
+  mimeType: string,
+): Promise<string> {
   const key = url.split("/").pop()!;
   const integrity = SRI_HASHES[key];
 
@@ -79,7 +99,11 @@ async function fetchWithIntegrity(url: string, mimeType: string): Promise<string
   return URL.createObjectURL(blob);
 }
 
-function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number): string {
+function buildVideoFilter(
+  recipe: EditRecipe,
+  targetW: number,
+  targetH: number,
+): string {
   const filters: string[] = [];
 
   if (recipe.trimStart > 0 || recipe.trimEnd !== null) {
@@ -102,12 +126,12 @@ function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number):
   if (recipe.framing === "fit") {
     filters.push(
       `scale=${targetW}:${targetH}:force_original_aspect_ratio=decrease`,
-      `pad=${targetW}:${targetH}:(ow-iw)/2:(oh-ih)/2:color=black`
+      `pad=${targetW}:${targetH}:(ow-iw)/2:(oh-ih)/2:color=black`,
     );
   } else {
     filters.push(
       `scale=${targetW}:${targetH}:force_original_aspect_ratio=increase`,
-      `crop=${targetW}:${targetH}`
+      `crop=${targetW}:${targetH}`,
     );
   }
 
@@ -125,13 +149,11 @@ function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number):
   }
 
   const needsEq =
-    recipe.brightness !== 0 ||
-    recipe.contrast !== 1 ||
-    recipe.saturation !== 1;
+    recipe.brightness !== 0 || recipe.contrast !== 1 || recipe.saturation !== 1;
 
   if (needsEq) {
     filters.push(
-      `eq=brightness=${recipe.brightness}:contrast=${recipe.contrast}:saturation=${recipe.saturation}`
+      `eq=brightness=${recipe.brightness}:contrast=${recipe.contrast}:saturation=${recipe.saturation}`,
     );
   }
 
@@ -187,11 +209,13 @@ function buildArguments(
   overlayInputName: string,
   overlayOptions: ImageOverlayOptions | undefined,
   hasOriginalAudio: boolean,
-  videoDuration: number
+  videoDuration: number,
 ): string[] {
   const vf = buildVideoFilter(recipe, targetW, targetH);
   const audioTrim = hasOriginalAudio ? buildAudioTrimFilter(recipe) : "";
-  const audioSpeed = hasOriginalAudio ? buildAudioFilter(recipe.speed, recipe.normalizeAudio ?? false) : "";
+  const audioSpeed = hasOriginalAudio
+    ? buildAudioFilter(recipe.speed, recipe.normalizeAudio ?? false)
+    : "";
   const afParts = [audioTrim, audioSpeed].filter(Boolean);
   const af = afParts.join(",");
 
@@ -209,7 +233,8 @@ function buildArguments(
   }
 
   const needsFilterComplex = hasOverlay || hasMusicTrack;
-  const shouldKeepAudio = recipe.keepAudio && (hasOriginalAudio || hasMusicTrack);
+  const shouldKeepAudio =
+    recipe.keepAudio && (hasOriginalAudio || hasMusicTrack);
 
   if (needsFilterComplex) {
     const filterParts: string[] = [];
@@ -220,31 +245,29 @@ function buildArguments(
       videoOut = "[vbase]";
     }
 
-if (hasOverlay) {
-  const scaledW = overlayOptions!.size;
-  const alpha = (overlayOptions!.opacity / 100).toFixed(2);
-  const posMap: Record<string, string> = {
-    "top-left":     "20:20",
-    "top-right":    "W-w-20:20",
-    "bottom-left":  "20:H-h-20",
-    "bottom-right": "W-w-20:H-h-20",
-  };
+    if (hasOverlay) {
+      const scaledW = overlayOptions!.size;
+      const alpha = (overlayOptions!.opacity / 100).toFixed(2);
+      const posMap: Record<string, string> = {
+        "top-left": "20:20",
+        "top-right": "W-w-20:20",
+        "bottom-left": "20:H-h-20",
+        "bottom-right": "W-w-20:H-h-20",
+      };
 
-interface PositionCoords {
-    x: number;
-    y: number;
-  }
+      const pos =
+        typeof overlayOptions?.position === "string"
+          ? (posMap[overlayOptions.position] ?? "main_w-w-20:main_h-h-20")
+          : overlayOptions?.position
+            ? `(main_w)*${(overlayOptions.position as any).x}/100:(main_h)*${(overlayOptions.position as any).y}/100`
+            : "main_w-w-20:main_h-h-20";
 
-  const pos = typeof overlayOptions?.position === "string"
-    ? (posMap[overlayOptions.position] ?? "W-w-20:H-h-20")
-    : overlayOptions?.position
-    ? `(W-w)*${(overlayOptions.position as PositionCoords).x}/100:(H-h)*${(overlayOptions.position as PositionCoords).y}/100`
-    : "W-w-20:H-h-20";
-
-  filterParts.push(`[${overlayIdx}:v]scale=${scaledW}:-2,format=rgba,colorchannelmixer=aa=${alpha}[logo]`);
-  filterParts.push(`${videoOut}[logo]overlay=${pos}[vout]`);
-  videoOut = "[vout]";
-}
+      filterParts.push(
+        `[${overlayIdx}:v]scale=${scaledW}:-2,format=rgba,colorchannelmixer=aa=${alpha}[logo]`,
+      );
+      filterParts.push(`${videoOut}[logo]overlay=${pos}[vout]`);
+      videoOut = "[vout]";
+    }
 
     let audioOut = "";
     if (shouldKeepAudio) {
@@ -252,12 +275,15 @@ interface PositionCoords {
         const musicVol = (musicOptions!.musicVolume / 100).toFixed(2);
         if (hasOriginalAudio) {
           const origVol = (musicOptions!.originalAudioVolume / 100).toFixed(2);
-          const origChain = afParts.length > 0
-            ? `[0:a]${afParts.join(",")},volume=${origVol}[orig]`
-            : `[0:a]volume=${origVol}[orig]`;
+          const origChain =
+            afParts.length > 0
+              ? `[0:a]${afParts.join(",")},volume=${origVol}[orig]`
+              : `[0:a]volume=${origVol}[orig]`;
           filterParts.push(origChain);
           filterParts.push(`[${musicIdx}:a]volume=${musicVol}[music]`);
-          filterParts.push(`[orig][music]amix=inputs=2:duration=first:dropout_transition=0[aout]`);
+          filterParts.push(
+            `[orig][music]amix=inputs=2:duration=first:dropout_transition=0[aout]`,
+          );
           audioOut = "[aout]";
         } else {
           filterParts.push(`[${musicIdx}:a]volume=${musicVol}[aout]`);
@@ -292,18 +318,39 @@ interface PositionCoords {
 
   if (format === "webm") {
     args.push(
-      "-c:v", "libvpx-vp9",
-      "-b:v", "0",
-      "-crf", String(recipe.quality),
-      "-cpu-used", "4",
-      "-deadline", "realtime"
+      "-c:v",
+      "libvpx-vp9",
+      "-b:v",
+      "0",
+      "-crf",
+      String(recipe.quality),
+      "-cpu-used",
+      "4",
+      "-deadline",
+      "realtime",
     );
     if (shouldKeepAudio) args.push("-c:a", "libopus");
   } else if (format === "mkv") {
-    args.push("-c:v", "libx264", "-crf", String(recipe.quality), "-preset", "ultrafast");
+    args.push(
+      "-c:v",
+      "libx264",
+      "-crf",
+      String(recipe.quality),
+      "-preset",
+      "ultrafast",
+    );
     if (shouldKeepAudio) args.push("-c:a", "aac", "-b:a", "128k");
   } else {
-    args.push("-c:v", "libx264", "-crf", String(recipe.quality), "-preset", "ultrafast", "-movflags", "+faststart");
+    args.push(
+      "-c:v",
+      "libx264",
+      "-crf",
+      String(recipe.quality),
+      "-preset",
+      "ultrafast",
+      "-movflags",
+      "+faststart",
+    );
     if (shouldKeepAudio) args.push("-c:a", "aac", "-b:a", "128k");
   }
 
@@ -336,10 +383,19 @@ async function loadCore(onProgress?: (percent: number) => void): Promise<void> {
 
   try {
     await ffmpeg.load({
-      coreURL: await fetchWithIntegrity(`${baseURL}/ffmpeg-core.js`, "text/javascript"),
-      wasmURL: await fetchWithIntegrity(`${baseURL}/ffmpeg-core.wasm`, "application/wasm"),
+      coreURL: await fetchWithIntegrity(
+        `${baseURL}/ffmpeg-core.js`,
+        "text/javascript",
+      ),
+      wasmURL: await fetchWithIntegrity(
+        `${baseURL}/ffmpeg-core.wasm`,
+        "application/wasm",
+      ),
       ...(isIsolated && {
-        workerURL: await fetchWithIntegrity(`${baseURL}/ffmpeg-core.worker.js`, "text/javascript"),
+        workerURL: await fetchWithIntegrity(
+          `${baseURL}/ffmpeg-core.worker.js`,
+          "text/javascript",
+        ),
       }),
     });
 
@@ -359,7 +415,10 @@ function getOutputConfig(format: string, sessionId: string) {
     case "webm":
       return { filename: `output_${sessionId}.webm`, mimeType: "video/webm" };
     case "mkv":
-      return { filename: `output_${sessionId}.mkv`, mimeType: "video/x-matroska" };
+      return {
+        filename: `output_${sessionId}.mkv`,
+        mimeType: "video/x-matroska",
+      };
     case "gif":
       return { filename: `output_${sessionId}.gif`, mimeType: "image/gif" };
     default:
@@ -402,21 +461,35 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
   const ext = request.file.name.split(".").pop() ?? "mp4";
   const inputName = `input_${sessionId}.${ext}`;
 
-  const { filename: outputName, mimeType } = getOutputConfig(recipe.format, sessionId);
+  const { filename: outputName, mimeType } = getOutputConfig(
+    recipe.format,
+    sessionId,
+  );
   const fallbackOutputName = `fallback_${sessionId}.webm`;
   const paletteName = `palette_${sessionId}.png`;
-  const cleanupFiles = new Set<string>([inputName, outputName, fallbackOutputName, paletteName]);
+  const cleanupFiles = new Set<string>([
+    inputName,
+    outputName,
+    fallbackOutputName,
+    paletteName,
+  ]);
 
   const fileBytes = serializeFileBuffer(request.file);
-  await ffmpeg.writeFile(inputName, fileBytes, { signal: activeExportAbortController?.signal });
+  await ffmpeg.writeFile(inputName, fileBytes, {
+    signal: activeExportAbortController?.signal,
+  });
 
   const hasMusicTrack = !!(request.musicFile && recipe.keepAudio);
   const musicInputName = `music_input_${sessionId}.mp3`;
   if (hasMusicTrack) {
     cleanupFiles.add(musicInputName);
-    await ffmpeg.writeFile(musicInputName, serializeFileBuffer(request.musicFile!), {
-      signal: activeExportAbortController?.signal,
-    });
+    await ffmpeg.writeFile(
+      musicInputName,
+      serializeFileBuffer(request.musicFile!),
+      {
+        signal: activeExportAbortController?.signal,
+      },
+    );
   }
 
   const hasOverlay = !!request.overlayFile;
@@ -424,16 +497,23 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
   const overlayInputName = `overlay_${sessionId}.${overlayExt}`;
   if (hasOverlay) {
     cleanupFiles.add(overlayInputName);
-    await ffmpeg.writeFile(overlayInputName, serializeFileBuffer(request.overlayFile!), {
-      signal: activeExportAbortController?.signal,
-    });
+    await ffmpeg.writeFile(
+      overlayInputName,
+      serializeFileBuffer(request.overlayFile!),
+      {
+        signal: activeExportAbortController?.signal,
+      },
+    );
   }
 
   const videoDuration = request.videoDuration;
 
   const handleProgress = ({ progress }: { progress: number }) => {
     if (activeExportId !== sessionId) return;
-    postMessage({ type: "progress", percent: Math.min(99, Math.round(progress * 100)) });
+    postMessage({
+      type: "progress",
+      percent: Math.min(99, Math.round(progress * 100)),
+    });
   };
 
   let logListener: ((event: { message: string }) => void) | null = null;
@@ -447,25 +527,45 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
         ? `[0:v]${vf}[x];[x][1:v]paletteuse`
         : "[0:v][1:v]paletteuse";
 
-      const gifDurationArgs = recipe.speed !== 1
-        ? (() => {
-            const sourceDuration = (recipe.trimEnd ?? videoDuration) - recipe.trimStart;
-            const outputDuration = sourceDuration / recipe.speed;
-            return ["-t", outputDuration.toFixed(6)];
-          })()
-        : [];
+      const gifDurationArgs =
+        recipe.speed !== 1
+          ? (() => {
+              const sourceDuration =
+                (recipe.trimEnd ?? videoDuration) - recipe.trimStart;
+              const outputDuration = sourceDuration / recipe.speed;
+              return ["-t", outputDuration.toFixed(6)];
+            })()
+          : [];
 
       const pass1Code = await ffmpeg.exec(
-        ["-i", inputName, "-vf", vfWithPalette, ...gifDurationArgs, "-y", paletteName],
+        [
+          "-i",
+          inputName,
+          "-vf",
+          vfWithPalette,
+          ...gifDurationArgs,
+          "-y",
+          paletteName,
+        ],
         undefined,
-        { signal: activeExportAbortController?.signal }
+        { signal: activeExportAbortController?.signal },
       );
       if (pass1Code !== 0) throw new Error("GIF palette generation failed");
 
       const pass2Code = await ffmpeg.exec(
-        ["-i", inputName, "-i", paletteName, "-lavfi", vfWithPaletteUse, ...gifDurationArgs, "-y", outputName],
+        [
+          "-i",
+          inputName,
+          "-i",
+          paletteName,
+          "-lavfi",
+          vfWithPaletteUse,
+          ...gifDurationArgs,
+          "-y",
+          outputName,
+        ],
         undefined,
-        { signal: activeExportAbortController?.signal }
+        { signal: activeExportAbortController?.signal },
       );
       if (pass2Code !== 0) throw new Error("GIF export failed");
 
@@ -512,7 +612,7 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
       overlayInputName,
       request.overlayOptions,
       true,
-      videoDuration
+      videoDuration,
     );
 
     let exitCode = await ffmpeg.exec(args, undefined, {
@@ -535,7 +635,7 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
         overlayInputName,
         request.overlayOptions,
         false,
-        videoDuration
+        videoDuration,
       );
       exitCode = await ffmpeg.exec(args, undefined, {
         signal: activeExportAbortController?.signal,
@@ -557,7 +657,7 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
         overlayInputName,
         request.overlayOptions,
         !missingAudioDetected,
-        videoDuration
+        videoDuration,
       );
 
       const fallbackCode = await ffmpeg.exec(args, undefined, {
@@ -641,7 +741,11 @@ async function handleCommand(message: WorkerCommand) {
     }
     case "export": {
       if (!ffmpeg) {
-        postMessage({ type: "error", id: message.id, message: "FFmpeg engine is not loaded." });
+        postMessage({
+          type: "error",
+          id: message.id,
+          message: "FFmpeg engine is not loaded.",
+        });
         return;
       }
       if (activeExportAbortController?.signal.aborted) {
@@ -663,7 +767,11 @@ async function handleCommand(message: WorkerCommand) {
         if (activeExportAbortController?.signal.aborted) {
           postMessage({ type: "cancelled", id: message.id });
         } else {
-          postMessage({ type: "error", id: message.id, message: (error as Error).message });
+          postMessage({
+            type: "error",
+            id: message.id,
+            message: (error as Error).message,
+          });
         }
       } finally {
         activeExportAbortController = null;
@@ -672,7 +780,10 @@ async function handleCommand(message: WorkerCommand) {
       return;
     }
     case "cancel": {
-      if (activeExportAbortController && !activeExportAbortController.signal.aborted) {
+      if (
+        activeExportAbortController &&
+        !activeExportAbortController.signal.aborted
+      ) {
         activeExportAbortController.abort();
       }
       return;


### PR DESCRIPTION
## Description
This PR introduces an interactive, dual-thumb range slider overlay directly on top of the trimming timeline to drastically elevate the visual editing workflow.
**Key changes include:**
- **Interactive Timeline Tracks:** Implemented dual-thumb visual handles inside src/components/TrimControl.tsx overlaying the WaveformCanvas container. Powered by standard React pointer events (onPointerDown, onPointerMove, onPointerUp) to guarantee native desktop and touch-screen responsiveness.
- **Live Video Scrubbing:** Hooked the active dragging state into the parent seekTo context passed down via src/components/VideoEditor.tsx. The HTML5 video element now mirrors timeline adjustments frame-by-frame in real-time.
- **URL Caching Optimization:** Wrapped the query-parameter tracking mechanism within src/hooks/useVideoEditor.ts inside a 500ms debounce loop. This completely eliminates client-side SecurityError page crashes caused by rapid history.replaceState triggers during handle scrubbing.
- **Accessibility Maintained:** Retained full functionality of the native numeric inputs underneath the track for pixel-perfect millisecond precision and accessible screen-reader compatibility.

## Related Issue
Fixes #537 

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: @SatyaViswas
- Contribution level (Beginner/Intermediate/Advanced): Intermediate/Advanced

## Screen Recording

**Before:**

https://github.com/user-attachments/assets/fb16ee26-69f8-4cc3-9870-1b6363e466a6


**After:**

https://github.com/user-attachments/assets/16ba838c-0c2a-46cf-ad08-a21e16c713eb


## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)

