### PR TITLE
fix: add unique metadata titles to Contact and Privacy pages

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,6 +1,7 @@
+import type { Metadata } from "next";
 import Link from "next/link";
-export const metadata = {
-  title: "Contact | Reframe",
+export const metadata: Metadata = {
+  title: "Contact — Reframe",
   description: "Get in touch with the Reframe team.",
 };
 export default function ContactPage() {

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,6 +1,7 @@
+import type { Metadata } from "next";
 import Link from "next/link";
-export const metadata = {
-  title: "Privacy Policy | Reframe",
+export const metadata: Metadata = {
+  title: "Privacy Policy — Reframe",
   description: "Privacy policy for Reframe — your videos never leave your device.",
 };
 export default function PrivacyPage() {


### PR DESCRIPTION
## Description
Added unique `metadata` title exports to the Contact and Privacy pages. 
Previously, both pages inherited the default title from `layout.tsx`, 
so the browser tab never updated on navigation. Each page now has its 
own descriptive title.

## Related Issue
Closes #857

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] GSSoC contribution

## Participant Info
- GitHub username: Pranav-IIITM
- Contribution level : Beginner

## Screen Recording
> navigate to `/contact` and `/privacy` → observe 
> tab title updating on each page.

https://github.com/user-attachments/assets/3050d4df-4062-4877-9d1c-4a268872335b

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [ ] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)