### PR TITLE
feat: add reduce noise toggle using hqdn3d filter

### DIFF
--- a/src/components/ExportSettings.tsx
+++ b/src/components/ExportSettings.tsx
@@ -186,6 +186,57 @@ export default function ExportSettings({
           </span>
         </div>
       </div>
+      <div>
+        <div className="flex items-center justify-between mb-1">
+          <label
+            htmlFor="denoise-toggle"
+            className="text-sm font-heading font-semibold uppercase tracking-wider text-[var(--muted)] flex items-center gap-2"
+          >
+            <SlidersHorizontal size={10} />
+            Reduce noise
+
+            <span
+              className="cursor-help"
+              title="Reduces video noise. May slow down export slightly."
+            >
+              <InfoIcon size={14} />
+            </span>
+          </label>
+
+          <span className="flex text-sm font-heading font-bold text-film-600">
+            <input
+              id="denoise-toggle"
+              type="checkbox"
+              checked={recipe.denoise}
+              onChange={(e) =>
+                onChange({
+                  denoise: e.target.checked,
+                })
+              }
+              aria-label="Enable noise reduction"
+              aria-checked={recipe.denoise}
+              className="w-full accent-film-600 cursor-pointer"
+            />
+          </span>
+        </div>
+
+        <p className="text-xs text-[var(--muted)] mb-1">
+          Reduce low-light video grain
+        </p>
+
+        <div className="flex justify-end">
+          <span
+            className={cn(
+              "text-xs",
+              recipe.denoise
+                ? "text-red-700 font-medium"
+                : "text-[var(--muted)]"
+            )}
+          >
+            May slightly increase export time.
+          </span>
+        </div>
+      </div>
     </>
   );
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -19,6 +19,7 @@ export const DEFAULT_RECIPE: EditRecipe = {
   contrast: 1,
   saturation: 1,
   stabilization: false,
+  denoise: false,
   soundOnCompletion: false,
   normalizeAudio: false,
   version: RECIPE_VERSION,

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -39,7 +39,7 @@ export class FFmpegLoadError extends Error {
 }
 
 export async function loadFFmpeg(
-  signal?: AbortSignal, 
+  signal?: AbortSignal,
   onProgress?: (percent: number) => void
 ): Promise<FFmpeg> {
   if (ffmpegInstance?.loaded) {
@@ -96,7 +96,7 @@ function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number):
     filters.push("setpts=PTS-STARTPTS");
   }
 
- 
+
   if (recipe.stabilization) {
     filters.push("deshake");
   }
@@ -122,9 +122,14 @@ function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number):
   }
 
   if (recipe.speed !== 1) {
-    const pts = (1 / recipe.speed).toFixed(4);
-    filters.push(`setpts=${pts}*PTS`);
+  const pts = (1 / recipe.speed).toFixed(4);
+  filters.push(`setpts=${pts}*PTS`);
   }
+
+  if (recipe.denoise) {
+    filters.push("hqdn3d=1.5:1.5:6:6");
+  }
+
   filters.push(
     `eq=brightness=${recipe.brightness}:contrast=${recipe.contrast}:saturation=${recipe.saturation}`
   );
@@ -177,7 +182,7 @@ function buildArguments(
 ): string[] {
   const vf = buildVideoFilter(recipe, targetW, targetH);
   const audioTrim = hasOriginalAudio ? buildAudioTrimFilter(recipe) : "";
-const audioSpeed = hasOriginalAudio ? buildAudioFilter(recipe.speed, recipe.normalizeAudio ?? false) : "";
+  const audioSpeed = hasOriginalAudio ? buildAudioFilter(recipe.speed, recipe.normalizeAudio ?? false) : "";
   const afParts = [audioTrim, audioSpeed].filter(Boolean);
   const af = afParts.join(",");
 
@@ -328,7 +333,7 @@ export async function exportVideo(
     onProgress(Math.min(99, Math.round(progress * 100)));
   };
 
-  
+
   try {
     await ffmpeg.writeFile(inputName, await fetchFile(file), { signal });
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,6 +14,7 @@ export interface EditRecipe {
   quality: number;
   format: "mp4" | "webm" | "mkv" | "gif";
   stabilization: boolean;
+  denoise: boolean;
   brightness: number;
   contrast: number;
   saturation: number;
@@ -81,6 +82,7 @@ export const DEFAULT_RECIPE: EditRecipe = {
   quality: 23,
   format: "mp4",
   stabilization: false,
+  denoise: false,
   brightness: 0,
   contrast: 0,
   saturation: 0,


### PR DESCRIPTION
## Description

Closes #678

Added a new **"Reduce noise"** toggle to the export settings panel to expose FFmpeg's `hqdn3d` denoise filter for low-light and noisy footage.

### What Changed

* Added `denoise: boolean` to `EditRecipe`
* Added `denoise: false` to `DEFAULT_RECIPE`
* Integrated `hqdn3d=1.5:1.5:6:6` into the FFmpeg video filter chain
* Added a new "Reduce noise" checkbox toggle in `ExportSettings`
* Added tooltip/help text:

  > "Reduces video noise. May slow down export slightly."
* Ensured exports work correctly with the toggle enabled and disabled

### Testing

Tested locally with:

* Toggle OFF → normal export works
* Toggle ON → `hqdn3d` filter added successfully to FFmpeg filter chain
* Export completes successfully in both cases
* `bunx tsc --noEmit` passes with no TypeScript errors
* `bun run lint` passes with no ESLint errors related to this change

## Related Issue

Closes #678

## Type of Contribution

* [x] New feature
* [x] GSSoC contribution

## Participant Info

* GitHub username: imuniqueshiv
* Contribution level: Intermediate

## Screen Recording

https://github.com/user-attachments/assets/737db795-741a-4972-b4ed-7edbbb2b5531

## Checklist

* [x] I have read the contribution guidelines
* [x] My changes follow the project structure
* [x] I have tested my changes in Chrome, Firefox, and Safari
* [x] `bun run lint` passes (no ESLint errors)
* [x] `bunx tsc --noEmit` passes (no TypeScript errors)
* [x] New interactive elements have `aria-label` / accessible names
* [x] No `console.log` statements left in
* [x] This PR is related to a valid issue
* [x] Screen recording attached above
