### PR TITLE
fix: add spaces around ternary operator in ExportOverlay aria-label

### DIFF
--- a/src/components/ExportOverlay.tsx
+++ b/src/components/ExportOverlay.tsx
@@ -113,7 +113,7 @@ export default function ExportOverlay({ status, progress, onCancel }: Props) {
                   aria-valuenow={progress}
                   aria-valuemin={0}
                   aria-valuemax={100}
-                  aria-label={isLoading? "Engine download progress": "Export progress"}
+                  aria-label={isLoading ? "Engine download progress" : "Export progress"}
                   className="h-full bg-film-600 rounded-full transition-all duration-300"
                   style={{ width: `${progress}%` }}
                 />


### PR DESCRIPTION
## Description
The `aria-label` on the progressbar element in `ExportOverlay.tsx` used a ternary expression without spaces around `?` and `:` (`isLoading? "...": "..."`). This is inconsistent with the project's code style.

## Related Issue
N/A — proactive code quality fix.

## Type of Contribution
- [x] Bug fix

## Participant Info
- GitHub username: magic-peach
- Contribution level: Beginner

## Screen Recording
No visual change — whitespace only.

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] No `console.log` statements left in