### PR TITLE
fix: correct DEFAULT_RECIPE contrast and saturation to FFmpeg eq neutral values

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -82,8 +82,8 @@ export const DEFAULT_RECIPE: EditRecipe = {
   format: "mp4",
   stabilization: false,
   brightness: 0,
-  contrast: 0,
-  saturation: 0,
+  contrast: 1,
+  saturation: 1,
   soundOnCompletion: false,
   version: RECIPE_VERSION,
 };


### PR DESCRIPTION
## Description
The FFmpeg `eq` filter uses `1.0` as the neutral (no-op) value for both contrast and saturation — not `0`. With `contrast: 0` and `saturation: 0` the filter was producing black/desaturated video whenever color adjustments were applied. Setting them to `1` makes the default a true passthrough.

## Type of Contribution
- [x] Bug fix

## Participant Info
- GitHub username: magic-peach
- Contribution level: Intermediate

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] bun run lint passes (no ESLint errors)
- [x] bunx tsc --noEmit passes (no TypeScript errors)
- [x] No console.log statements left in