### PR TITLE
fix: prevent trim end input from stripping decimal points while typing

### DIFF
--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -59,39 +59,39 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
     }
   }, [xToSeconds, duration, recipe.trimStart, recipe.trimEnd, onChange]);
 
- useEffect(() => {
-  const onMove = (e: MouseEvent | TouchEvent) => {
-    let clientX: number;
+  useEffect(() => {
+    const onMove = (e: MouseEvent | TouchEvent) => {
+      let clientX: number;
 
-    if ("touches" in e) {
-      const touch = e.touches[0];
+      if ("touches" in e) {
+        const touch = e.touches[0];
 
-      if (!touch) return;
+        if (!touch) return;
 
-      clientX = touch.clientX;
-    } else {
-      clientX = e.clientX;
-    }
+        clientX = touch.clientX;
+      } else {
+        clientX = e.clientX;
+      }
 
-    applyDrag(clientX);
-  };
+      applyDrag(clientX);
+    };
 
-  const onUp = () => {
-    dragging.current = null;
-  };
+    const onUp = () => {
+      dragging.current = null;
+    };
 
-  document.addEventListener("mousemove", onMove);
-  document.addEventListener("mouseup", onUp);
-  document.addEventListener("touchmove", onMove);
-  document.addEventListener("touchend", onUp);
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+    document.addEventListener("touchmove", onMove);
+    document.addEventListener("touchend", onUp);
 
-  return () => {
-    document.removeEventListener("mousemove", onMove);
-    document.removeEventListener("mouseup", onUp);
-    document.removeEventListener("touchmove", onMove);
-    document.removeEventListener("touchend", onUp);
-  };
-}, [applyDrag]);
+    return () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+      document.removeEventListener("touchmove", onMove);
+      document.removeEventListener("touchend", onUp);
+    };
+  }, [applyDrag]);
   const handleStart = (val: string) => {
     setStartInput(val);
 
@@ -330,5 +330,3 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
     </div>
   );
 }
-
-

--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -20,6 +20,7 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
   const [startErrorMsg, setStartErrorMsg] = useState("");
   const [endErrorMsg, setEndErrorMsg] = useState("");
   const [startInput, setStartInput] = useState(recipe.trimStart.toString());
+  const [endInput, setEndInput] = useState(recipe.trimEnd !== null ? recipe.trimEnd.toString() : "");
 
   const { waveform, isLoading: waveformLoading } = useAudioWaveform(file);
   const hasAudio = waveform.length > 0;
@@ -27,6 +28,10 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
   useEffect(() => {
     setStartInput(recipe.trimStart.toString());
   }, [recipe.trimStart]);
+
+  useEffect(() => {
+    setEndInput(recipe.trimEnd !== null ? recipe.trimEnd.toString() : "");
+  }, [recipe.trimEnd]);
 
   const clipLength = (recipe.trimEnd ?? duration) - recipe.trimStart;
 
@@ -74,9 +79,12 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
   };
 
   const handleEnd = (val: string) => {
+    setEndInput(val);
+
     if (val === "") {
       onChange({ trimEnd: null });
       setEnd(false);
+      setEndErrorMsg("");
       return;
     }
 
@@ -181,7 +189,7 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
             min={0}
             max={duration > 0 ? duration : undefined}
             step={0.1}
-            value={recipe.trimEnd ?? ""}
+            value={endInput}
             spellCheck={false}
             onChange={(e) => handleEnd(e.target.value)}
             aria-label="Trim end time in seconds"

--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -134,6 +134,11 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
     onChange({ trimStart: n });
   };
 
+  /**
+   * Handles changes to the trim-end input field.
+   * Uses local `endInput` state to avoid stripping decimals mid-entry
+   * (e.g. typing "2." would not be coerced to "2" before the user finishes).
+   */
   const handleEnd = (val: string) => {
     setEndInput(val);
 


### PR DESCRIPTION

## Description
Fixes a bug where typing a decimal point in the Trim End input field would immediately strip the decimal, making it impossible to type values like 1.5 manually.
Previously, the Trim End input field bound its value directly to recipe.trimEnd. Because trimEnd is stored as a parsed float, typing a decimal point (e.g., 1.) caused the trailing decimal to be immediately stripped by parseFloat during the React re-render.

**Fix**: Introduced a local endInput state variable for the Trim End input, mirroring the existing architecture used for the startInput field. This acts as an intermediary text state, allowing users to type decimals naturally while keeping the underlying recipe state synchronized.

## Related Issue
fixes #904 

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info

- GitHub username: Nightcoder-26
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Screen Recording

https://github.com/user-attachments/assets/56012c4b-a3a8-419a-a6b4-434c6357bf9b



## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)
