### PR TITLE
fix: remove redundant title attribute and comment block from ThemeToggle

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -2,11 +2,6 @@
 
 import { useTheme } from "./ThemeProvider";
 
-/**
- * A toggle button that switches between light and dark mode.
- * Renders a sun icon in dark mode and a moon icon in light mode.
- * Fully accessible with aria-label and keyboard support.
- */
 export function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
 
@@ -20,14 +15,7 @@ export function ThemeToggle() {
            : theme === "dark"
            ? "Switch to high contrast mode"
            : "Switch to light mode"
-      } 
-       title={
-         theme === "light"
-           ? "Switch to dark mode"
-           : theme === "dark"
-           ? "Switch to high contrast mode"
-           : "Switch to light mode"
-     }
+      }
       className="
         relative flex items-center justify-center
         w-9 h-9 rounded-full
@@ -40,7 +28,6 @@ export function ThemeToggle() {
         transition-colors duration-200
       "
     >
-      {/* Sun icon — shown in light mode */}
       {theme === "light" ? (
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -57,7 +44,6 @@ export function ThemeToggle() {
           <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
         </svg>
       ) : (
-       /* Moon icon — shown in dark/high contrast mode */
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"


### PR DESCRIPTION
## Description
Two issues fixed in `ThemeToggle.tsx`:

1. **Redundant `title` attribute** — The `title` prop duplicated the `aria-label` value exactly, creating a redundant tooltip that screen readers may announce twice. Removed it since `aria-label` already provides the accessible name.

2. **Multi-paragraph comment block** — The component had a 4-line JSDoc block restating what the code says. Per project code style, comments should only explain non-obvious WHY. Removed it.

## Type of Contribution
- [x] Bug fix

## Participant Info
- GitHub username: magic-peach
- Contribution level: Beginner

## Screen Recording
No visual change.

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] No `console.log` statements left in