### PR TITLE
fix: Prevent custom dimension inputs from clipping 4-digit values

### DIFF
--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -290,7 +290,7 @@ export default function PresetSelector({ recipe, onChange }: Props) {
               step={2}
               value={recipe.customWidth}
               onChange={(e) => handleWidthChange(Number(e.target.value))}
-              className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2 text-sm font-heading transition-all focus:outline-none focus:ring-2 focus:ring-film-400 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              className="w-full min-w-20 rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2 text-sm font-heading transition-all focus:outline-none focus:ring-2 focus:ring-film-400 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
             />
           </div>
 
@@ -316,7 +316,7 @@ export default function PresetSelector({ recipe, onChange }: Props) {
               step={2}
               value={recipe.customHeight}
               onChange={(e) => handleHeightChange(Number(e.target.value))}
-              className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2 text-sm font-heading transition-all focus:outline-none focus:ring-2 focus:ring-film-400 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              className="w-full min-w-20 rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2 text-sm font-heading transition-all focus:outline-none focus:ring-2 focus:ring-film-400 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
             />
           </div>
 


### PR DESCRIPTION
Resolves #876
**What changed?**
Added `min-w-20` to the custom width and height inputs in the `PresetSelector` component. 
**Why?**
As mentioned in the issue, the inputs were getting squished by flexbox layout constraints to the point where 4-digit resolutions (like 1920 or 1080) were getting clipped and looking like "19" and "10". Enforcing a minimum width ensures the inputs stay wide enough to comfortably fit standard video dimensions without breaking the UI on smaller panels. 
Let me know if you want me to make any adjustments! (GSSoC'26)
<img width="620" height="99" alt="image" src="https://github.com/user-attachments/assets/a02285c1-9d2e-4811-bf6c-f64cfd5a74a3" />
