### PR TITLE
fix: improve border and surface contrast in light mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,8 +5,8 @@
 /* ── Light mode tokens ── */
 :root {
   --bg: #ffffff;
-  --surface: #f8fafc;
-  --border: #e2e8f0;
+  --surface: #f1f5f9;
+  --border: #cbd5e1;
   --text: #0f172a;
   --muted: #64748b;
   --accent: #3b82f6;


### PR DESCRIPTION
## Summary
Closes #1018

Improves the visibility of borders and UI surfaces in light mode by 
darkening the CSS token values.

## Changes
Only `src/app/globals.css` touched — 2 token value changes in `:root`:

| Token | Before | After | Change |
|---|---|---|---|
| `--border` | `#e2e8f0` | `#cbd5e1` | Darker, more visible borders |
| `--surface` | `#f8fafc` | `#f1f5f9` | Slightly more surface contrast |

Dark mode and high-contrast mode tokens are **unchanged**.

## Why These Values
Both values are from the Tailwind slate palette:
- `#cbd5e1` = `slate-300` (was `slate-200`)
- `#f1f5f9` = `slate-100` (was `slate-50`)

One step darker on the scale — enough to be clearly visible without 
feeling heavy or changing the overall aesthetic.

## Testing
1. Visit the app in light mode
2. Observe panels, cards, inputs and dividers are clearly visible
3. Switch to dark mode — no change