### PR TITLE
fix: remove duplicate input ref and fileError paragraph in FileUpload

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -128,23 +128,6 @@ export default function FileUpload({
         Change
         <span className="text-[var(--muted)] ml-1">(Ctrl+O)</span>
       </button>
-
-
-      {fileError && (
-        <p className="text-xs text-red-500 mt-2 font-medium">
-          {fileError}
-        </p>
-      )}
-      <input
-        ref={inputRef}
-        type="file"
-        accept="video/*"
-        className="hidden"
-        onChange={(e) => {
-          const f = e.target.files?.[0];
-          if (f) handleFile(f);
-        }}
-      />
     </div>
 
     <p className="text-xs text-gray-500 mt-3 break-words">


### PR DESCRIPTION
## Description
The `FileInfo` component in `FileUpload.tsx` had two identical `<input ref={inputRef}>` elements and two identical `fileError` paragraphs. Multiple DOM nodes assigned to the same ref means only the last one wins — the earlier inputs are orphaned and never respond to `inputRef.current?.click()`. Removed the duplicates inside the flex row and kept the structurally correct ones at the bottom.

## Type of Contribution
- [x] Bug fix

## Participant Info
- GitHub username: magic-peach
- Contribution level: Intermediate

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] bun run lint passes (no ESLint errors)
- [x] bunx tsc --noEmit passes (no TypeScript errors)
- [x] No console.log statements left in