### PR TITLE
fix: grab frame button ignores crop, scale, and rotate edits

### DIFF
--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useRef, useState, useCallback, RefObject } from "react";
 import { EditRecipe } from "@/lib/types";
 import { getPresetById } from "@/lib/presets";
+import { captureFrameAsPng } from "@/lib/frame-export";
 import { cn } from "@/lib/utils";
 import { Camera } from "lucide-react";
 
@@ -21,34 +22,22 @@ export default function VideoPreview({ file, recipe, videoRef }: Props) {
   const onLoadedRef = useRef<(() => void) | null>(null);
 
   /** Capture the current video frame and download it as a PNG. */
-  const handleGrabFrame = useCallback(() => {
+  const handleGrabFrame = useCallback(async () => {
     const video = videoRef.current;
-    if (!video || video.readyState < 2) return;
+    if (!video || video.readyState < 2 || !recipe) return;
 
-    const canvas = document.createElement("canvas");
-    canvas.width = video.videoWidth;
-    canvas.height = video.videoHeight;
-
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
-
-    canvas.toBlob((blob) => {
-      if (!blob) return;
-
-      const totalSec = Math.floor(video.currentTime);
-      const mins = String(Math.floor(totalSec / 60)).padStart(2, "0");
-      const secs = String(totalSec % 60).padStart(2, "0");
-      const filename = `frame-${mins}m${secs}s.png`;
-
+    try {
+      const { blob, filename } = await captureFrameAsPng(video, recipe);
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
       a.download = filename;
       a.click();
       URL.revokeObjectURL(url);
-    }, "image/png");
-  }, [videoRef]);
+    } catch (err) {
+      console.error("Failed to capture frame:", err);
+    }
+  }, [videoRef, recipe]);
 
   useEffect(() => {
     if (!file) return;

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -60,7 +60,6 @@ export default function VideoPreview({
   useEffect(() => {
     if (!file) return;
 
-    if (urlRef.current) URL.revokeObjectURL(urlRef.current);
     setIsLoading(true);
     const id = ++lastId.current;
     const url = URL.createObjectURL(file);


### PR DESCRIPTION

## Description
Fixes a bug where the "Grab Frame" button completely ignored all user edits (such as cropping, zooming, rotating, or aspect ratio changes) and instead downloaded the raw, original video frame directly from the <video> element.

**Fix:** Replaced the manual canvas drawing logic inside VideoPreview.tsx with the existing captureFrameAsPng(video, recipe) utility from frame-export.ts. This utility correctly computes and applies all recipe transformations (scale, rotation, crop dimensions) to the canvas before saving the PNG.

## Related Issue
fixes #905 

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info

- GitHub username: Nightcoder-26
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Screen Recording

https://github.com/user-attachments/assets/f5177305-6529-4b2a-9014-1f6f89358a26



## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)
