### PR TITLE
fix: replace title with aria-label on delete button in ImageOverlay

### DIFF
--- a/src/components/ImageOverlay.tsx
+++ b/src/components/ImageOverlay.tsx
@@ -112,14 +112,13 @@ export default function ImageOverlayPanel({
                 </div>
               </div>
 
-              {/* Action Delete Button */}
               <button
                 type="button"
                 onClick={() => setOverlayFile(null)}
+                aria-label="Remove overlay image"
                 className="w-6 h-6 rounded flex items-center justify-center bg-red-500/10 hover:bg-red-500/20 text-red-400 border border-red-500/20 transition shrink-0"
-                title="Remove image"
               >
-                <Trash2 size={11} />
+                <Trash2 size={11} aria-hidden="true" />
               </button>
             </>
           ) : (


### PR DESCRIPTION
## Description
The icon-only delete button in ImageOverlay.tsx had title="Remove image" as its only accessible name. The title attribute is not reliably announced by screen readers and is not keyboard-discoverable. Replaced with aria-label and added aria-hidden to the Trash2 icon.

## Type of Contribution
- [x] Bug fix

## Participant Info
- GitHub username: magic-peach
- Contribution level: Beginner