### PR TITLE
fix(ffmpeg): guard buildAudioFilter against zero or negative speed

### DIFF
--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -132,6 +132,7 @@ function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number):
 }
 
  export function buildAudioFilter(speed: number, normalizeAudio: boolean): string {
+  if (speed <= 0) return "";
   const filters: string[] = [];
 
   let remaining = speed;


### PR DESCRIPTION
Closes #862

## Root Cause

`buildAudioFilter` in `src/lib/ffmpeg.ts` enters an infinite loop when `speed` is zero or negative. The loop condition is `while (remaining < 0.5)`, and inside the loop `remaining /= 0.5` is executed. When `speed` is `0`, `remaining` starts at `0` and `0 / 0.5 == 0`, so the value never changes and the loop never terminates. This blocks the browser thread entirely, freezing the tab.

## Fix

Added a guard at the top of `buildAudioFilter`:

```ts
if (speed <= 0) return "";
```

This returns an empty filter string immediately for any non-positive speed value, which is consistent with the function's existing behavior of returning `""` when no audio adjustment is needed. The FFmpeg caller already handles empty filter strings correctly.

## Scope

Single-line change in `src/lib/ffmpeg.ts`. No other files are touched.

## Testing

- `buildAudioFilter(0, false)` now returns `""` instead of hanging.
- `buildAudioFilter(-1, false)` now returns `""` instead of hanging.
- `buildAudioFilter(0.5, false)` returns `"atempo=0.5000"` (unchanged behavior).
- `buildAudioFilter(2.0, false)` returns `""` (unchanged behavior, no filter needed at exactly 2.0).
- `buildAudioFilter(1.5, true)` returns `"atempo=1.5000,loudnorm=I=-14:TP=-1.5:LRA=11"` (unchanged behavior).