### PR TITLE
feat: add intro splash screen animation on first app load

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from "@/components/ThemeProvider";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import ScrollToTop from "@/components/ScrollToTop";
 import BrandLogo from "@/components/BrandLogo";
+import SplashScreen from "@/components/SplashScreen";
 
 export const metadata: Metadata = {
   title: "Reframe — Resize, trim, and export videos in your browser",
@@ -75,6 +76,7 @@ export default function RootLayout({
           Skip to main content
         </a>
         <ThemeProvider>
+          <SplashScreen />
           <ErrorBoundary>
             <header
               role="banner"

--- a/src/components/SplashScreen.tsx
+++ b/src/components/SplashScreen.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import BrandLogo from "@/components/BrandLogo";
+
+const SPLASH_KEY = "reframe_splash_shown";
+
+export default function SplashScreen() {
+  const [visible, setVisible] = useState(false);
+  const [fading, setFading] = useState(false);
+
+  useEffect(() => {
+    // Respect prefers-reduced-motion
+    const reducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    ).matches;
+    if (reducedMotion) return;
+
+    // Only show on first visit
+    const alreadyShown = localStorage.getItem(SPLASH_KEY);
+    if (alreadyShown) return;
+
+    setVisible(true);
+
+    // Start fade-out after 1.4s
+    const fadeTimer = setTimeout(() => {
+      setFading(true);
+    }, 1400);
+
+    // Remove from DOM after fade completes
+    const removeTimer = setTimeout(() => {
+      setVisible(false);
+      localStorage.setItem(SPLASH_KEY, "1");
+    }, 1900); // 1400ms hold + 500ms fade
+
+    return () => {
+      clearTimeout(fadeTimer);
+      clearTimeout(removeTimer);
+    };
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-[var(--bg)]"
+      style={{
+        transition: "opacity 500ms ease",
+        opacity: fading ? 0 : 1,
+        pointerEvents: fading ? "none" : "auto",
+      }}
+    >
+      <div
+        className="flex flex-col items-center gap-4"
+        style={{
+          animation: "splash-in 600ms cubic-bezier(0.16, 1, 0.3, 1) forwards",
+        }}
+      >
+        <BrandLogo size={48} />
+        <div className="flex flex-col items-center gap-1">
+          <h1 className="text-2xl font-bold tracking-tight text-[var(--text)]">
+            Reframe
+          </h1>
+          <p className="text-[10px] font-mono tracking-[0.4em] uppercase opacity-50">
+            Browser Video Studio
+          </p>
+        </div>
+
+        {/* Loading bar */}
+        <div className="w-32 h-0.5 bg-[var(--border)] rounded-full overflow-hidden mt-2">
+          <div
+            className="h-full bg-red-500 rounded-full"
+            style={{
+              animation: "splash-bar 1200ms ease-in-out forwards",
+            }}
+          />
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes splash-in {
+          from { opacity: 0; transform: translateY(8px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes splash-bar {
+          from { width: 0%; }
+          to   { width: 100%; }
+        }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Closes #1017

Adds a polished splash screen that appears on first visit before the 
main app loads.

## What's New

### `src/components/SplashScreen.tsx` (new file)
- Shows Reframe logo + tagline + animated loading bar
- Fades in smoothly on mount
- Holds for 1.4s then fades out over 500ms
- Uses `localStorage` to show only on first visit

### `src/app/layout.tsx`
- Import and render `<SplashScreen />` inside `ThemeProvider`

## Accessibility
- Fully respects `prefers-reduced-motion` — skips animation entirely 
  for users with motion sensitivity
- `aria-hidden="true"` so screen readers skip the splash overlay

## Testing
1. Clear localStorage (`reframe_splash_shown`)
2. Visit the app
3. Splash screen appears with logo + loading bar then fades out
4. Refresh — splash does NOT appear again
5. Set `prefers-reduced-motion: reduce` — splash is skipped entirely