### PR TITLE
fix: remove double space before self-closing tag in AudioSpeedControl

### DIFF
--- a/src/components/AudioSpeedControl.tsx
+++ b/src/components/AudioSpeedControl.tsx
@@ -77,7 +77,7 @@ export default function AudioSpeedControl({ recipe, onChange }: Props) {
             htmlFor="speed-control"
             className="text-sm font-heading font-semibold uppercase tracking-wider text-[var(--muted)] flex items-center gap-2"
           >
-            <Gauge size={10} aria-hidden="true"  /> Speed
+            <Gauge size={10} aria-hidden="true" /> Speed
           </label>
 
           <div className="text-right">


### PR DESCRIPTION
## Description
The Gauge icon element in AudioSpeedControl.tsx had two spaces before the closing />, inconsistent with the rest of the codebase.

## Type of Contribution
- [x] Bug fix

## Participant Info
- GitHub username: magic-peach
- Contribution level: Beginner