### PR TITLE
Feat/split video segments

### DIFF
--- a/src/components/SplitExport.tsx
+++ b/src/components/SplitExport.tsx
@@ -1,0 +1,79 @@
+"use client";
+import { useState } from "react";
+import { EditRecipe } from "@/lib/types";
+import { loadFFmpeg } from "@/lib/ffmpeg";
+import { splitExportVideo } from "@/lib/splitExport";
+import { cn } from "@/lib/utils";
+
+interface Props { file: File; recipe: EditRecipe; duration: number; }
+
+export default function SplitExport({ file, recipe, duration }: Props) {
+    const [segments, setSegments] = useState(2);
+    const [status, setStatus] = useState<"idle"|"busy"|"done"|"error">("idle");
+    const [progress, setProgress] = useState({ seg: 0, pct: 0 });
+    const [zipUrl, setZipUrl] = useState<string|null>(null);
+    const [error, setError] = useState<string|null>(null);
+
+    const run = async () => {
+        setStatus("busy"); setError(null); setZipUrl(null);
+        try {
+            const ffmpeg = await loadFFmpeg();
+            const result = await splitExportVideo(ffmpeg, file, recipe, segments, duration,
+                (seg, pct) => setProgress({ seg: seg + 1, pct }));
+            setZipUrl(result.zipUrl);
+            setStatus("done");
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Failed");
+            setStatus("error");
+        }
+    };
+
+    return (
+        <div className="space-y-3">
+            <div className="space-y-1">
+                <div className="flex justify-between text-xs">
+                    <span>Parts</span>
+                    <span className="font-bold text-film-500">{segments}</span>
+                </div>
+                <input type="range" min={2} max={10} value={segments}
+                    onChange={e => setSegments(Number(e.target.value))}
+                    disabled={status === "busy"}
+                    className="w-full accent-film-600" aria-label="Number of parts" />
+            </div>
+
+            {status === "busy" && (
+                <div className="space-y-1">
+                    <div className="flex justify-between text-xs text-[var(--muted)]">
+                        <span>Segment {progress.seg}/{segments}</span>
+                        <span>{progress.pct}%</span>
+                    </div>
+                    <div className="w-full bg-[var(--border)] rounded-full h-1.5">
+                        <div className="bg-film-600 h-1.5 rounded-full transition-all"
+                            style={{ width: `${progress.pct}%` }} />
+                    </div>
+                </div>
+            )}
+
+            {status === "error" && <p className="text-xs text-red-500">{error}</p>}
+
+            {status === "done" && zipUrl && (
+                <a href={zipUrl}
+                    download={`${file.name.replace(/\.[^/.]+$/, "")}_${segments}parts.zip`}
+                    className="block w-full text-center py-2 bg-green-600 text-white text-xs font-bold rounded-lg hover:bg-green-700">
+                    Download ZIP
+                </a>
+            )}
+
+            <button type="button"
+                onClick={status === "done" ? () => setStatus("idle") : run}
+                disabled={status === "busy"}
+                aria-label="Split video into equal segments"
+                className={cn("w-full py-2 rounded-lg text-sm font-bold transition-all",
+                    status === "busy" ? "bg-[var(--border)] text-[var(--muted)] cursor-not-allowed"
+                    : status === "done" ? "border border-[var(--border)] text-[var(--muted)]"
+                    : "bg-film-600 hover:bg-film-700 text-white")}>
+                {status === "busy" ? "Splitting..." : status === "done" ? "Split again" : `Split into ${segments} parts`}
+            </button>
+        </div>
+    );
+}

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -18,6 +18,7 @@ import ExportOverlay from "./ExportOverlay";
 import DownloadResult from "./DownloadResult";
 import ImageOverlay from "./ImageOverlay"
 import { getPresetById } from "@/lib/presets";
+import SplitExport from "./SplitExport";
 
 import { cn } from "@/lib/utils";
 import {
@@ -232,6 +233,7 @@ export default function VideoEditor() {
     rotation: false,
     text: false,
     audio: false,
+    split: false,
     export: false,
   });
 
@@ -556,6 +558,16 @@ export default function VideoEditor() {
                   <Section icon={<SlidersHorizontal size={12} />} title="Output format" delay={190}>
                     <FormatSelector recipe={recipe} onChange={updateRecipe} />
                   </Section>
+                  <AccordionSection
+                    id="split"
+                    icon={<Scissors size={12} />}
+                    title="Split Video"
+                    isOpen={openSections.split}
+                    onToggle={() => toggleSection("split")}
+                    delay={195}
+                  >
+                    <SplitExport file={file} recipe={recipe} duration={duration} />
+                  </AccordionSection>
                   <AccordionSection
                     id="export"
                     icon={<SlidersHorizontal size={12} />}

--- a/src/lib/splitExport.ts
+++ b/src/lib/splitExport.ts
@@ -1,0 +1,65 @@
+import { FFmpeg } from "@ffmpeg/ffmpeg";
+import { fetchFile } from "@ffmpeg/util";
+import JSZip from "jszip";
+import { EditRecipe } from "./types";
+import { getPresetById } from "./presets";
+
+export async function splitExportVideo(
+    ffmpeg: FFmpeg,
+    file: File,
+    recipe: EditRecipe,
+    segments: number,
+    duration: number,
+    onProgress: (segmentIndex: number, percent: number) => void,
+    signal?: AbortSignal
+): Promise<{ zipUrl: string; totalSize: number }> {
+    const id = Date.now();
+    const ext = file.name.split(".").pop() ?? "mp4";
+    const inputName = `input_${id}.${ext}`;
+    const trimStart = recipe.trimStart ?? 0;
+    const trimEnd = recipe.trimEnd ?? duration;
+    const segDuration = (trimEnd - trimStart) / segments;
+
+    let targetW = recipe.customWidth, targetH = recipe.customHeight;
+    if (recipe.preset !== "custom") {
+        const p = getPresetById(recipe.preset);
+        targetW = p?.width ?? 1920;
+        targetH = p?.height ?? 1080;
+    }
+    targetW = Math.round(targetW / 2) * 2;
+    targetH = Math.round(targetH / 2) * 2;
+
+    await ffmpeg.writeFile(inputName, await fetchFile(file), { signal });
+    const zip = new JSZip();
+    let totalSize = 0;
+
+    for (let i = 0; i < segments; i++) {
+        const start = (trimStart + i * segDuration).toFixed(3);
+        const end = (trimStart + (i + 1) * segDuration).toFixed(3);
+        const outName = `seg_${id}_${i}.mp4`;
+
+        const onProg = ({ progress }: { progress: number }) =>
+            onProgress(i, Math.min(100, Math.round(progress * 100)));
+        ffmpeg.on("progress", onProg);
+
+        await ffmpeg.exec([
+            "-i", inputName,
+            "-ss", start, "-to", end,
+            "-c:v", "libx264", "-crf", String(recipe.quality),
+            "-preset", "medium", "-movflags", "+faststart",
+            ...(recipe.keepAudio ? ["-c:a", "aac", "-b:a", "128k"] : ["-an"]),
+            outName
+        ], undefined, { signal });
+
+        ffmpeg.off("progress", onProg);
+        const data = await ffmpeg.readFile(outName, undefined, { signal });
+        const bytes = new Uint8Array(data as Uint8Array);
+        totalSize += bytes.byteLength;
+        zip.file(`part${i + 1}_of_${segments}.mp4`, bytes);
+        try { await ffmpeg.deleteFile(outName); } catch {}
+    }
+
+    try { await ffmpeg.deleteFile(inputName); } catch {}
+    const blob = await zip.generateAsync({ type: "blob" });
+    return { zipUrl: URL.createObjectURL(blob), totalSize };
+}


### PR DESCRIPTION
## Description
Added the ability to split a video into N equal segments and download them all as a ZIP file. The user can choose between 2–10 parts using a slider. FFmpeg runs N times with different trim settings, and progress is shown for each segment.

## Related Issue
 Closes #128 

## Type of Contribution
- [ ] New feature
- [ ] GSSoC contribution

## Participant Info
- GitHub username: garima-agarwall
- Contribution level (Beginner/Intermediate/Advanced): Beginner

## Screen Recording
<!-- Drag a video file here or paste a Loom link below. -->
https://github.com/user-attachments/assets/ef339bb2-1368-4634-9fe8-484057e74b48
**Recording / Loom link:** <!-- drag file here or paste link [-->]


## Checklist
- [yes ] I have read the contribution guidelines
- [yes ] My changes follow the project structure
- [yes ] I have tested my changes in Chrome, Firefox, and Safari
- [ yes] `bun run lint` passes (no ESLint errors)
- [ yes] `bunx tsc --noEmit` passes (no TypeScript errors)
- [yes ] New interactive elements have `aria-label` / accessible names
- [yes ] No `console.log` statements left in
- [ yes] This PR is related to a valid issue
- [ yes] **Screen recording attached above** (required for UI/feature/design changes)
