### PR TITLE
fix: resolve audio filter infinite loops, thumbnail strip races, and custom dimension bypasses

### DIFF
--- a/src/components/ThumbnailStrip.tsx
+++ b/src/components/ThumbnailStrip.tsx
@@ -32,81 +32,100 @@ export default function ThumbnailStrip({
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const stripRef = useRef<HTMLDivElement>(null);
   const offscreenVideoRef = useRef<HTMLVideoElement | null>(null);
-  const abortRef = useRef(false);
+  const lastRunIdRef = useRef(0);
 
   const effectiveTrimEnd = trimEnd ?? duration;
 
   const generateThumbnails = useCallback(async () => {
     if (!videoSrc || duration <= 0) return;
 
-    abortRef.current = false;
+    const runId = ++lastRunIdRef.current;
     setIsGenerating(true);
     setThumbnails([]);
     setProgress(0);
 
     const video = document.createElement("video");
-    video.src = videoSrc;
-    video.crossOrigin = "anonymous";
-    video.muted = true;
-    video.preload = "auto";
-    offscreenVideoRef.current = video;
+    try {
+      video.src = videoSrc;
+      video.crossOrigin = "anonymous";
+      video.muted = true;
+      video.preload = "auto";
+      offscreenVideoRef.current = video;
 
-    await new Promise<void>((resolve, reject) => {
-      video.onloadedmetadata = () => resolve();
-      video.onerror = () => reject(new Error("Video load failed"));
-      video.load();
-    });
-
-    const canvas = document.createElement("canvas");
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-
-    const thumbW = 160;
-    const thumbH = 90;
-    canvas.width = thumbW;
-    canvas.height = thumbH;
-
-    const times: number[] = [];
-    for (let t = 0; t <= duration; t += intervalSeconds) {
-      times.push(Math.min(t, duration - 0.1));
-    }
-    if (times[times.length - 1] < duration - 0.5) {
-      times.push(duration - 0.1);
-    }
-
-    const captured: Thumbnail[] = [];
-
-    for (let i = 0; i < times.length; i++) {
-      if (abortRef.current) break;
-
-      const time = times[i];
-      await new Promise<void>((resolve) => {
-        const onSeeked = () => {
-          video.removeEventListener("seeked", onSeeked);
-          ctx.drawImage(video, 0, 0, thumbW, thumbH);
-          captured.push({ time, dataUrl: canvas.toDataURL("image/jpeg", 0.7) });
-          setThumbnails([...captured]);
-          setProgress(Math.round(((i + 1) / times.length) * 100));
-          resolve();
-        };
-        video.addEventListener("seeked", onSeeked);
-        video.currentTime = time;
+      await new Promise<void>((resolve, reject) => {
+        video.onloadedmetadata = () => resolve();
+        video.onerror = () => reject(new Error("Video load failed"));
+        video.load();
       });
-    }
 
-    video.src = "";
-    offscreenVideoRef.current = null;
-    setIsGenerating(false);
+      if (lastRunIdRef.current !== runId) return;
+
+      const canvas = document.createElement("canvas");
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+
+      const thumbW = 160;
+      const thumbH = 90;
+      canvas.width = thumbW;
+      canvas.height = thumbH;
+
+      const times: number[] = [];
+      for (let t = 0; t <= duration; t += intervalSeconds) {
+        times.push(Math.min(t, duration - 0.1));
+      }
+      if (times[times.length - 1] < duration - 0.5) {
+        times.push(duration - 0.1);
+      }
+
+      const captured: Thumbnail[] = [];
+
+      for (let i = 0; i < times.length; i++) {
+        if (lastRunIdRef.current !== runId) break;
+
+        const time = times[i];
+        await new Promise<void>((resolve) => {
+          const onSeeked = () => {
+            video.removeEventListener("seeked", onSeeked);
+            if (lastRunIdRef.current !== runId) {
+              resolve();
+              return;
+            }
+            ctx.drawImage(video, 0, 0, thumbW, thumbH);
+            captured.push({ time, dataUrl: canvas.toDataURL("image/jpeg", 0.7) });
+            setThumbnails([...captured]);
+            setProgress(Math.round(((i + 1) / times.length) * 100));
+            resolve();
+          };
+          video.addEventListener("seeked", onSeeked);
+          video.currentTime = time;
+        });
+      }
+
+      if (lastRunIdRef.current === runId) {
+        setIsGenerating(false);
+      }
+    } catch (err) {
+      console.error(err);
+      if (lastRunIdRef.current === runId) {
+        setIsGenerating(false);
+      }
+    } finally {
+      video.src = "";
+      if (offscreenVideoRef.current === video) {
+        offscreenVideoRef.current = null;
+      }
+    }
   }, [videoSrc, duration, intervalSeconds]);
 
   useEffect(() => {
     if (videoSrc && duration > 0) {
       generateThumbnails();
     }
+    const currentRun = lastRunIdRef;
     return () => {
-      abortRef.current = true;
+      currentRun.current++;
     };
-  }, [generateThumbnails]);
+  }, [generateThumbnails, videoSrc, duration]);
 
   const formatTime = (seconds: number) => {
     const m = Math.floor(seconds / 60);

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -77,11 +77,11 @@ function validateRecipe(recipe: EditRecipe, duration: number ): string | null {
       "Trim start time must be earlier than the end time.",
     ],
     [
-      recipe.preset === "custom" && (recipe.customWidth < 16 || recipe.customWidth > 7680),
+      recipe.preset === "custom" && (Number.isNaN(recipe.customWidth) || recipe.customWidth < 16 || recipe.customWidth > 7680),
       "Width must be between 16px and 7680px.",
     ],
     [
-      recipe.preset === "custom" && (recipe.customHeight < 16 || recipe.customHeight > 7680),
+      recipe.preset === "custom" && (Number.isNaN(recipe.customHeight) || recipe.customHeight < 16 || recipe.customHeight > 7680),
       "Height must be between 16px and 7680px.",
     ],
     [
@@ -229,14 +229,28 @@ export function useVideoEditor() {
         const saved = localStorage.getItem("reframe-settings");
         if (saved) {
           const parsed = JSON.parse(saved);
-          setRecipe(prev => ({
-            ...prev,
-            preset: parsed.preset ?? prev.preset,
-            quality: parsed.quality ?? prev.quality,
-            speed: parsed.speed ?? prev.speed,
-            customWidth: parsed.customWidth ?? prev.customWidth,
-            customHeight: parsed.customHeight ?? prev.customHeight
-          }));
+          setRecipe(prev => {
+            const sanitized: Partial<EditRecipe> = {};
+            if (typeof parsed.preset === "string") {
+              sanitized.preset = parsed.preset;
+            }
+            if (typeof parsed.quality === "number" && !Number.isNaN(parsed.quality) && parsed.quality >= 18 && parsed.quality <= 30) {
+              sanitized.quality = parsed.quality;
+            }
+            if (typeof parsed.speed === "number" && !Number.isNaN(parsed.speed) && [0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 4].includes(parsed.speed)) {
+              sanitized.speed = parsed.speed;
+            }
+            if (typeof parsed.customWidth === "number" && !Number.isNaN(parsed.customWidth) && parsed.customWidth >= 16 && parsed.customWidth <= 7680) {
+              sanitized.customWidth = parsed.customWidth;
+            }
+            if (typeof parsed.customHeight === "number" && !Number.isNaN(parsed.customHeight) && parsed.customHeight >= 16 && parsed.customHeight <= 7680) {
+              sanitized.customHeight = parsed.customHeight;
+            }
+            return {
+              ...prev,
+              ...sanitized
+            };
+          });
         }
       }
     } catch (e) {

--- a/src/lib/exportEstimate.test.ts
+++ b/src/lib/exportEstimate.test.ts
@@ -1,3 +1,4 @@
+import { describe, test, expect } from "vitest";
 import { estimateExportSize, formatEstimatedSize } from "./exportEstimate";
 import { EditRecipe } from "./types";
 

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -132,6 +132,7 @@ function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number):
 }
 
  export function buildAudioFilter(speed: number, normalizeAudio: boolean): string {
+  if (speed <= 0) return "";
   const filters: string[] = [];
 
   let remaining = speed;


### PR DESCRIPTION
This pull request resolves the three assigned issues under GSSoC 2026.

### Proposed Fixes

1. **buildAudioFilter safety check (Resolves #862)**
   - Added validation check to return an empty string if speed is zero or negative. This prevents thread-blocking infinite loops where values divided by 0.5 never incremented or drifted towards negative infinity.

2. **generateThumbnails concurrency control and resource release (Resolves #863)**
   - Implemented run identifier tracking using lastRunIdRef to discard stale callbacks when newer generation runs are started.
   - Wrapped thumbnail generation inside a try/catch/finally block to ensure that video.src = "" is executed, releasing video element resources and preventing memory leaks.

3. **validateRecipe custom dimensions NaN checks and sanitization (Resolves #864)**
   - Updated validation rules to explicitly check for NaN custom dimensions using Number.isNaN.
   - Added sanitization logic to the settings parser loading from localStorage to validate and sanitize values before merging them into state.
   - Updated exportEstimate.test.ts to import Vitest variables correctly, resolving a pre-existing testing environment issue.

### Verification

- Successfully built the application (npm run build). All previous ESLint dependency warnings are resolved.
- Ran Vitest unit tests (npx vitest run) and all 53 tests passed successfully.
