### PR TITLE
feat: add side-by-side comparison preview with draggable slider (#896)

### DIFF
--- a/src/components/ComparisonPreview.tsx
+++ b/src/components/ComparisonPreview.tsx
@@ -1,0 +1,270 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+"use client";
+
+import { useEffect, useRef, useState, useCallback, RefObject } from "react";
+import { EditRecipe } from "@/lib/types";
+import { getPresetById } from "@/lib/presets";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  file: File | null;
+  recipe?: EditRecipe;
+  videoRef: RefObject<HTMLVideoElement | null>;
+}
+
+export default function ComparisonPreview({ file, recipe, videoRef }: Props) {
+  const leftVideoRef = useRef<HTMLVideoElement>(null);
+  const rightVideoRef = useRef<HTMLVideoElement>(null);
+  const [sliderPosition, setSliderPosition] = useState(50);
+  const [isDragging, setIsDragging] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Calculate overlay for the right (reframed) side
+  const overlay = (() => {
+    if (!recipe) return null;
+
+    const preset = recipe.preset === "custom"
+      ? { width: recipe.customWidth, height: recipe.customHeight }
+      : getPresetById(recipe.preset);
+
+    if (!preset) return null;
+
+    const containerW = 16;
+    const containerH = 9;
+    const containerRatio = containerW / containerH;
+    const outputRatio = preset.width / preset.height;
+
+    if (recipe.framing === "fit") {
+      if (outputRatio > containerRatio) {
+        const contentH = (containerRatio / outputRatio) * 100;
+        const barH = (100 - contentH) / 2;
+        return { mode: "fit", barTop: `${barH}%`, barBottom: `${barH}%`, barLeft: "0", barRight: "0" };
+      } else {
+        const contentW = (outputRatio / containerRatio) * 100;
+        const barW = (100 - contentW) / 2;
+        return { mode: "fit", barTop: "0", barBottom: "0", barLeft: `${barW}%`, barRight: `${barW}%` };
+      }
+    } else {
+      if (outputRatio < containerRatio) {
+        const visibleH = (outputRatio / containerRatio) * 100;
+        const cropH = (100 - visibleH) / 2;
+        return { mode: "fill", barTop: `${cropH}%`, barBottom: `${cropH}%`, barLeft: "0", barRight: "0" };
+      } else {
+        const visibleW = (containerRatio / outputRatio) * 100;
+        const cropW = (100 - visibleW) / 2;
+        return { mode: "fill", barTop: "0", barBottom: "0", barLeft: `${cropW}%`, barRight: `${cropW}%` };
+      }
+    }
+  })();
+
+  // Load video source for both left and right videos
+  useEffect(() => {
+    if (!file) return;
+    const url = URL.createObjectURL(file);
+
+    if (leftVideoRef.current) {
+      leftVideoRef.current.src = url;
+      leftVideoRef.current.load();
+    }
+    if (rightVideoRef.current) {
+      rightVideoRef.current.src = url;
+      rightVideoRef.current.load();
+    }
+
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
+
+  // Sync right video with left video and auto-play left
+  useEffect(() => {
+    const leftVideo = leftVideoRef.current;
+    const rightVideo = rightVideoRef.current;
+
+    if (!leftVideo || !rightVideo || !file) return;
+
+    const handleTimeUpdate = () => {
+      rightVideo.currentTime = leftVideo.currentTime;
+    };
+
+    const handlePlay = () => {
+      rightVideo.play().catch(() => {});
+    };
+
+    const handlePause = () => {
+      rightVideo.pause();
+    };
+
+    const handleRateChange = () => {
+      rightVideo.playbackRate = leftVideo.playbackRate;
+    };
+
+    const handleLoadedData = () => {
+      leftVideo.play().catch(() => {});
+    };
+
+    leftVideo.addEventListener("timeupdate", handleTimeUpdate);
+    leftVideo.addEventListener("play", handlePlay);
+    leftVideo.addEventListener("pause", handlePause);
+    leftVideo.addEventListener("ratechange", handleRateChange);
+    leftVideo.addEventListener("loadeddata", handleLoadedData);
+
+    return () => {
+      leftVideo.removeEventListener("timeupdate", handleTimeUpdate);
+      leftVideo.removeEventListener("play", handlePlay);
+      leftVideo.removeEventListener("pause", handlePause);
+      leftVideo.removeEventListener("ratechange", handleRateChange);
+      leftVideo.removeEventListener("loadeddata", handleLoadedData);
+    };
+  }, [file, videoRef]);
+
+  // Handle slider dragging (mouse + touch)
+  const handleMouseDown = useCallback(() => {
+    setIsDragging(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const container = containerRef.current;
+      if (!container) return;
+
+      const rect = container.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const percentage = Math.max(0, Math.min(100, (x / rect.width) * 100));
+      setSliderPosition(percentage);
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      const container = containerRef.current;
+      if (!container || !e.touches[0]) return;
+
+      const rect = container.getBoundingClientRect();
+      const x = e.touches[0].clientX - rect.left;
+      const percentage = Math.max(0, Math.min(100, (x / rect.width) * 100));
+      setSliderPosition(percentage);
+    };
+
+    const handleMouseUp = () => {
+      setIsDragging(false);
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("touchmove", handleTouchMove, { passive: true });
+    document.addEventListener("mouseup", handleMouseUp);
+    document.addEventListener("touchend", handleMouseUp);
+
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("touchmove", handleTouchMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+      document.removeEventListener("touchend", handleMouseUp);
+    };
+  }, [isDragging]);
+
+  if (!file) return null;
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative w-full rounded-lg overflow-hidden bg-[#0a0a0a] aspect-video"
+      role="group"
+      aria-label="Video comparison preview"
+    >
+      {/* Left side: Original video — clipped to left of slider */}
+      <div className="absolute inset-0 overflow-hidden" style={{ width: `${sliderPosition}%` }}>
+        {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+        <video
+          ref={leftVideoRef}
+          className="absolute inset-0 w-full h-full object-contain"
+          playsInline
+          muted
+        >
+          <track kind="captions" />
+        </video>
+      </div>
+
+      {/* Right side: Reframed video with overlay — clipped to right of slider */}
+      <div
+        className="absolute inset-0 overflow-hidden"
+        style={{ left: `${sliderPosition}%` }}
+      >
+        <div className="absolute inset-0" style={{ left: `-${sliderPosition}%`, right: 0 }}>
+          {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+          <video
+            ref={rightVideoRef}
+            className="w-full h-full object-contain"
+            playsInline
+            muted
+            autoPlay
+            loop
+          >
+            <track kind="captions" />
+          </video>
+        </div>
+
+        {/* Overlay on reframed side */}
+        {overlay && (
+          <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
+            {overlay.mode === "fit" ? (
+              // Letterbox: semi-transparent bars outside the content area
+              <>
+                <div className="absolute left-0 right-0 top-0 bg-black/50" style={{ height: overlay.barTop }} />
+                <div className="absolute left-0 right-0 bottom-0 bg-black/50" style={{ height: overlay.barBottom }} />
+                <div className="absolute top-0 bottom-0 left-0 bg-black/50" style={{ width: overlay.barLeft }} />
+                <div className="absolute top-0 bottom-0 right-0 bg-black/50" style={{ width: overlay.barRight }} />
+              </>
+            ) : (
+              // Fill/crop: dashed border around the surviving area, dimmed outside
+              <>
+                <div className="absolute left-0 right-0 top-0 bg-red-900/50" style={{ height: overlay.barTop }} />
+                <div className="absolute left-0 right-0 bottom-0 bg-red-900/50" style={{ height: overlay.barBottom }} />
+                <div className="absolute top-0 bottom-0 left-0 bg-red-900/50" style={{ width: overlay.barLeft }} />
+                <div className="absolute top-0 bottom-0 right-0 bg-red-900/50" style={{ width: overlay.barRight }} />
+                <div
+                  className="absolute border-2 border-dashed border-film-400"
+                  style={{
+                    top: overlay.barTop,
+                    bottom: overlay.barBottom,
+                    left: overlay.barLeft,
+                    right: overlay.barRight,
+                  }}
+                />
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Draggable divider slider */}
+      <div
+        className={cn(
+          "absolute top-0 bottom-0 w-1 bg-white pointer-events-none transition-opacity",
+          isDragging ? "opacity-100" : "opacity-75 hover:opacity-100"
+        )}
+        style={{ left: `${sliderPosition}%`, transform: "translateX(-50%)" }}
+        aria-hidden="true"
+      >
+        {/* Circular drag handle */}
+        <button
+          type="button"
+          onMouseDown={handleMouseDown}
+          onTouchStart={handleMouseDown}
+          className="absolute top-1/2 left-1/2 w-8 h-8 -ml-4 -mt-4 rounded-full bg-white shadow-lg pointer-events-auto cursor-grab active:cursor-grabbing flex items-center justify-center transition-shadow"
+          style={{
+            boxShadow: isDragging ? "0 0 12px rgba(255, 255, 255, 0.8)" : undefined,
+          }}
+          aria-label="Drag to compare original vs reframed"
+          title="Drag left/right to compare"
+        >
+          <svg
+            className="w-4 h-4 text-black"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path d="M9 6h2v12H9V6zm4 0h2v12h-2V6z" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -6,6 +6,7 @@ import { EditRecipe } from "@/lib/types";
 import { getPresetById } from "@/lib/presets";
 import { cn } from "@/lib/utils";
 import { Camera } from "lucide-react";
+import ComparisonPreview from "./ComparisonPreview";
 
 interface Props {
   file: File | null;
@@ -18,6 +19,7 @@ export default function VideoPreview({ file, recipe, videoRef }: Props) {
   const urlRef = useRef<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [showOverlay, setShowOverlay] = useState(false);
+  const [showComparison, setShowComparison] = useState(false);
   const onLoadedRef = useRef<(() => void) | null>(null);
 
   const handleGrabFrame = useCallback(() => {
@@ -176,94 +178,120 @@ export default function VideoPreview({ file, recipe, videoRef }: Props) {
   };
 
   return (
-    <div
-      role="group"
-      className="relative w-full rounded-lg overflow-hidden bg-[#0a0a0a] aspect-video focus:outline-none focus-visible:ring-2 focus-visible:ring-film-500"
-      tabIndex={0}
-      onKeyDown={handleKeyDown}
-      aria-label="Video preview (press Space to play/pause)"
-    >
-      {isLoading && (
-        <div
-          className="absolute inset-0 animate-pulse bg-gray-700 rounded-xl transition-opacity duration-300"
-          aria-label="Loading video preview"
-        />
-      )}
-      {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-      <video
-        ref={videoRef}
-        controls
-        className={cn("w-full h-full object-contain transition-opacity duration-300", isLoading ? "opacity-0" : "opacity-100")}
-        onLoadedData={() => setIsLoading(false)}
-        playsInline
-        muted={!recipe?.keepAudio}
+    <>
+      <div
+        role="group"
+        className="relative w-full rounded-lg overflow-hidden bg-[#0a0a0a] aspect-video focus:outline-none focus-visible:ring-2 focus-visible:ring-film-500"
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        aria-label="Video preview (press Space to play/pause)"
       >
-        <track kind="captions" />
-      </video>
+        {isLoading && (
+          <div
+            className="absolute inset-0 animate-pulse bg-gray-700 rounded-xl transition-opacity duration-300"
+            aria-label="Loading video preview"
+          />
+        )}
+        {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+        <video
+          ref={videoRef}
+          controls
+          className={cn("w-full h-full object-contain transition-opacity duration-300", isLoading ? "opacity-0" : "opacity-100")}
+          onLoadedData={() => setIsLoading(false)}
+          playsInline
+          muted={!recipe?.keepAudio}
+        >
+          <track kind="captions" />
+        </video>
 
-      {/* Letterbox / Crop overlay */}
-      {overlay && (
-        <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
-          {overlay.mode === "fit" ? (
-            // Letterbox: semi-transparent bars outside the content area
-            <>
-              <div className="absolute left-0 right-0 top-0 bg-black/50" style={{ height: overlay.barTop }} />
-              <div className="absolute left-0 right-0 bottom-0 bg-black/50" style={{ height: overlay.barBottom }} />
-              <div className="absolute top-0 bottom-0 left-0 bg-black/50" style={{ width: overlay.barLeft }} />
-              <div className="absolute top-0 bottom-0 right-0 bg-black/50" style={{ width: overlay.barRight }} />
-            </>
-          ) : (
-            // Fill/crop: dashed border around the surviving area, dimmed outside
-            <>
-              <div className="absolute left-0 right-0 top-0 bg-red-900/50" style={{ height: overlay.barTop }} />
-              <div className="absolute left-0 right-0 bottom-0 bg-red-900/50" style={{ height: overlay.barBottom }} />
-              <div className="absolute top-0 bottom-0 left-0 bg-red-900/50" style={{ width: overlay.barLeft }} />
-              <div className="absolute top-0 bottom-0 right-0 bg-red-900/50" style={{ width: overlay.barRight }} />
-              <div
-                className="absolute border-2 border-dashed border-film-400"
-                style={{
-                  top: overlay.barTop,
-                  bottom: overlay.barBottom,
-                  left: overlay.barLeft,
-                  right: overlay.barRight,
-                }}
-              />
-            </>
-          )}
+        {/* Letterbox / Crop overlay */}
+        {overlay && (
+          <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
+            {overlay.mode === "fit" ? (
+              // Letterbox: semi-transparent bars outside the content area
+              <>
+                <div className="absolute left-0 right-0 top-0 bg-black/50" style={{ height: overlay.barTop }} />
+                <div className="absolute left-0 right-0 bottom-0 bg-black/50" style={{ height: overlay.barBottom }} />
+                <div className="absolute top-0 bottom-0 left-0 bg-black/50" style={{ width: overlay.barLeft }} />
+                <div className="absolute top-0 bottom-0 right-0 bg-black/50" style={{ width: overlay.barRight }} />
+              </>
+            ) : (
+              // Fill/crop: dashed border around the surviving area, dimmed outside
+              <>
+                <div className="absolute left-0 right-0 top-0 bg-red-900/50" style={{ height: overlay.barTop }} />
+                <div className="absolute left-0 right-0 bottom-0 bg-red-900/50" style={{ height: overlay.barBottom }} />
+                <div className="absolute top-0 bottom-0 left-0 bg-red-900/50" style={{ width: overlay.barLeft }} />
+                <div className="absolute top-0 bottom-0 right-0 bg-red-900/50" style={{ width: overlay.barRight }} />
+                <div
+                  className="absolute border-2 border-dashed border-film-400"
+                  style={{
+                    top: overlay.barTop,
+                    bottom: overlay.barBottom,
+                    left: overlay.barLeft,
+                    right: overlay.barRight,
+                  }}
+                />
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Toggle button */}
+        {recipe && !isLoading && (
+          <button
+            type="button"
+            onClick={() => setShowOverlay((v) => !v)}
+            className={`absolute top-2 left-2 px-2 py-1 text-[10px] font-heading font-bold uppercase tracking-wider rounded transition-colors z-10 pointer-events-auto ${
+              showOverlay
+                ? "bg-film-600 text-white"
+                : "bg-black/60 text-white/70 hover:bg-black/80"
+            }`}
+            aria-pressed={showOverlay}
+            aria-label={showOverlay ? "Hide framing overlay" : "Show framing overlay"}
+            title={showOverlay ? "Hide framing overlay" : "Show framing overlay"}
+          >
+            {showOverlay ? "Hide overlay" : "Show overlay"}
+          </button>
+        )}
+
+        {/* Compare button */}
+        {recipe && !isLoading && (
+          <button
+            type="button"
+            onClick={() => setShowComparison((v) => !v)}
+            className={`absolute top-2 right-32 px-2 py-1 text-[10px] font-heading font-bold uppercase tracking-wider rounded transition-colors z-10 pointer-events-auto ${
+              showComparison
+                ? "bg-film-600 text-white"
+                : "bg-black/60 text-white/70 hover:bg-black/80"
+            }`}
+            aria-pressed={showComparison}
+            aria-label={showComparison ? "Hide comparison preview" : "Show comparison preview"}
+            title={showComparison ? "Hide comparison preview" : "Show comparison preview"}
+          >
+            Compare
+          </button>
+        )}
+
+        {/* Grab frame button */}
+        {!isLoading && (
+          <button
+            type="button"
+            onClick={handleGrabFrame}
+            className="absolute top-2 right-2 px-2 py-1 text-[10px] font-heading font-bold uppercase tracking-wider rounded transition-colors z-10 pointer-events-auto bg-black/60 text-white/70 hover:bg-black/80 flex items-center gap-1"
+            aria-label="Grab frame as PNG"
+            title="Download current frame as PNG"
+          >
+            <Camera className="w-3 h-3" />
+            Grab frame
+          </button>
+        )}
+      </div>
+
+      {showComparison && file && (
+        <div className="mt-4">
+          <ComparisonPreview file={file} recipe={recipe} videoRef={videoRef} />
         </div>
       )}
-
-      {/* Toggle button */}
-      {recipe && !isLoading && (
-        <button
-          type="button"
-          onClick={() => setShowOverlay((v) => !v)}
-          className={`absolute top-2 left-2 px-2 py-1 text-[10px] font-heading font-bold uppercase tracking-wider rounded transition-colors z-10 pointer-events-auto ${
-            showOverlay
-              ? "bg-film-600 text-white"
-              : "bg-black/60 text-white/70 hover:bg-black/80"
-          }`}
-          aria-pressed={showOverlay}
-          aria-label={showOverlay ? "Hide framing overlay" : "Show framing overlay"}
-          title={showOverlay ? "Hide framing overlay" : "Show framing overlay"}
-        >
-          {showOverlay ? "Hide overlay" : "Show overlay"}
-        </button>
-      )}
-
-      {/* Grab frame button */}
-      {!isLoading && (
-        <button
-          type="button"
-          onClick={handleGrabFrame}
-          className="absolute top-2 right-2 px-2 py-1 text-[10px] font-heading font-bold uppercase tracking-wider rounded transition-colors z-10 pointer-events-auto bg-black/60 text-white/70 hover:bg-black/80 flex items-center gap-1"
-          aria-label="Grab frame as PNG"
-          title="Download current frame as PNG"
-        >
-          <Camera className="w-3 h-3" />
-          Grab frame
-        </button>
-      )}
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
## Description
Added a side-by-side comparison preview with a draggable slider divider, letting users visually compare the original video against the reframed output without exporting.

**New component: `ComparisonPreview.tsx`**
- Left side: original video (`object-contain`, no overlay)
- Right side: same video with crop/framing overlay applied (reuses `barTop/barBottom/barLeft/barRight` logic from `VideoPreview`)
- Draggable vertical divider — white line with circular handle — drag left/right to reveal either side
- Both videos synced via `timeupdate` event (same `currentTime`, play/pause, playback rate)
- Touch + mouse events supported for full mobile compatibility
- Overlays are `pointer-events-none`, drag handle is `pointer-events-auto`
- No new dependencies — pure React hooks + Tailwind only

**Updated: `VideoPreview.tsx`**
- Added `showComparison` state
- Added "Compare" toggle button on the video preview
- Renders `ComparisonPreview` below main preview when toggled on

---

## Related Issue
Closes #896

---

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: @Pranav-IIITM
- Contribution level: Intermediate

---

## Screen Recording

https://github.com/user-attachments/assets/2e27d9a8-44bf-49bc-a677-5e5494637977

---

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)