### PR TITLE
fix: correct indentation of <html> element in RootLayout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -47,7 +47,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-<html lang="en" suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning>
       <head>
         <link rel="preconnect" href="https://cdn.jsdelivr.net" />
         <link rel="dns-prefetch" href="https://cdn.jsdelivr.net" />


### PR DESCRIPTION
## Description
The opening `<html>` tag in `src/app/layout.tsx` was at column 0 instead of being indented inside the `return (` statement, breaking visual alignment with the rest of the JSX tree.

## Type of Contribution
- [x] Bug fix

## Participant Info
- GitHub username: magic-peach
- Contribution level: Beginner