### PR TITLE
feat: add landing hero for first-time visitors

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -1,11 +1,15 @@
 "use client";
 
-import { useRef, useState, useEffect} from "react";
+import { forwardRef, useImperativeHandle, useRef, useState, useEffect } from "react";
 import { Film, FolderOpen } from "lucide-react";
 import LottiePlayer from "./LottiePlayer";
 import uploadAnim from "@/lib/lottie/upload.json";
 import { cn, formatBytes, formatDuration } from "@/lib/utils";
 import { MAX_FILE_SIZE, WARNING_FILE_SIZE } from "@/lib/types";
+
+export interface FileUploadHandle {
+  openFilePicker: () => void;
+}
 
 interface Props {
   onFileSelect: (file: File) => void;
@@ -14,13 +18,15 @@ interface Props {
   duration: number;
 }
 
-export default function FileUpload({
-  onFileSelect,
-  currentFile,
-  fileError,
-  duration,
-}: Props) {
+const FileUpload = forwardRef<FileUploadHandle, Props>(function FileUpload(
+  { onFileSelect, currentFile, fileError, duration },
+  ref
+) {
   const inputRef = useRef<HTMLInputElement>(null);
+
+  useImperativeHandle(ref, () => ({
+    openFilePicker: () => inputRef.current?.click(),
+  }));
 
   const [dragging, setDragging] = useState(false);
   const [error, setError] = useState("");
@@ -135,16 +141,6 @@ export default function FileUpload({
           {fileError}
         </p>
       )}
-      <input
-        ref={inputRef}
-        type="file"
-        accept="video/*"
-        className="hidden"
-        onChange={(e) => {
-          const f = e.target.files?.[0];
-          if (f) handleFile(f);
-        }}
-      />
     </div>
 
     <p className="text-xs text-gray-500 mt-3 break-words">
@@ -154,17 +150,6 @@ export default function FileUpload({
     {fileError && (
       <p className="text-xs text-red-500 mt-2 font-medium">{fileError}</p>
     )}
-
-    <input
-      ref={inputRef}
-      type="file"
-      accept="video/*"
-      className="hidden"
-      onChange={(e) => {
-        const f = e.target.files?.[0];
-        if (f) handleFile(f);
-      }}
-    />
   </div>
 );
   const DropZone = () => (
@@ -229,23 +214,6 @@ export default function FileUpload({
         <p className="text-sm text-red-500 text-center">{fileError}</p>
       )}
 
-      {currentFile && (
-        <p className="text-xs text-[var(--muted)] mt-2">
-          Selected: {formatBytes(currentFile.size)}
-        </p>
-      )}
-
-        <input
-          ref={inputRef}
-          type="file"
-          accept="video/*"
-          className="hidden"
-          onChange={(e) => {
-            const f = e.target.files?.[0];
-
-            if (f) handleFile(f);
-          }}
-        />
       </div>
   );
 
@@ -256,6 +224,21 @@ export default function FileUpload({
       {warning && <p className="text-sm text-yellow-500">{warning}</p>}
 
       {currentFile ? <FileInfo /> : <DropZone />}
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept="video/*"
+        className="hidden"
+        aria-hidden="true"
+        tabIndex={-1}
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          if (f) handleFile(f);
+        }}
+      />
     </div>
   );
-}
+});
+
+export default FileUpload;

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { Gift, Lock, WifiOff, Zap } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const FEATURES = [
+  { icon: Lock, label: "Private" },
+  { icon: Zap, label: "Fast" },
+  { icon: Gift, label: "Free" },
+  { icon: WifiOff, label: "Works offline" },
+] as const;
+
+interface HeroSectionProps {
+  onChooseVideo: () => void;
+}
+
+export default function HeroSection({ onChooseVideo }: HeroSectionProps) {
+  return (
+    <section
+      aria-labelledby="hero-headline"
+      className="mb-5 animate-fade-in"
+    >
+      <div className="relative text-center px-2 sm:px-4 py-4 sm:py-6">
+        <div
+          className="pointer-events-none absolute inset-x-0 top-1/2 -translate-y-1/2 h-32 sm:h-40 bg-gradient-to-b from-film-500/10 via-transparent to-transparent blur-2xl rounded-full"
+          aria-hidden="true"
+        />
+
+        <div className="relative space-y-3 sm:space-y-4 max-w-2xl mx-auto">
+          <h2
+            id="hero-headline"
+            className="font-display text-2xl sm:text-3xl lg:text-4xl leading-tight tracking-wide text-[var(--text)]"
+          >
+            Resize, trim &amp; export videos — entirely in your browser
+          </h2>
+
+          <p className="font-heading text-sm sm:text-base text-[var(--muted)] leading-relaxed">
+            No upload. No account. No limits. Powered by FFmpeg.wasm
+          </p>
+
+          <ul
+            className="flex flex-wrap items-center justify-center gap-2 sm:gap-3 pt-1"
+            aria-label="Features"
+          >
+            {FEATURES.map(({ icon: Icon, label }) => (
+              <li key={label}>
+                <span
+                  className={cn(
+                    "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full",
+                    "text-xs font-heading font-semibold uppercase tracking-wider",
+                    "bg-[var(--bg)] border border-[var(--border)] text-[var(--muted)]"
+                  )}
+                >
+                  <Icon size={14} className="text-film-500 shrink-0" aria-hidden="true" />
+                  {label}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          <div className="pt-2 sm:pt-3">
+            <button
+              type="button"
+              onClick={onChooseVideo}
+              aria-label="Choose a video to edit"
+              className={cn(
+                "inline-flex items-center justify-center gap-2",
+                "px-8 py-3.5 sm:px-10 sm:py-4 rounded-xl",
+                "font-display text-lg sm:text-xl tracking-widest",
+                "bg-film-600 hover:bg-film-700 text-white",
+                "shadow-lg shadow-film-500/20",
+                "hover:scale-[1.02] active:scale-[0.98]",
+                "transition-all duration-200"
+              )}
+            >
+              Choose a video
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -3,7 +3,8 @@
 
 import { useState, useRef, useEffect, useMemo } from "react";
 import { useVideoEditor } from "@/hooks/useVideoEditor";
-import FileUpload from "./FileUpload";
+import FileUpload, { type FileUploadHandle } from "./FileUpload";
+import HeroSection from "./HeroSection";
 import VideoPreview from "./VideoPreview";
 import ThumbnailStrip from "./ThumbnailStrip";
 import PresetSelector from "./PresetSelector";
@@ -63,6 +64,8 @@ export default function VideoEditor() {
   } = useVideoEditor();
   const [copied, setCopied] = useState(false);
   const downloadRef = useRef<HTMLDivElement>(null);
+  const fileUploadRef = useRef<FileUploadHandle>(null);
+  const hasFile = Boolean(file);
 
   useEffect(() => {
     if (status === "done" && downloadRef.current) {
@@ -119,14 +122,19 @@ export default function VideoEditor() {
 
           <div className="space-y-4 min-w-0">
             <div className="bg-[var(--surface)] rounded-xl p-5 border border-[var(--border)] animate-fade-in">
-              <FileUpload onFileSelect={handleFileSelect} currentFile={file} fileError={fileError} duration={duration} />
-
-              {!file && (
-              <div className="text-center text-[var(--muted)] py-6">
-                <p>Upload a video to get started</p>
-                <p className="text-sm">Supports MP4, MOV, WebM and more</p>
-              </div>
+              {!hasFile && (
+                <HeroSection
+                  onChooseVideo={() => fileUploadRef.current?.openFilePicker()}
+                />
               )}
+
+              <FileUpload
+                ref={fileUploadRef}
+                onFileSelect={handleFileSelect}
+                currentFile={file}
+                fileError={fileError}
+                duration={duration}
+              />
 
               {file && (
                 <div className="mt-4 animate-fade-in">


### PR DESCRIPTION
## Description
Added a responsive landing hero section for first-time visitors above the upload dropzone.

The hero introduces the product value proposition, highlights key features, and provides a prominent CTA that reuses the existing file picker flow. The hero automatically hides once a video is uploaded, preserving the current editor experience.

---

## Related Issue
Closes #671

---

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] GSSoC contribution

---

## Participant Info
- GitHub username: jaygaikar-09
- Contribution level (Beginner/Intermediate/Advanced): Advanced

---

## Screen Recording

https://drive.google.com/file/d/1vw_2R4S8YKQ3nvZv-byTIrf82ZGBActl/view?usp=sharing

---

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)

---

## Summary of Changes
- Added `HeroSection` component
- Added responsive landing hero UI with:
  - headline
  - subheadline
  - feature pills
  - CTA button
- Hero renders only when no file is loaded
- CTA reuses the existing upload/file picker flow
- Refactored `FileUpload` to expose `openFilePicker()` via `forwardRef`
- Removed duplicate hidden file inputs
- Preserved existing editor/upload behavior after file selection