### PR TITLE
fix: remove redundant sr-only span in RotateControl buttons

### DIFF
--- a/src/components/RotateControl.tsx
+++ b/src/components/RotateControl.tsx
@@ -30,8 +30,7 @@ export default function RotateControl({ recipe, onChange }: Props) {
                 : "border-[var(--border)] text-[var(--muted)] hover:border-film-300 bg-[var(--surface)]"
             )}
           >
-            <RotateCw size={15} style={{ transform: `rotate(${deg}deg)`, transformOrigin: 'center' }} className="transition-transform" />
-            <span className="sr-only">Rotate video to {deg} degrees</span>
+            <RotateCw size={15} aria-hidden="true" style={{ transform: `rotate(${deg}deg)`, transformOrigin: 'center' }} className="transition-transform" />
             {deg}
           </button>
         );


### PR DESCRIPTION
## Description
Each rotation button in RotateControl.tsx already has an aria-label providing its accessible name. The sr-only span with identical text caused screen readers to announce the label twice. Also added aria-hidden to the icon element.

## Type of Contribution
- [x] Bug fix

## Participant Info
- GitHub username: magic-peach
- Contribution level: Beginner