### PR TITLE
fix: remove redundant aria-checked from native checkbox in ExportSettings

### DIFF
--- a/src/components/ExportSettings.tsx
+++ b/src/components/ExportSettings.tsx
@@ -162,7 +162,6 @@ export default function ExportSettings({
                 })
               }
               aria-label="Enable video stabilization"
-              aria-checked={recipe.stabilization}
               className="w-full accent-film-600 cursor-pointer"
             />
           </span>


### PR DESCRIPTION
## Description
Native `<input type="checkbox">` elements already expose their checked state via the ARIA implicit role. Adding `aria-checked` explicitly on a native checkbox is redundant and can confuse assistive technology.

## Type of Contribution
- [x] Bug fix

## Participant Info
- GitHub username: magic-peach
- Contribution level: Beginner

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] bun run lint passes (no ESLint errors)
- [x] bunx tsc --noEmit passes (no TypeScript errors)
- [x] No console.log statements left in