### PR TITLE
fix: remove double spaces before self-closing JSX tags in DownloadResult

### DIFF
--- a/src/components/DownloadResult.tsx
+++ b/src/components/DownloadResult.tsx
@@ -122,7 +122,7 @@ export default function DownloadResult({ result, onReset, soundOnCompletion, onT
             if (!isValid) e.preventDefault();
           }}
         >
-          <Download size={15} aria-hidden="true"  />
+          <Download size={15} aria-hidden="true" />
           Download {result.format.toUpperCase()}
         </a>
         <a
@@ -141,7 +141,7 @@ export default function DownloadResult({ result, onReset, soundOnCompletion, onT
           onClick={handleReset}
           className="flex items-center gap-2 px-4 py-3 border border-[var(--border)] text-[var(--muted)] text-sm rounded-lg hover:bg-[var(--bg)] transition-colors"
         >
-          <RotateCcw size={14} aria-hidden="true"  />
+          <RotateCcw size={14} aria-hidden="true" />
           New
         </button>
         <a


### PR DESCRIPTION
## Description
The Download and RotateCcw icon elements in DownloadResult.tsx had two spaces before the closing />, inconsistent with the rest of the codebase.

## Type of Contribution
- [x] Bug fix

## Participant Info
- GitHub username: magic-peach
- Contribution level: Beginner

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] bun run lint passes (no ESLint errors)
- [x] bunx tsc --noEmit passes (no TypeScript errors)
- [x] No console.log statements left in