### PR TITLE
Fix: Allow exporting of videos with unknown duration (e.g. streaming WebM)

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -70,11 +70,13 @@ function validateRecipe(recipe: EditRecipe, duration: number ): string | null {
       "Trim start time cannot be less than 0 seconds.",
     ],
     [
-      recipe.trimEnd !== null && recipe.trimEnd > duration,
+      recipe.trimEnd !== null && duration > 0 && recipe.trimEnd > duration,
       `Trim end time cannot exceed the video duration (${Math.floor(duration)}s).`,
     ],
     [
-      recipe.trimStart >= (recipe.trimEnd ?? duration),
+      recipe.trimEnd !== null 
+        ? recipe.trimStart >= recipe.trimEnd 
+        : (duration > 0 && recipe.trimStart >= duration),
       "Trim start time must be earlier than the end time.",
     ],
     [


### PR DESCRIPTION

## Description
This pull request fixes a critical bug where videos missing duration metadata (such as streaming WebM blobs where `video.duration` is `Infinity`) were completely blocked from being exported. 

**The Problem:**
When `extractMetadata` encountered a video with `Infinity` duration, it correctly fell back to setting the duration to `0`. However, the validation checks in `useVideoEditor.ts` rigidly enforced that `trimStart` (default `0`) must be earlier than the duration. This caused `0 >= 0` to evaluate to `true`, instantly failing the validation and throwing a "Trim start time must be earlier than the end time" error, making these videos completely unexportable.

**The Solution:**
Updated the validation logic in `useVideoEditor.ts` to smartly bypass the duration constraint when `duration === 0` (meaning it's unknown/missing metadata).
- If the user sets a custom `trimEnd`, we still rigidly enforce `trimStart < trimEnd`.
- If `trimEnd` is null and `duration` is missing, we safely allow the export to proceed to FFmpeg without failing the pre-flight checks.

**Testing:**
- Verified that standard videos with valid durations still validate correctly.
- Verified that videos with missing duration metadata (duration 0) no longer fail the initial export checks and proceed properly to the engine.

Closes #955.