### PR TITLE
fix: allow external contributors to trigger automated PR review workflows

### DIFF
--- a/.github/workflows/claude-manager.yml
+++ b/.github/workflows/claude-manager.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: "*"
           trigger_phrase: ""
           direct_prompt: |
             You are the automated manager for magic-peach/reframe, a GSSoC'26 open-source project.
@@ -70,6 +71,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: "*"
           trigger_phrase: ""
           direct_prompt: |
             You are the automated manager for magic-peach/reframe, a GSSoC'26 open-source project.
@@ -118,6 +120,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: "*"
           trigger_phrase: ""
           direct_prompt: |
             You are the automated manager for magic-peach/reframe, a GSSoC'26 open-source project.


### PR DESCRIPTION
### Description
This pull request enables non-write contributors to trigger automated repository manager actions on pull requests, issues, and issue comments.

### Key Changes
1. Added `allowed_non_write_users: "*"` to the action steps in `.github/workflows/claude-manager.yml` to allow non-collaborators to trigger automated checks.
