### PR TITLE
fix: add aria-label to DropZone role="button" in FileUpload

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -171,6 +171,7 @@ export default function FileUpload({
     <div
       id="upload-zone"
       role="button"
+      aria-label="Upload video — drag and drop or click to browse"
       tabIndex={0}
       onDragOver={(e) => {
         e.preventDefault();


### PR DESCRIPTION
## Description
The drop zone div has role="button" but no accessible name. ARIA spec requires every element with role="button" to have a non-empty accessible name — without it, screen readers announce just "button" with no context. Added a descriptive aria-label.

## Type of Contribution
- [x] Bug fix

## Participant Info
- GitHub username: magic-peach
- Contribution level: Beginner

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] bun run lint passes
- [x] bunx tsc --noEmit passes
- [x] No console.log statements left in