### PR TITLE
perf: Optimise FFmpeg args and show elapsed export time (#694)

### DIFF
--- a/src/components/DownloadResult.tsx
+++ b/src/components/DownloadResult.tsx
@@ -12,6 +12,16 @@ import { cn } from "@/lib/utils";
 const SHARE_TWEET_TEXT =
   "I just edited my video with @reframevideo — free browser-based video editor! Check it out: https://github.com/magic-peach/reframe";
 
+function formatExportDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  if (minutes === 0) return `${seconds} sec`;
+  if (seconds === 0) return `${minutes} min`;
+  return `${minutes} min ${seconds} sec`;
+}
+
 interface Props {
   result: ExportResult;
   onReset: () => void;
@@ -73,6 +83,12 @@ export default function DownloadResult({ result, onReset, soundOnCompletion, onT
           <p className="text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)] mb-1">File size</p>
           <p className="font-heading font-bold text-[var(--text)]">{formatBytes(result.size)}</p>
         </div>
+        {typeof result.exportDurationMs === "number" && (
+          <div className="col-span-2 bg-[var(--bg)] rounded-lg p-3 border border-[var(--border)]">
+            <p className="text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)] mb-1">Export time</p>
+            <p className="font-heading font-bold text-[var(--text)]">Exported in {formatExportDuration(result.exportDurationMs)}</p>
+          </div>
+        )}
       </div>
 
       <div className="space-y-1.5 pt-2">

--- a/src/components/ExportOverlay.tsx
+++ b/src/components/ExportOverlay.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import FocusTrap from "focus-trap-react";
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useRef, useCallback, useState } from "react";
 import { ExportStatus } from "@/lib/types";
 import LottiePlayer from "./LottiePlayer";
 import spinnerAnim from "@/lib/lottie/spinner.json";
@@ -10,13 +10,22 @@ import TipCarousel from "./TipCarousel";
 interface Props {
   status: ExportStatus;
   progress: number;
+  exportStartedAt?: number | null;
   onCancel?: () => void;
 }
 
-export default function ExportOverlay({ status, progress, onCancel }: Props) {
+function formatElapsed(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+export default function ExportOverlay({ status, progress, exportStartedAt, onCancel }: Props) {
   const visible = status === "loading-engine" || status === "exporting";
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const focusAnchorRef = useRef<HTMLDivElement | null>(null);
+  const [elapsedMs, setElapsedMs] = useState(0);
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key === "Escape") {
@@ -49,6 +58,21 @@ export default function ExportOverlay({ status, progress, onCancel }: Props) {
       previousFocusRef.current.focus();
     }
   }, [visible]);
+
+  useEffect(() => {
+    if (status !== "exporting" || !exportStartedAt) {
+      setElapsedMs(0);
+      return;
+    }
+
+    const updateElapsed = () => {
+      setElapsedMs(Date.now() - exportStartedAt);
+    };
+
+    updateElapsed();
+    const timer = window.setInterval(updateElapsed, 1000);
+    return () => window.clearInterval(timer);
+  }, [status, exportStartedAt]);
 
   if (!visible) return null;
 
@@ -104,7 +128,7 @@ export default function ExportOverlay({ status, progress, onCancel }: Props) {
           <span className="sr-only">
             {status === "loading-engine"
               ? `Loading video engine: ${progress}%`
-              : `Exporting: ${progress}%`}
+              : `Exporting: ${progress}%, ${formatElapsed(elapsedMs)} elapsed`}
           </span>
             <div className="w-full space-y-2">
               <div className="h-1 w-full bg-film-100 rounded-full overflow-hidden">
@@ -118,9 +142,12 @@ export default function ExportOverlay({ status, progress, onCancel }: Props) {
                   style={{ width: `${progress}%` }}
                 />
               </div>
-              <p className="text-xs font-heading font-semibold text-[var(--muted)]">
-                {progress}%
-              </p>
+              <div className="flex items-center justify-between gap-4 text-xs font-heading font-semibold text-[var(--muted)]">
+                <span>{progress}%</span>
+                {!isLoading && (
+                  <span>{formatElapsed(elapsedMs)} elapsed</span>
+                )}
+              </div>
               <TipCarousel />
               {!isLoading && (
               <div className="flex flex-col items-center gap-3 mt-4">

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -208,7 +208,7 @@ function KeyboardShortcutsPanel() {
 export default function VideoEditor() {
   const {
     file, duration, recipe, status, progress,
-    result, error, updateRecipe,
+    result, error, exportStartedAt, updateRecipe,
     handleFileSelect, fileError, handleExport, cancelExport, reset, resetSettings,
     videoRef,
     seekTo,
@@ -292,7 +292,12 @@ export default function VideoEditor() {
 
   return (
     <div className="min-h-screen relative flex flex-col" style={{ background: "var(--bg)" }}>
-      <ExportOverlay status={status} progress={progress} onCancel={cancelExport} />
+      <ExportOverlay
+        status={status}
+        progress={progress}
+        exportStartedAt={exportStartedAt}
+        onCancel={cancelExport}
+      />
       <OnboardingTour />
 
       <div aria-live="polite" aria-atomic="true" className="sr-only">

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -137,6 +137,7 @@ export function useVideoEditor() {
   const [result, setResult] = useState<ExportResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [fileError, setFileError] = useState("");
+  const [exportStartedAt, setExportStartedAt] = useState<number | null>(null);
   const exportAbortControllerRef = useRef<AbortController | null>(null);
   const exportCancelledRef = useRef(false);
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -430,12 +431,15 @@ export function useVideoEditor() {
       setStatus("loading-engine");
       setProgress(0);
       setError(null);
+      setExportStartedAt(null);
       if (result?.blobUrl) URL.revokeObjectURL(result.blobUrl);
       setResult(null);
 
       const ffmpeg = await loadFFmpeg(abortController.signal);
       if (exportCancelledRef.current) return;
 
+      const startedAt = Date.now();
+      setExportStartedAt(startedAt);
       setStatus("exporting");
 
       const exportResult = await exportVideo(
@@ -459,7 +463,10 @@ export function useVideoEditor() {
       );
       if (exportCancelledRef.current) return;
 
-      setResult(exportResult);
+      setResult({
+        ...exportResult,
+        exportDurationMs: Date.now() - startedAt,
+      });
       setStatus("done");
      }  catch (err) {
       if (exportCancelledRef.current) return;
@@ -474,6 +481,7 @@ export function useVideoEditor() {
       } else {
         setError('Export failed. Please try again or use a different video.');
       }
+      setExportStartedAt(null);
       setStatus("error");
     }
     finally {
@@ -592,6 +600,7 @@ export function useVideoEditor() {
     setStatus("idle");
     setProgress(0);
     setError(null);
+    setExportStartedAt(null);
   }, []);
 
 
@@ -605,6 +614,7 @@ export function useVideoEditor() {
     setProgress(0);
     setResult(null);
     setError(null);
+    setExportStartedAt(null);
     try {
       localStorage.removeItem(STORAGE_KEY);
     } catch {
@@ -639,6 +649,7 @@ export function useVideoEditor() {
     recipe,
     status,
     progress,
+    exportStartedAt,
     result,
     error,
     videoRef,

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -133,17 +133,24 @@ export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: n
   }
 
   if (recipe.speed !== 1) {
-  const pts = (1 / recipe.speed).toFixed(4);
-  filters.push(`setpts=${pts}*PTS`);
+    const pts = (1 / recipe.speed).toFixed(4);
+    filters.push(`setpts=${pts}*PTS`);
   }
 
   if (recipe.denoise) {
     filters.push("hqdn3d=1.5:1.5:6:6");
   }
 
-  filters.push(
-    `eq=brightness=${recipe.brightness}:contrast=${recipe.contrast}:saturation=${recipe.saturation}`
-  );
+  const needsEq =
+    recipe.brightness !== 0 ||
+    recipe.contrast !== 1 ||
+    recipe.saturation !== 1;
+
+  if (needsEq) {
+    filters.push(
+      `eq=brightness=${recipe.brightness}:contrast=${recipe.contrast}:saturation=${recipe.saturation}`
+    );
+  }
 
   // Add text overlays
   const textOverlays = recipe.textOverlays || [];
@@ -154,7 +161,7 @@ export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: n
   return filters.join(",");
 }
 
- export function buildAudioFilter(speed: number, normalizeAudio: boolean): string {
+export function buildAudioFilter(speed: number, normalizeAudio: boolean): string {
   if (speed <= 0) return "";
   const filters: string[] = [];
 
@@ -169,7 +176,7 @@ export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: n
     remaining /= 2.0;
   }
 
- if (Math.abs(remaining - 1.0) > 0.001) {
+  if (Math.abs(remaining - 1.0) > 0.001) {
     filters.push(`atempo=${Number(remaining.toFixed(4))}`);
   }
 
@@ -290,13 +297,19 @@ function buildArguments(
   }
 
   if (format === "webm") {
-    args.push("-c:v", "libvpx-vp9", "-b:v", "0", "-crf", String(recipe.quality));
+    args.push(
+      "-c:v", "libvpx-vp9",
+      "-b:v", "0",
+      "-crf", String(recipe.quality),
+      "-cpu-used", "4",
+      "-deadline", "realtime"
+    );
     if (shouldKeepAudio) args.push("-c:a", "libopus");
   } else if (format === "mkv") {
-    args.push("-c:v", "libx264", "-crf", String(recipe.quality), "-preset", "medium");
+    args.push("-c:v", "libx264", "-crf", String(recipe.quality), "-preset", "ultrafast");
     if (shouldKeepAudio) args.push("-c:a", "aac", "-b:a", "128k");
   } else {
-    args.push("-c:v", "libx264", "-crf", String(recipe.quality), "-preset", "medium", "-movflags", "+faststart");
+    args.push("-c:v", "libx264", "-crf", String(recipe.quality), "-preset", "ultrafast", "-movflags", "+faststart");
     if (shouldKeepAudio) args.push("-c:a", "aac", "-b:a", "128k");
   }
 
@@ -356,12 +369,6 @@ export async function exportVideo(
   try {
     await ffmpeg.writeFile(inputName, await fetchFile(file), { signal });
 
-    const vf = buildVideoFilter(recipe, targetW, targetH);
-  const audioTrim = buildAudioTrimFilter(recipe);
-  const audioSpeed = buildAudioFilter(recipe.speed, recipe.normalizeAudio ?? false);
-
-  const afParts = [audioTrim, audioSpeed].filter(Boolean);
-  const af = afParts.join(",");
     const hasMusicTrack = !!(musicOptions?.file && recipe.keepAudio);
     const musicInputName = `music_input_${sessionId}.mp3`;
     if (hasMusicTrack) {

--- a/src/lib/tests/videoFilter.test.ts
+++ b/src/lib/tests/videoFilter.test.ts
@@ -79,6 +79,11 @@ describe("buildVideoFilter", () => {
     expect(result).toContain("eq=brightness=0.5:contrast=1.2:saturation=1.5");
   });
 
+  it("should skip eq filter when adjustments are neutral", () => {
+    const result = buildVideoFilter(base({ brightness: 0, contrast: 1, saturation: 1 }), 1280, 720);
+    expect(result).not.toContain("eq=");
+  });
+
   it("should handle trim + speed + rotate all at once", () => {
     const result = buildVideoFilter(base({ trimStart: 2, trimEnd: 8, speed: 2, rotate: 90 }), 1280, 720);
     expect(result).toContain("trim=start=2:end=8");

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -63,6 +63,7 @@ export interface ExportResult {
   width: number;
   height: number;
   format: "mp4" | "webm" | "mkv" | "gif";
+  exportDurationMs?: number;
 }
 
 export type ExportStatus =

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,11 @@
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  oxc: {
+    jsx: {
+      runtime: 'automatic',
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,2 +1,16 @@
 // Vitest setup: polyfills and global mocks
 import '@testing-library/jest-dom/vitest'
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+})


### PR DESCRIPTION

## New Reframe - (30 sec clip showing , relatively fast export)
https://github.com/user-attachments/assets/88063841-1b1c-4b36-b944-5def182ce0c5

## Old Reframe - (30 sec clip showing , slow export) 
https://github.com/user-attachments/assets/132b87a1-7b2c-47b7-83f1-ac8d8cb49496

## Summary
Resolves #694

Optimises FFmpeg export settings so browser-based exports complete much faster, and adds visible elapsed export timing during and after export.

## Changes Made
- Switched x264 MP4/MKV exports from `-preset medium` to `-preset ultrafast`
- Added VP9 speed flags: `-cpu-used 4 -deadline realtime`
- Skipped the FFmpeg `eq` filter when brightness/contrast/saturation are neutral
- Preserved neutral defaults: brightness `0`, contrast `1`, saturation `1`
- Added live elapsed time in the export overlay, e.g. `0:42 elapsed`
- Added total export duration to the download result card, e.g. `Exported in 1 min 23 sec`
- Added export duration tracking through `useVideoEditor`
- Added a regression test proving neutral adjustments skip `eq`
- Added the minimal Vitest JSX/matchMedia setup needed for the current test suite to run cleanly

## COOP/COEP
`vercel.json` already contains:
- `Cross-Origin-Opener-Policy: same-origin`
- `Cross-Origin-Embedder-Policy: require-corp`

No hosting-header changes were needed in this PR.

## Testing
- `bun run lint` ✅
- `bunx tsc --noEmit` ✅
- `bun run test -- --run` ✅
- `bun run build` ✅

Note: `bun run lint` and `bun run build` still print the existing `ThumbnailStrip.tsx` hook warning from `main`, but both commands exit successfully. The build required elevated filesystem access locally because Next.js hit Windows sandbox `readlink` permissions.

## Screen Recordings
Required before merge:
- Before recording: export the same 1–2 minute video on current `main`
- After recording: export the same video on this branch and show the elapsed timer + faster completion