### PR TITLE
fix(ui): resolve framing control truncation overflow in resize sidebar

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -67,17 +67,6 @@ function AccordionSection({
   onToggle: () => void;
   delay?: number;
 }) {
-  const contentRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (!contentRef.current) return;
-    if (isOpen) {
-      contentRef.current.style.maxHeight = `${contentRef.current.scrollHeight}px`;
-    } else {
-      contentRef.current.style.maxHeight = `0px`;
-    }
-  }, [isOpen]);
-
   return (
     <div className="animate-fade-in" style={{ animationDelay: `${delay}ms` }}>
       <button
@@ -105,9 +94,10 @@ function AccordionSection({
 
       <div
         id={`${id}-panel`}
-        ref={contentRef}
-        className="overflow-hidden transition-all duration-200"
-        style={{ maxHeight: isOpen ? undefined : 0 }}
+        className={cn(
+          "transition-all duration-200",
+          isOpen ? "block" : "hidden"
+        )}
       >
         <div className="px-3 pt-3 pb-0">{children}</div>
       </div>
@@ -571,8 +561,8 @@ export default function VideoEditor() {
                     </p>
                   </div>
                 )}
-                <PresetSelector recipe={recipe} onChange={updateRecipe} />
-                <div className="mt-3">
+                <div className="space-y-3">
+                  <PresetSelector recipe={recipe} onChange={updateRecipe} />
                   <FramingControl recipe={recipe} onChange={updateRecipe} />
                 </div>
               </AccordionSection>


### PR DESCRIPTION
## Description
This is a minor CSS layout fix that resolves a framing control truncation bug in the right sidebar panel. 

### Root Cause
The `AccordionSection` component inside `VideoEditor.tsx` was using a React `useEffect` hook to calculate and bind a strict dynamic `maxHeight` tracking value in pixels based on its initial `scrollHeight` when it first mounted open. When a video file is subsequently loaded, the layout context shifts. Because that calculated `maxHeight` value remained stale and never re-triggered a pixel recalculation upon the video asset re-render, the container capped the card layout height, cleanly clipping out the lower section items (`FIT` and `FILL` buttons).

### Solution
Replaced the rigid `maxHeight` calculation layout with a standard CSS toggle block (`hidden` / `block`) layout flow. This allows the structural content layout to dictate its own natural height bounds fluidly at all times without clipping elements.
* Removed the unnecessary layout constraints (`contentRef`, `style` overrides, and stale measurement lifecycle loops).
* Cleanly preserved the smooth layout chevron arrow rotation animation transitions on the toggle controls.

## Related Issue
Closes #1008

### Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: Vagventure
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Screen Recording
- Before

https://github.com/user-attachments/assets/0236e24b-9a69-4aaf-b865-8bae4f9e2c21

- After
 

https://github.com/user-attachments/assets/3f83f367-9376-4f2b-b634-736c9176e061



## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)