### PR TITLE
fix: add autoComplete=off to trim start and end inputs (#74)

### DIFF
--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -247,6 +247,7 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
           <input
             id="trim-start"
             type="number"
+            autoComplete="off"
             min={0}
             max={duration > 0 ? duration : undefined}
             step={0.1}
@@ -281,6 +282,7 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
           <input
             id="trim-end"
             type="number"
+            autoComplete="off"
             min={0}
             max={duration > 0 ? duration : undefined}
             step={0.1}


### PR DESCRIPTION
## Description
This pull request adds the `autoComplete="off"` attribute to the trim start and trim end inputs in `TrimControl.tsx`. Autocomplete suggestions on these fields can be distracting or intrusive, as these numeric values are video-specific and vary every time.

Note: The custom width and height inputs in `PresetSelector.tsx` already correctly had `autoComplete="off"` implemented.

## Related Issue
Closes #74

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] GSSoC contribution

## Participant Info
- GitHub username: @Rucha0901
- Contribution level (Beginner/Intermediate/Advanced): Beginner

## Screen Recording
*(Please attach a screen recording showing that the trim start/end fields no longer display autocomplete suggestions when clicked)*

**Recording / Loom link:**

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [ ] **Screen recording attached above** (required for UI/feature/design changes)