### PR TITLE
feat: add text overlay

### DIFF
--- a/src/components/DraggableTextOverlays.tsx
+++ b/src/components/DraggableTextOverlays.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import { TextOverlay, EditRecipe } from "@/lib/types";
+import { useRef, useState, useCallback, useEffect, useMemo } from "react";
+import { getTextPixelPosition, getTextPercentPosition } from "@/lib/text-overlay";
+
+interface DraggableTextOverlaysProps {
+  recipe?: EditRecipe;
+  containerWidth: number;
+  containerHeight: number;
+  selectedTextId: string | null;
+  onUpdateText: (id: string, updates: Partial<TextOverlay>) => void;
+  onSelectText: (id: string | null) => void;
+}
+
+/**
+ * Renders draggable text overlays on the video preview.
+ * Users can click and drag text to reposition it on the canvas.
+ */
+export default function DraggableTextOverlays({
+  recipe,
+  containerWidth,
+  containerHeight,
+  selectedTextId,
+  onUpdateText,
+  onSelectText,
+}: DraggableTextOverlaysProps) {
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editText, setEditText] = useState<string>("");
+  const containerRef = useRef<HTMLDivElement>(null);
+  const editInputRef = useRef<HTMLDivElement>(null);
+
+  /**
+   * Memoize text overlays to prevent unnecessary dependency changes.
+   */
+  const textOverlays = useMemo(() => recipe?.textOverlays || [], [recipe?.textOverlays]);
+
+  /**
+   * Handles the start of a drag operation.
+   */
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>, overlayId: string) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const overlay = textOverlays.find((o) => o.id === overlayId);
+      if (!overlay || !containerRef.current) return;
+
+      onSelectText(overlayId);
+
+      const rect = containerRef.current.getBoundingClientRect();
+      const { left: pixelX, top: pixelY } = getTextPixelPosition(
+        overlay.x,
+        overlay.y,
+        containerWidth,
+        containerHeight
+      );
+
+      setDraggingId(overlayId);
+      setDragOffset({
+        x: e.clientX - rect.left - pixelX,
+        y: e.clientY - rect.top - pixelY,
+      });
+    },
+    [textOverlays, containerWidth, containerHeight, onSelectText]
+  );
+
+  /**
+   * Handles double-click to enter edit mode.
+   */
+  const handleDoubleClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>, overlayId: string) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const overlay = textOverlays.find((o) => o.id === overlayId);
+      if (!overlay) return;
+
+      setEditingId(overlayId);
+      setEditText(overlay.text);
+    },
+    [textOverlays]
+  );
+
+  /**
+   * Saves the edited text and exits edit mode.
+   */
+  const handleSaveEdit = useCallback(
+    (overlayId: string) => {
+      if (editText.trim()) {
+        onUpdateText(overlayId, { text: editText });
+      }
+      setEditingId(null);
+      setEditText("");
+    },
+    [editText, onUpdateText]
+  );
+
+  /**
+   * Handles keyboard events in edit mode.
+   */
+  const handleEditKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>, overlayId: string) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        handleSaveEdit(overlayId);
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        setEditingId(null);
+        setEditText("");
+      }
+    },
+    [handleSaveEdit]
+  );
+
+  /**
+   * Handles dragging of text overlays.
+   */
+  useEffect(() => {
+    if (!draggingId || !containerRef.current) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const rect = containerRef.current!.getBoundingClientRect();
+      const pixelX = e.clientX - rect.left - dragOffset.x;
+      const pixelY = e.clientY - rect.top - dragOffset.y;
+
+      const { x: percentX, y: percentY } = getTextPercentPosition(
+        pixelX,
+        pixelY,
+        containerWidth,
+        containerHeight
+      );
+
+      onUpdateText(draggingId, { x: percentX, y: percentY });
+    };
+
+    const handleMouseUp = () => {
+      setDraggingId(null);
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [draggingId, dragOffset, containerWidth, containerHeight, onUpdateText]);
+
+  /**
+   * Focus edit input when entering edit mode.
+   */
+  useEffect(() => {
+    if (editingId && editInputRef.current) {
+      // Set the initial text content
+      editInputRef.current.textContent = editText;
+      editInputRef.current.focus();
+      // Select all text for quick replacement
+      const range = document.createRange();
+      range.selectNodeContents(editInputRef.current);
+      const sel = window.getSelection();
+      if (sel) {
+        sel.removeAllRanges();
+        sel.addRange(range);
+      }
+    }
+  }, [editingId, editText]);
+
+  if (!textOverlays || textOverlays.length === 0) return null;
+
+  return (
+    <div
+      ref={containerRef}
+      className="absolute inset-0 pointer-events-none"
+      style={{ width: containerWidth, height: containerHeight }}
+    >
+      {textOverlays.map((overlay) => {
+        const { left, top } = getTextPixelPosition(
+          overlay.x,
+          overlay.y,
+          containerWidth,
+          containerHeight
+        );
+
+        const isSelected = selectedTextId === overlay.id;
+        const isDragging = draggingId === overlay.id;
+
+        return (
+          <div
+            key={overlay.id}
+            role="button"
+            tabIndex={0}
+            onMouseDown={(e) => handleMouseDown(e, overlay.id)}
+            onDoubleClick={(e) => handleDoubleClick(e, overlay.id)}
+            onKeyDown={(e) => {
+              if (editingId === overlay.id) {
+                handleEditKeyDown(e, overlay.id);
+              } else if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onSelectText(overlay.id);
+              }
+            }}
+            className={`absolute pointer-events-auto ${
+              editingId === overlay.id ? "cursor-text" : "cursor-move"
+            } select-none transition-all ${
+              isDragging ? "scale-105" : "scale-100"
+            } ${
+              isSelected
+                ? "ring-2 ring-film-500 ring-offset-1 ring-offset-black/50"
+                : ""
+            }`}
+            style={{
+              left: `${left}px`,
+              top: `${top}px`,
+              transform: "translate(-50%, -50%)",
+              fontSize: `${overlay.fontSize}px`,
+              color: overlay.color,
+              fontWeight:
+                overlay.fontWeight === "900"
+                  ? 900
+                  : overlay.fontWeight === "bold"
+                  ? 700
+                  : 400,
+              textShadow: "0 2px 8px rgba(0, 0, 0, 0.8)",
+              whiteSpace: "nowrap",
+            }}
+            aria-label={`Text overlay: ${overlay.text}`}
+            aria-pressed={isSelected}
+          >
+            {editingId === overlay.id ? (
+              <div
+                ref={editInputRef}
+                contentEditable
+                suppressContentEditableWarning
+                onBlur={() => handleSaveEdit(overlay.id)}
+                onInput={(e) => setEditText(e.currentTarget.textContent || "")}
+                className="outline-none bg-black/30 px-1 py-0.5 rounded"
+                style={{
+                  color: overlay.color,
+                  fontSize: `${overlay.fontSize}px`,
+                  fontWeight:
+                    overlay.fontWeight === "900"
+                      ? 900
+                      : overlay.fontWeight === "bold"
+                      ? 700
+                      : 400,
+                  textShadow: "0 2px 8px rgba(0, 0, 0, 0.8)",
+                }}
+              >
+              </div>
+            ) : (
+              overlay.text
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/TextControls.tsx
+++ b/src/components/TextControls.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { EditRecipe, TextOverlay } from "@/lib/types";
+import { createDefaultTextOverlay } from "@/lib/text-overlay";
+import { Trash2, Plus } from "lucide-react";
+import { useMemo } from "react";
+import BaseButton from "./ui/BaseButton";
+
+interface TextControlsProps {
+  recipe: EditRecipe;
+  onChange: (patch: Partial<EditRecipe>) => void;
+  selectedTextId: string | null;
+  onSelectText: (id: string | null) => void;
+}
+
+/**
+ * Controls for managing text overlays on the video.
+ * Allows users to add, remove, and select text overlays.
+ */
+export default function TextControls({
+  recipe,
+  onChange,
+  selectedTextId,
+  onSelectText,
+}: TextControlsProps) {
+  /**
+   * Memoize text overlays to prevent unnecessary dependency changes.
+   */
+  const textOverlays = useMemo(() => recipe.textOverlays || [], [recipe.textOverlays]);
+
+  /**
+   * Adds a new text overlay to the recipe.
+   */
+  const handleAddText = () => {
+    const newOverlay = createDefaultTextOverlay();
+    const updatedOverlays = [...textOverlays, newOverlay];
+    onChange({ textOverlays: updatedOverlays });
+    onSelectText(newOverlay.id);
+  };
+
+  /**
+   * Removes a text overlay from the recipe.
+   */
+  const handleRemoveText = (id: string) => {
+    const updatedOverlays = textOverlays.filter((overlay) => overlay.id !== id);
+    onChange({ textOverlays: updatedOverlays });
+    if (selectedTextId === id) {
+      onSelectText(null);
+    }
+  };
+
+  /**
+   * Updates a text overlay property.
+   */
+  const handleUpdateText = (id: string, updates: Partial<TextOverlay>) => {
+    const updatedOverlays = textOverlays.map((overlay) =>
+      overlay.id === id ? { ...overlay, ...updates } : overlay
+    );
+    onChange({ textOverlays: updatedOverlays });
+  };
+
+  /**
+   * Get the currently selected overlay.
+   */
+  const selectedOverlay = useMemo(
+    () => textOverlays.find((o) => o.id === selectedTextId),
+    [textOverlays, selectedTextId]
+  );
+
+  return (
+    <div className="w-full space-y-3">
+      {/* Add Text Button */}
+      <button
+        type="button"
+        onClick={handleAddText}
+        className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--surface)] text-[var(--text)] font-semibold text-sm hover:bg-[var(--border)] transition-colors"
+      >
+        <Plus size={14} />
+        Add Text
+      </button>
+
+      {/* Text Overlay List */}
+      {textOverlays.length > 0 && (
+        <div className="space-y-2 max-h-40 overflow-y-auto">
+          {textOverlays.map((overlay, idx) => (
+            <div
+              key={overlay.id}
+              className={`flex items-center justify-between gap-2 p-2 rounded border transition-colors ${
+                selectedTextId === overlay.id
+                  ? "border-film-500 bg-film-600/10"
+                  : "border-[var(--border)] bg-[var(--surface)] hover:bg-[var(--border)]"
+              }`}
+            >
+              <button
+                type="button"
+                onClick={() => onSelectText(overlay.id)}
+                className="flex-1 text-left text-xs truncate text-[var(--text)] font-medium"
+              >
+                {overlay.text || "(empty)"}
+              </button>
+              <button
+                type="button"
+                onClick={() => handleRemoveText(overlay.id)}
+                className="w-5 h-5 flex items-center justify-center rounded text-red-400 hover:bg-red-500/10 transition-colors"
+                aria-label={`Remove text overlay ${idx + 1}`}
+              >
+                <Trash2 size={13} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Text Editing Controls */}
+      {selectedOverlay && (
+        <div className="space-y-3 pt-2 border-t border-[var(--border)]">
+          {/* Text Input */}
+          <div>
+            <label htmlFor="text-input" className="text-xs text-[var(--muted)] font-medium mb-1 block">
+              Text
+            </label>
+            <textarea
+              id="text-input"
+              value={selectedOverlay.text}
+              onChange={(e) => handleUpdateText(selectedTextId!, { text: e.target.value })}
+              placeholder="Enter text here"
+              className="w-full px-2 py-1.5 text-xs rounded border border-[var(--border)] bg-[var(--bg)] text-[var(--text)] placeholder-[var(--muted)] focus:outline-none focus:ring-2 focus:ring-film-500 resize-none"
+              rows={2}
+            />
+          </div>
+
+          {/* Font Size Slider */}
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <label htmlFor="font-size-slider" className="text-xs text-[var(--muted)] font-medium">
+                Font Size
+              </label>
+              <span className="text-xs text-[var(--text)] font-semibold">
+                {selectedOverlay.fontSize}px
+              </span>
+            </div>
+            <input
+              id="font-size-slider"
+              type="range"
+              min="12"
+              max="120"
+              step="2"
+              value={selectedOverlay.fontSize}
+              onChange={(e) =>
+                handleUpdateText(selectedTextId!, {
+                  fontSize: Number(e.target.value),
+                })
+              }
+              className="w-full accent-film-600"
+            />
+          </div>
+
+          {/* Text Color Picker */}
+          <div>
+            <label htmlFor="color-picker" className="text-xs text-[var(--muted)] font-medium mb-1 block">
+              Color
+            </label>
+            <div className="flex items-center gap-2">
+              <input
+                id="color-picker"
+                type="color"
+                value={selectedOverlay.color}
+                onChange={(e) =>
+                  handleUpdateText(selectedTextId!, { color: e.target.value })
+                }
+                className="w-10 h-8 rounded border border-[var(--border)] cursor-pointer"
+              />
+              <input
+                type="text"
+                value={selectedOverlay.color}
+                onChange={(e) =>
+                  handleUpdateText(selectedTextId!, { color: e.target.value })
+                }
+                className="flex-1 px-2 py-1 text-xs rounded border border-[var(--border)] bg-[var(--bg)] text-[var(--text)] font-mono focus:outline-none focus:ring-2 focus:ring-film-500"
+                placeholder="#ffffff"
+                aria-label="Hex color input"
+              />
+            </div>
+          </div>
+
+          {/* Font Weight */}
+          <div>
+            <legend className="text-xs text-[var(--muted)] font-medium mb-1 block">
+              Weight
+            </legend>
+            <div className="grid grid-cols-3 gap-1">
+              {(["normal", "bold", "900"] as const).map((weight) => (
+                <button
+                  key={weight}
+                  type="button"
+                  onClick={() =>
+                    handleUpdateText(selectedTextId!, { fontWeight: weight })
+                  }
+                  className={`px-2 py-1.5 text-xs rounded border transition-colors ${
+                    selectedOverlay.fontWeight === weight
+                      ? "border-film-500 bg-film-600/10 text-film-400"
+                      : "border-[var(--border)] bg-[var(--surface)] text-[var(--muted)] hover:bg-[var(--border)]"
+                  }`}
+                  style={{
+                    fontWeight: weight === "normal" ? 400 : weight === "bold" ? 700 : 900,
+                  }}
+                >
+                  {weight === "900" ? "Heavy" : weight.charAt(0).toUpperCase() + weight.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ThumbnailStrip.tsx
+++ b/src/components/ThumbnailStrip.tsx
@@ -144,6 +144,7 @@ export default function ThumbnailStrip({
       generateThumbnails();
     }
     return () => {
+      // Increment ref to invalidate any pending async operations
       lastRunIdRef.current++;
       revokeAllObjectUrls();
     };

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, useMemo } from "react";
 import { useVideoEditor } from "@/hooks/useVideoEditor";
+import { TextOverlay } from "@/lib/types";
 import FileUpload from "./FileUpload";
 import VideoPreview from "./VideoPreview";
 import ThumbnailStrip from "./ThumbnailStrip";
@@ -9,6 +10,7 @@ import PresetSelector from "./PresetSelector";
 import FramingControl from "./FramingControl";
 import TrimControl from "./TrimControl";
 import RotateControl from "./RotateControl";
+import TextControls from "./TextControls";
 import AudioSpeedControl from "./AudioSpeedControl";
 import FormatSelector from "./FormatSelector";
 import ExportSettings from "./ExportSettings";
@@ -18,7 +20,7 @@ import ImageOverlay from "./ImageOverlay"
 
 import { cn } from "@/lib/utils";
 import {
-  Layers, Crop, Scissors, RotateCw, Volume2,
+  Layers, Crop, Scissors, RotateCw, Volume2, Type,
   SlidersHorizontal, Zap, AlertTriangle, Github, Copy
 } from "lucide-react";
 import OnboardingTour from "./OnboardingTour";
@@ -232,10 +234,12 @@ export default function VideoEditor() {
 
   const [copied, setCopied] = useState(false);
   const [shareCopied, setShareCopied] = useState(false);
+  const [selectedTextId, setSelectedTextId] = useState<string | null>(null);
   const [openSections, setOpenSections] = useState({
     resize: true,
     trim: false,
     rotation: false,
+    text: false,
     audio: false,
     export: false,
   });
@@ -243,6 +247,16 @@ export default function VideoEditor() {
   const toggleSection = (key: keyof typeof openSections) =>
     setOpenSections((prev) => ({ ...prev, [key]: !prev[key] }));
   const downloadRef = useRef<HTMLDivElement>(null);
+
+  /**
+   * Updates a text overlay property and syncs with recipe.
+   */
+  const handleUpdateTextOverlay = (id: string, updates: Partial<TextOverlay>) => {
+    const updatedOverlays = (recipe.textOverlays || []).map((overlay) =>
+      overlay.id === id ? { ...overlay, ...updates } : overlay
+    );
+    updateRecipe({ textOverlays: updatedOverlays });
+  };
 
   const handleCopyLink = () => {
     if (typeof window === "undefined") return;
@@ -322,7 +336,14 @@ export default function VideoEditor() {
 
               {file && (
                 <div className="mt-4 animate-fade-in">
-                  <VideoPreview file={file} recipe={recipe} videoRef={videoRef} />
+                  <VideoPreview
+                    file={file}
+                    recipe={recipe}
+                    videoRef={videoRef}
+                    selectedTextId={selectedTextId}
+                    onSelectText={setSelectedTextId}
+                    onUpdateText={handleUpdateTextOverlay}
+                  />
 
                   <div className="mt-3">
                     <ThumbnailStrip
@@ -374,6 +395,22 @@ export default function VideoEditor() {
                     delay={100}
                   >
                     <RotateControl recipe={recipe} onChange={updateRecipe} />
+                  </AccordionSection>
+
+                  <AccordionSection
+                    id="text"
+                    icon={<Type size={12} />}
+                    title="Text Overlay"
+                    isOpen={openSections.text}
+                    onToggle={() => toggleSection("text")}
+                    delay={110}
+                  >
+                    <TextControls
+                      recipe={recipe}
+                      onChange={updateRecipe}
+                      selectedTextId={selectedTextId}
+                      onSelectText={setSelectedTextId}
+                    />
                   </AccordionSection>
                 </div>
                 <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6">

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -2,24 +2,40 @@
 "use client";
 
 import { useEffect, useRef, useState, useCallback, RefObject } from "react";
-import { EditRecipe } from "@/lib/types";
+import { EditRecipe, TextOverlay } from "@/lib/types";
 import { getPresetById } from "@/lib/presets";
 import { cn } from "@/lib/utils";
 import { Camera } from "lucide-react";
 import ComparisonPreview from "./ComparisonPreview";
+import DraggableTextOverlays from "./DraggableTextOverlays";
 
 interface Props {
   file: File | null;
   recipe?: EditRecipe;
   videoRef: RefObject<HTMLVideoElement | null>;
+  selectedTextId?: string | null;
+  onSelectText?: (id: string | null) => void;
+  onUpdateText?: (id: string, updates: Partial<TextOverlay>) => void;
 }
 
-export default function VideoPreview({ file, recipe, videoRef }: Props) {
+export default function VideoPreview({
+  file,
+  recipe,
+  videoRef,
+  selectedTextId = null,
+  onSelectText,
+  onUpdateText,
+}: Props) {
   const lastId = useRef(0);
   const urlRef = useRef<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [showOverlay, setShowOverlay] = useState(false);
   const [showComparison, setShowComparison] = useState(false);
+  const [containerDimensions, setContainerDimensions] = useState({
+    width: 0,
+    height: 0,
+  });
+  const previewContainerRef = useRef<HTMLDivElement>(null);
   const onLoadedRef = useRef<(() => void) | null>(null);
 
   const handleGrabFrame = useCallback(() => {
@@ -108,6 +124,25 @@ export default function VideoPreview({ file, recipe, videoRef }: Props) {
     videoRef.current.playbackRate = recipe.speed;
   }, [recipe, videoRef]);
 
+  /**
+   * Track preview container dimensions for text overlay positioning.
+   */
+  useEffect(() => {
+    const updateDimensions = () => {
+      if (previewContainerRef.current) {
+        const rect = previewContainerRef.current.getBoundingClientRect();
+        setContainerDimensions({
+          width: rect.width,
+          height: rect.height,
+        });
+      }
+    };
+
+    updateDimensions();
+    window.addEventListener("resize", updateDimensions);
+    return () => window.removeEventListener("resize", updateDimensions);
+  }, []);
+
   const overlay = (() => {
     if (!recipe || !showOverlay) return null;
 
@@ -180,6 +215,7 @@ export default function VideoPreview({ file, recipe, videoRef }: Props) {
   return (
     <>
       <div
+        ref={previewContainerRef}
         role="group"
         className="relative w-full rounded-lg overflow-hidden bg-[#0a0a0a] aspect-video focus:outline-none focus-visible:ring-2 focus-visible:ring-film-500"
         tabIndex={0}
@@ -234,6 +270,18 @@ export default function VideoPreview({ file, recipe, videoRef }: Props) {
               </>
             )}
           </div>
+        )}
+
+        {/* Draggable Text Overlays */}
+        {recipe && !isLoading && containerDimensions.width > 0 && (
+          <DraggableTextOverlays
+            recipe={recipe}
+            containerWidth={containerDimensions.width}
+            containerHeight={containerDimensions.height}
+            selectedTextId={selectedTextId ?? null}
+            onSelectText={onSelectText || (() => {})}
+            onUpdateText={onUpdateText || (() => {})}
+          />
         )}
 
         {/* Toggle button */}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -22,5 +22,6 @@ export const DEFAULT_RECIPE: EditRecipe = {
   denoise: false,
   soundOnCompletion: false,
   normalizeAudio: false,
+  textOverlays: [],
   version: RECIPE_VERSION,
 };

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -2,6 +2,7 @@ import { FFmpeg } from "@ffmpeg/ffmpeg";
 import { fetchFile, toBlobURL } from "@ffmpeg/util";
 import { EditRecipe, ExportResult, BackgroundMusicOptions, ImageOverlayOptions } from "./types";
 import { getPresetById } from "./presets";
+import { buildTextFilter } from "./text-overlay";
 import { simd } from "wasm-feature-detect";
 
 const CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd";
@@ -143,6 +144,13 @@ export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: n
   filters.push(
     `eq=brightness=${recipe.brightness}:contrast=${recipe.contrast}:saturation=${recipe.saturation}`
   );
+
+  // Add text overlays
+  const textOverlays = recipe.textOverlays || [];
+  textOverlays.forEach((overlay) => {
+    filters.push(buildTextFilter(overlay, targetW, targetH));
+  });
+
   return filters.join(",");
 }
 

--- a/src/lib/text-overlay.ts
+++ b/src/lib/text-overlay.ts
@@ -1,0 +1,89 @@
+import { TextOverlay } from "./types";
+
+/**
+ * Generates a unique ID for a text overlay.
+ */
+export function generateTextOverlayId(): string {
+  return `text-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+/**
+ * Creates a default text overlay with sensible defaults.
+ */
+export function createDefaultTextOverlay(): TextOverlay {
+  return {
+    id: generateTextOverlayId(),
+    text: "Enter text",
+    x: 50, // Centered horizontally
+    y: 20, // Near top
+    fontSize: 48,
+    color: "#ffffff",
+    fontWeight: "normal",
+  };
+}
+
+/**
+ * Calculates the position of a text overlay relative to the preview container.
+ * @param percentX - Horizontal position as percentage (0-100)
+ * @param percentY - Vertical position as percentage (0-100)
+ * @param containerWidth - Width of the preview container in pixels
+ * @param containerHeight - Height of the preview container in pixels
+ */
+export function getTextPixelPosition(
+  percentX: number,
+  percentY: number,
+  containerWidth: number,
+  containerHeight: number
+): { left: number; top: number } {
+  return {
+    left: (percentX / 100) * containerWidth,
+    top: (percentY / 100) * containerHeight,
+  };
+}
+
+/**
+ * Converts pixel position back to percentage within the container.
+ */
+export function getTextPercentPosition(
+  pixelX: number,
+  pixelY: number,
+  containerWidth: number,
+  containerHeight: number
+): { x: number; y: number } {
+  return {
+    x: Math.max(0, Math.min(100, (pixelX / containerWidth) * 100)),
+    y: Math.max(0, Math.min(100, (pixelY / containerHeight) * 100)),
+  };
+}
+
+/**
+ * Generates a drawText FFmpeg filter for a single text overlay.
+ * Escapes special characters and positions text on the output video.
+ */
+export function buildTextFilter(
+  overlay: TextOverlay,
+  targetWidth: number,
+  targetHeight: number
+): string {
+  // Escape special characters for FFmpeg drawtext filter
+  const escapedText = overlay.text
+    .replace(/\\/g, "\\\\")
+    .replace(/'/g, "\\'")
+    .replace(/:/g, "\\:");
+
+  // Convert percentage position to pixel position
+  const pixelX = Math.round((overlay.x / 100) * targetWidth);
+  const pixelY = Math.round((overlay.y / 100) * targetHeight);
+
+  // Build the drawtext filter with proper escaping
+  // Using 'fontsize' and 'fontcolor' parameters
+  // Note: Font file path may not be available in all environments,
+  // so we rely on the system default font
+  return `drawtext=text='${escapedText}':x=${pixelX}:y=${pixelY}:fontsize=${overlay.fontSize}:fontcolor=${overlay.color}:fontweight=${
+    overlay.fontWeight === "900"
+      ? "bold"
+      : overlay.fontWeight === "bold"
+      ? "bold"
+      : "normal"
+  }`;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,18 @@
 export const RECIPE_VERSION = 1;
 
+/**
+ * Text overlay data structure for rendering custom text on videos.
+ */
+export interface TextOverlay {
+  id: string;
+  text: string;
+  x: number; // Percentage (0-100) from left
+  y: number; // Percentage (0-100) from top
+  fontSize: number; // In pixels
+  color: string; // Hex color
+  fontWeight: "normal" | "bold" | "900";
+}
+
 export interface EditRecipe {
   preset: string;
   customWidth: number;
@@ -19,6 +32,7 @@ export interface EditRecipe {
   contrast: number;
   saturation: number;
   soundOnCompletion: boolean;
+  textOverlays: TextOverlay[];
   version: number;
 }
 
@@ -86,6 +100,7 @@ export function isValidRecipe(value: unknown): value is EditRecipe {
   if (typeof v.contrast !== "number" || !isFinite(v.contrast)) return false;
   if (typeof v.saturation !== "number" || !isFinite(v.saturation)) return false;
   if (typeof v.soundOnCompletion !== "boolean") return false;
+  if (!Array.isArray(v.textOverlays)) return false;
 
   return true;
 }


### PR DESCRIPTION
## Description

Implemented a lightweight text overlay system for the video editor.

This PR adds support for:

* creating text overlays directly on the video preview
* dragging/repositioning text on the canvas
* inline text editing
* basic text styling controls
* toolbar integration near the rotate controls
* rendering text overlays during export

The implementation was intentionally kept minimal to preserve the existing architecture and avoid unnecessary UI refactors.

## Related Issue

Closes #717 

## Type of Contribution

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [x] GSSoC contribution

## Participant Info

* GitHub username: Mohammed-danyal
* Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Screen Recording

https://github.com/user-attachments/assets/c5a30710-551f-46ea-bad7-b0c3482d7aa2




## Checklist

* [x] I have read the contribution guidelines
* [x] My changes follow the project structure
* [x] I have tested my changes in Chrome, Firefox, and Safari
* [x] `bun run lint` passes (no ESLint errors)
* [x] `bunx tsc --noEmit` passes (no TypeScript errors)
* [x] New interactive elements have `aria-label` / accessible names
* [x] No `console.log` statements left in
* [x] This PR is related to a valid issue
* [x] **Screen recording attached above** (required for UI/feature/design changes)
