### PR TITLE
fix: add missing type="button" to ScrollToTop button

### DIFF
--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -28,6 +28,7 @@ export default function ScrollToTop() {
 
   return (
     <button
+      type="button"
       onClick={scrollToTop}
       aria-label="Scroll to top"
       className="


### PR DESCRIPTION
## Description
Adds the missing `type="button"` attribute to the scroll-to-top button in `ScrollToTop.tsx`. Without an explicit type, buttons default to `type="submit"`, which can cause unintended form submissions if the component is rendered inside a `<form>` element.

## Related Issue
N/A — proactive fix for correctness.

## Type of Contribution
- [x] Bug fix

## Participant Info
- GitHub username: magic-peach
- Contribution level: Beginner

## Screen Recording
No UI change — the button behaviour is identical; only the HTML attribute is corrected.

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue