### PR TITLE
fix: remove WHAT comment from ExportSettings stabilization section

### DIFF
--- a/src/components/ExportSettings.tsx
+++ b/src/components/ExportSettings.tsx
@@ -168,7 +168,6 @@ export default function ExportSettings({
           </span>
         </div>
 
-        {/* Short descriptive label explaining what the setting does */}
         <p className="text-xs text-[var(--muted)] mb-1">
           Reduce camera shake
         </p>


### PR DESCRIPTION
## Description
The JSX comment described what the paragraph element does (a WHAT comment), violating the project code style which requires comments to explain non-obvious WHY only. The visible text "Reduce camera shake" is already self-documenting.

## Type of Contribution
- [x] Bug fix

## Participant Info
- GitHub username: magic-peach
- Contribution level: Beginner