### PR TITLE
fix: make right panel sticky while scrolling through adjustments

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -601,7 +601,7 @@ export default function VideoEditor() {
           </div>
 
           <div className={cn(
-            "space-y-5 transition-opacity duration-300",
+            "space-y-5 transition-opacity duration-300 sticky top-8 self-start",
             (isProcessing || !file) && "pointer-events-none opacity-50"
           )}>
             {!file && (


### PR DESCRIPTION
## Description
Made the right sidebar panel (Output Size, Resize & Aspect Ratio, Export button) sticky while scrolling through the left panel adjustments. Added `sticky top-8 self-start` to the right column div in VideoEditor.tsx.
This keeps the export settings visible without needing to scroll back up.
## Related Issue
Closes #1043
## Type of Contribution
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: Sai-Ramya-prog
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Screen Recording
**Recording / Loom link:**
>https://www.loom.com/share/f2e95312bf1e48e3b2032d4e9d731e21

 ## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)