### PR TITLE
fix: add space before self-closing /> in FramingControl Icon element

### DIFF
--- a/src/components/FramingControl.tsx
+++ b/src/components/FramingControl.tsx
@@ -28,7 +28,7 @@ export default function FramingControl({ recipe, onChange }: Props) {
                 : "border-[var(--border)] text-[var(--muted)] hover:border-film-300 bg-[var(--surface)]"
             )}
           >
-            <Icon size={18} aria-hidden="true"/>
+            <Icon size={18} aria-hidden="true" />
             <span className="sr-only">
               Set framing to {mode === "fit" ? "fit within frame" : "fill frame by cropping"}
             </span>


### PR DESCRIPTION
## Description
The Icon element in FramingControl.tsx was missing a space before />, inconsistent with JSX self-closing tag style used throughout the codebase.

## Type of Contribution
- [x] Bug fix

## Participant Info
- GitHub username: magic-peach
- Contribution level: Beginner