### PR TITLE
fix: resolves mute shortcut collision

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -512,15 +512,13 @@ export function useVideoEditor() {
     };
   }, [file, status, handleExport]);
 
-
-
-  useEffect(()=>{
-    return ()=>{
-      if(result?.blobUrl){
+  useEffect(() => {
+    return () => {
+      if (result?.blobUrl) {
         URL.revokeObjectURL(result.blobUrl);
       }
-    }
-   },[result?.blobUrl])
+    };
+  }, [result?.blobUrl]);
 
   useEffect(() => {
     return () => {

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -512,30 +512,7 @@ export function useVideoEditor() {
     };
   }, [file, status, handleExport]);
 
-  // M key: toggle audio mute — only when a file is loaded and focus isn't in a text field
-  useEffect(() => {
-    if (!file) return;
 
-    const handleMuteShortcut = (e: KeyboardEvent) => {
-      if (e.key.toLowerCase() !== "m" || e.ctrlKey || e.metaKey || e.altKey) return;
-
-      const target = e.target as HTMLElement;
-      if (
-        target.tagName === "INPUT" ||
-        target.tagName === "TEXTAREA" ||
-        target.isContentEditable
-      ) {
-        return;
-      }
-
-      setRecipe((prev) => ({ ...prev, keepAudio: !prev.keepAudio }));
-    };
-
-    document.addEventListener("keydown", handleMuteShortcut);
-    return () => {
-      document.removeEventListener("keydown", handleMuteShortcut);
-    };
-  }, [file]);
 
   useEffect(()=>{
     return ()=>{

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["bun-types"],
+    "types": ["bun"],
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Description
Removes the redundant handleMuteShortcut useEffect block from useVideoEditor.ts that was causing the M keyboard shortcut to be completely non-functional.

Previously, two independent document.addEventListener calls were registered for the M key at the same time (one in useVideoEditor.ts and one in useKeyboardShortcuts.ts). Both fired on every keypress and scheduled concurrent state updates against the same state snapshot, cancelling each other out and leaving the mute status unchanged. The listener inside useKeyboardShortcuts.ts is the correct, centralized location for all keyboard shortcuts.
(Also includes a minor TypeScript config fix by updating the deprecated bun-types type definitions to bun in tsconfig.json to fix local compilation errors).

## Related Issue
fixes #903 

## Type of Contribution

- [x]  Bug fix
- [ ]  New feature
- [ ]  Documentation update
- [x]  GSSoC contribution

## Participant Info
GitHub username: Nightcoder-26
Contribution level (Beginner/Intermediate/Advanced): Intermediate

## ScreenRecording

https://github.com/user-attachments/assets/33a37ebe-f967-412b-a728-497608be5a83


## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)
