### PR TITLE
fix: replace hardcoded gray color classes with CSS design token in FileUpload

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -108,7 +108,7 @@ export default function FileUpload({
               </span>
             )}
           </div>
-          <div className="text-xs text-gray-500 dark:text-gray-400 mt-1 space-y-0.5">
+          <div className="text-xs text-[var(--muted)] mt-1 space-y-0.5">
             <p>{formatBytes(currentFile?.size ?? 0)}</p>
 
             <p>
@@ -147,7 +147,7 @@ export default function FileUpload({
       />
     </div>
 
-    <p className="text-xs text-gray-500 mt-3 break-words">
+    <p className="text-xs text-[var(--muted)] mt-3 break-words">
       Supports: MP4, MOV, AVI, MKV, WebM, and most video formats
     </p>
 
@@ -221,7 +221,7 @@ export default function FileUpload({
         MP4 / MOV / AVI / WebM
       </div>
 
-      <p className="text-xs text-gray-500 text-center">
+      <p className="text-xs text-[var(--muted)] text-center">
         Supports: MP4, MOV, AVI, MKV, WebM, and most video formats up to 2GB
       </p>
 


### PR DESCRIPTION
## Description
Three elements in `FileUpload.tsx` used `text-gray-500` / `dark:text-gray-400` instead of the project's `text-[var(--muted)]` design token. These hard-coded values would not respect theme changes and would break high-contrast mode support.

## Type of Contribution
- [x] Bug fix

## Participant Info
- GitHub username: magic-peach
- Contribution level: Beginner

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] bun run lint passes (no ESLint errors)
- [x] bunx tsc --noEmit passes (no TypeScript errors)
- [x] No console.log statements left in