### PR TITLE
feat: optimize thumbnail generation interval dynamically based on video duration

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -279,6 +279,13 @@ export default function VideoEditor() {
   const isProcessing = status === "loading-engine" || status === "exporting";
   const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
 
+  const intervalSeconds = useMemo(() => {
+    if (duration <= 30) return 2;
+    if (duration <= 120) return 5;
+    if (duration <= 300) return 15;
+    return 30;
+  }, [duration]);
+
   const videoSrc = useMemo(
     () => (file ? URL.createObjectURL(file) : null),
     [file]
@@ -375,6 +382,7 @@ export default function VideoEditor() {
                       trimStart={recipe.trimStart ?? 0}
                       trimEnd={recipe.trimEnd ?? duration}
                       onSeek={seekTo}
+                      intervalSeconds={intervalSeconds}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
## Description

This PR resolves the performance bottleneck and sparseness issues associated with the fixed 5-second thumbnail generation interval in the timeline.

Instead of hardcoding a 5-second interval, `intervalSeconds` is now calculated dynamically in `VideoEditor.tsx` based on the loaded video's duration and passed to `<ThumbnailStrip />`:
- **Duration <= 30 seconds:** every 2 seconds (enables precise trimming for short clips).
- **30s < Duration <= 120s (2m):** every 5 seconds.
- **120s < Duration <= 300s (5m):** every 15 seconds.
- **Duration > 300s (5m):** every 30 seconds (avoids rendering 100+ thumbnails, saving significant browser memory and preventing UI freezes).

## Related Issue

Closes #1054 

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

:** ## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [ ] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [ ] **Screen recording attached above** (required for UI/feature/design changes)