### PR TITLE
Fix: Prevent premature state update and export corruption in TrimControl

### DIFF
--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -82,8 +82,6 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
 
     const n = parseFloat(val);
 
-    onChange({ trimEnd: n });
-
     if (isNaN(n)) {
       setEnd(true);
       setEndErrorMsg("Enter a valid number.");
@@ -112,6 +110,7 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
 
     setEnd(false);
     setEndErrorMsg("");
+    onChange({ trimEnd: n });
   };
 
   const inputClass =

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -70,11 +70,13 @@ function validateRecipe(recipe: EditRecipe, duration: number ): string | null {
       "Trim start time cannot be less than 0 seconds.",
     ],
     [
-      recipe.trimEnd !== null && recipe.trimEnd > duration,
+      recipe.trimEnd !== null && duration > 0 && recipe.trimEnd > duration,
       `Trim end time cannot exceed the video duration (${Math.floor(duration)}s).`,
     ],
     [
-      recipe.trimStart >= (recipe.trimEnd ?? duration),
+      recipe.trimEnd !== null 
+        ? recipe.trimStart >= recipe.trimEnd 
+        : (duration > 0 && recipe.trimStart >= duration),
       "Trim start time must be earlier than the end time.",
     ],
     [


### PR DESCRIPTION
## Description
This pull request fixes a critical state corruption bug in the video trimming workflow.
**The Problem:**
Previously, the `handleEnd` function in `TrimControl` updated the global `recipe.trimEnd` state *before* validating the user's input. If a user entered an invalid value (resulting in `NaN`) or an out-of-bounds value, the `NaN` value was committed to the state despite the UI showing an error. This bypassed the pre-export validation (`NaN > duration` evaluates to `false`), passing corrupted state to FFmpeg and causing the video export to fail/crash.
**The Solution:**
Moved the `onChange({ trimEnd: n })` state dispatch to the very end of the `handleEnd` function. The global recipe state is now only updated *after* all input validation checks (like `isNaN`, positive integer bounds, and duration checks) pass successfully.
**Testing:**
- Verified that entering invalid characters correctly shows an inline error without persisting to the global `recipe`.
- Verified that valid inputs successfully update the state.
- Verified that corrupted values no longer bypass the export validations.

Closes #954 