### PR TITLE
feat: add tooltip to disabled Export button (#983)

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -437,9 +437,10 @@ export default function VideoEditor() {
               id="export-button"
               type="button"
               onClick={handleExport}
-              disabled={!file || isProcessing}
-              aria-label='Export video'
-              aria-disabled={!file || isProcessing ? "true" : undefined}
+                disabled={!file || isProcessing}
+                aria-label='Export video'
+                aria-disabled={!file || isProcessing ? "true" : undefined}
+                title={!file ? "Upload a video to enable export" : undefined}
               className={cn(
                 "w-full flex items-center justify-center gap-3 py-5 min-h-[44px] rounded-xl",
                 "font-display text-2xl tracking-widest transition-all duration-200",


### PR DESCRIPTION
## Description
When no video is uploaded, the Export button now shows a native browser tooltip ("Upload a video to enable export") on hover via a conditional `title` prop. The tooltip is removed once a video is loaded. No extra JS, state, or dependencies added — single prop change in `VideoEditor.tsx`.

---

## Related Issue
Closes #983

---

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: @Pranav-IIITM
- Contribution level: Intermediate

---

## Screen Recording

https://github.com/user-attachments/assets/8516cce2-0cb9-4b8d-923a-8dae1e31118a

---

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)