### PR TITLE
fix: recalculate spotlight overlay position on scroll events

### DIFF
--- a/src/components/OnboardingTour.tsx
+++ b/src/components/OnboardingTour.tsx
@@ -318,6 +318,8 @@ export default function OnboardingTour() {
         clearTimeout(retryTimer);
       }
     };
+  }, [stepIndex, visible, measureTarget, dismiss, currentStep]);
+
   // Re-measure on resize or scroll so spotlight stays anchored to target.
   // requestAnimationFrame prevents layout thrashing on rapid scroll/resize events.
   useEffect(() => {

--- a/src/components/OnboardingTour.tsx
+++ b/src/components/OnboardingTour.tsx
@@ -318,16 +318,24 @@ export default function OnboardingTour() {
         clearTimeout(retryTimer);
       }
     };
-  }, [stepIndex, visible, measureTarget, dismiss, currentStep]);
-
-  // Re-measure on resize
+  // Re-measure on resize or scroll so spotlight stays anchored to target.
+  // requestAnimationFrame prevents layout thrashing on rapid scroll/resize events.
   useEffect(() => {
     if (!visible) return;
-    const onResize = () => {
-      measureTarget(TOUR_STEPS[stepIndex]?.targetId ?? "").then(setTargetRect);
+    let rafId: number;
+    const remeasure = () => {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => {
+        measureTarget(TOUR_STEPS[stepIndex]?.targetId ?? "").then(setTargetRect);
+      });
     };
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
+    window.addEventListener("resize", remeasure);
+    window.addEventListener("scroll", remeasure, true);
+    return () => {
+      cancelAnimationFrame(rafId);
+      window.removeEventListener("resize", remeasure);
+      window.removeEventListener("scroll", remeasure, true);
+    };
   }, [visible, stepIndex, measureTarget]);
 
   // Keyboard support


### PR DESCRIPTION
## Summary
Closes #913

Fixes the spotlight overlay drifting away from its target element when 
the user scrolls during the onboarding tour.

## Root Cause
The spotlight used `getBoundingClientRect()` to position itself, which 
returns viewport-relative coordinates. When the user scrolled, the stored 
`targetRect` became stale — the coordinates no longer matched the element's 
actual position — causing the spotlight to highlight unrelated content.

The component already had a resize listener that re-measured on window 
resize, but no equivalent for scroll events.

## Fix
Added a scroll event listener alongside the existing resize listener in 
the re-measure `useEffect`:

```ts
window.addEventListener("scroll", remeasure, true);
```

Using capture phase (`true`) ensures scroll events from nested scrollable 
containers are also caught, not just window-level scrolling.

The cleanup function removes both listeners correctly on unmount.

## Files Changed
- `src/components/OnboardingTour.tsx` — added scroll listener, renamed 
  `onResize` to `remeasure` for clarity

## Testing
1. Start the onboarding tour
2. Scroll the page during any step
3. Spotlight should remain anchored to the target element