### PR TITLE
fix: wrap console.error in arrow function in audio.play catch

### DIFF
--- a/src/components/DownloadResult.tsx
+++ b/src/components/DownloadResult.tsx
@@ -31,7 +31,7 @@ export default function DownloadResult({ result, onReset, soundOnCompletion, onT
   useEffect(() => {
     if (soundOnCompletion) {
       const audio = new Audio("/sounds/export-complete.mp3");
-      audio.play().catch(console.error);
+      audio.play().catch((err) => console.error(err));
     }
   }, [soundOnCompletion]);
   const handleReset = () => {


### PR DESCRIPTION
## Description
Fixes `audio.play().catch(console.error)` in `DownloadResult.tsx`. Passing `console.error` as a direct callback reference can cause binding issues in some environments. Using an explicit arrow function `(err) => console.error(err)` is the safe, idiomatic pattern.

## Type of Contribution
- [x] Bug fix

## Participant Info
- GitHub username: magic-peach
- Contribution level: Beginner

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] No `console.log` statements left in