### PR TITLE
fix: remove extra blank line after "use client" in VideoEditor

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-
 import { useState, useRef, useEffect, useMemo } from "react";
 import { useVideoEditor } from "@/hooks/useVideoEditor";
 import FileUpload from "./FileUpload";


### PR DESCRIPTION
The use client directive was followed by two blank lines instead of one.

## Participant Info
- GitHub username: magic-peach
- Contribution level: Beginner