### PR TITLE
feat: add audio-only export option (MP3/AAC)

### DIFF
--- a/src/components/FormatSelector.tsx
+++ b/src/components/FormatSelector.tsx
@@ -14,6 +14,8 @@ const FORMAT_OPTIONS = [
   { id: "webm", label: "WebM", description: "Open format, optimized for web" },
   { id: "mkv", label: "MKV", description: "Container, maximum quality" },
   { id: "gif", label: "GIF", description: "Animated image — keep clips under 10 s" },
+  { id: "mp3", label: "MP3", description: "Audio only, widely supported" },
+  { id: "aac", label: "AAC", description: "Audio only, high efficiency" },
 ] as const;
 
 export default function FormatSelector({ recipe, onChange }: Props) {
@@ -30,7 +32,7 @@ export default function FormatSelector({ recipe, onChange }: Props) {
           <button
             key={option.id}
             type="button"
-            onClick={() => onChange({ format: option.id as "mp4" | "webm" | "mkv" | "gif" })}
+            onClick={() => onChange({ format: option.id as EditRecipe['format'] })}
             aria-label={`Select ${option.label} format`}
             aria-pressed={recipe.format === option.id}
             className={cn(

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -281,6 +281,8 @@ export default function VideoEditor() {
     return 30;
   }, [duration]);
 
+  const isAudioOnly = recipe.format === "mp3" || recipe.format === "aac";
+
   const videoSrc = useMemo(
     () => (file ? URL.createObjectURL(file) : null),
     [file]
@@ -432,32 +434,36 @@ export default function VideoEditor() {
                     />
                   </AccordionSection>
 
-                  <AccordionSection
-                    id="rotation"
-                    icon={<RotateCw size={12} />}
-                    title="Rotation"
-                    isOpen={openSections.rotation}
-                    onToggle={() => toggleSection("rotation")}
-                    delay={100}
-                  >
-                    <RotateControl recipe={recipe} onChange={updateRecipe} />
-                  </AccordionSection>
+                  {!isAudioOnly && (
+                    <>
+                      <AccordionSection
+                        id="rotation"
+                        icon={<RotateCw size={12} />}
+                        title="Rotation"
+                        isOpen={openSections.rotation}
+                        onToggle={() => toggleSection("rotation")}
+                        delay={100}
+                      >
+                        <RotateControl recipe={recipe} onChange={updateRecipe} />
+                      </AccordionSection>
 
-                  <AccordionSection
-                    id="text"
-                    icon={<Type size={12} />}
-                    title="Text Overlay"
-                    isOpen={openSections.text}
-                    onToggle={() => toggleSection("text")}
-                    delay={110}
-                  >
-                    <TextControls
-                      recipe={recipe}
-                      onChange={updateRecipe}
-                      selectedTextId={selectedTextId}
-                      onSelectText={setSelectedTextId}
-                    />
-                  </AccordionSection>
+                      <AccordionSection
+                        id="text"
+                        icon={<Type size={12} />}
+                        title="Text Overlay"
+                        isOpen={openSections.text}
+                        onToggle={() => toggleSection("text")}
+                        delay={110}
+                      >
+                        <TextControls
+                          recipe={recipe}
+                          onChange={updateRecipe}
+                          selectedTextId={selectedTextId}
+                          onSelectText={setSelectedTextId}
+                        />
+                      </AccordionSection>
+                    </>
+                  )}
                 </div>
                 <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6">
                   <AccordionSection
@@ -470,114 +476,120 @@ export default function VideoEditor() {
                   >
                     <AudioSpeedControl recipe={recipe} onChange={updateRecipe} />
                   </AccordionSection>
-                  <Section
-                    icon={<SlidersHorizontal size={12} />}
-                    title="Adjustments"
-                    delay={175}
-                  >
-                    <div className="space-y-5">
-                      {/* Brightness */}
-                      <div className="space-y-2">
-                        <div className="flex items-center justify-between text-xs">
-                          <label htmlFor="brightness-slider">Brightness</label>
-                          <button
-                            type="button"
-                            onClick={() => updateRecipe({ brightness: 0 })}
-                            className="text-film-500 hover:underline"
-                            aria-label="reset brightness"
-                          >
-                            Reset
-                          </button>
+                  {!isAudioOnly && (
+                    <Section
+                      icon={<SlidersHorizontal size={12} />}
+                      title="Adjustments"
+                      delay={175}
+                    >
+                      <div className="space-y-5">
+                        {/* Brightness */}
+                        <div className="space-y-2">
+                          <div className="flex items-center justify-between text-xs">
+                            <label htmlFor="brightness-slider">Brightness</label>
+                            <button
+                              type="button"
+                              onClick={() => updateRecipe({ brightness: 0 })}
+                              className="text-film-500 hover:underline"
+                              aria-label="reset brightness"
+                            >
+                              Reset
+                            </button>
+                          </div>
+                          <input
+                            id="brightness-slider"
+                            type="range"
+                            min="-1"
+                            max="1"
+                            step="0.1"
+                            value={recipe.brightness}
+                            onChange={(e) => updateRecipe({ brightness: Number(e.target.value) })}
+                            aria-label="Adjust brightness"
+                            className="w-full accent-film-600"
+                          />
                         </div>
-                        <input
-                          id="brightness-slider"
-                          type="range"
-                          min="-1"
-                          max="1"
-                          step="0.1"
-                          value={recipe.brightness}
-                          onChange={(e) => updateRecipe({ brightness: Number(e.target.value) })}
-                          aria-label="Adjust brightness"
-                          className="w-full accent-film-600"
-                        />
-                      </div>
-                      {/* Contrast */}
-                      <div className="space-y-2">
-                        <div className="flex items-center justify-between text-xs">
-                          <label htmlFor="contrast-slider">Contrast</label>
-                          <button
-                            type="button"
-                            onClick={() => updateRecipe({ contrast: 1 })}
-                            className="text-film-500 hover:underline"
-                            aria-label="reset-contrast"
-                          >
-                            Reset
-                          </button>
+                        {/* Contrast */}
+                        <div className="space-y-2">
+                          <div className="flex items-center justify-between text-xs">
+                            <label htmlFor="contrast-slider">Contrast</label>
+                            <button
+                              type="button"
+                              onClick={() => updateRecipe({ contrast: 1 })}
+                              className="text-film-500 hover:underline"
+                              aria-label="reset-contrast"
+                            >
+                              Reset
+                            </button>
+                          </div>
+                          <input
+                            id="contrast-slider"
+                            type="range"
+                            min="0"
+                            max="2"
+                            step="0.1"
+                            value={recipe.contrast}
+                            onChange={(e) => updateRecipe({ contrast: Number(e.target.value) })}
+                            aria-label="Adjust contrast"
+                            className="w-full accent-film-600"
+                          />
                         </div>
-                        <input
-                          id="contrast-slider"
-                          type="range"
-                          min="0"
-                          max="2"
-                          step="0.1"
-                          value={recipe.contrast}
-                          onChange={(e) => updateRecipe({ contrast: Number(e.target.value) })}
-                          aria-label="Adjust contrast"
-                          className="w-full accent-film-600"
-                        />
-                      </div>
-                      {/* Saturation */}
-                      <div className="space-y-2">
-                        <div className="flex items-center justify-between text-xs">
-                          <label htmlFor="saturation-slider">Saturation</label>
-                          <button
-                            type="button"
-                            onClick={() => updateRecipe({ saturation: 1 })}
-                            className="text-film-500 hover:underline"
-                            aria-label="reset-saturation"
-                          >
-                            Reset
-                          </button>
+                        {/* Saturation */}
+                        <div className="space-y-2">
+                          <div className="flex items-center justify-between text-xs">
+                            <label htmlFor="saturation-slider">Saturation</label>
+                            <button
+                              type="button"
+                              onClick={() => updateRecipe({ saturation: 1 })}
+                              className="text-film-500 hover:underline"
+                              aria-label="reset-saturation"
+                            >
+                              Reset
+                            </button>
+                          </div>
+                          <input
+                            id="saturation-slider"
+                            type="range"
+                            min="0"
+                            max="3"
+                            step="0.1"
+                            value={recipe.saturation}
+                            onChange={(e) => updateRecipe({ saturation: Number(e.target.value) })}
+                            aria-label="Adjust saturation"
+                            className="w-full accent-film-600"
+                          />
                         </div>
-                        <input
-                          id="saturation-slider"
-                          type="range"
-                          min="0"
-                          max="3"
-                          step="0.1"
-                          value={recipe.saturation}
-                          onChange={(e) => updateRecipe({ saturation: Number(e.target.value) })}
-                          aria-label="Adjust saturation"
-                          className="w-full accent-film-600"
-                        />
                       </div>
-                    </div>
-                  </Section>
+                    </Section>
+                  )}
                   <Section icon={<SlidersHorizontal size={12} />} title="Output format" delay={190}>
                     <FormatSelector recipe={recipe} onChange={updateRecipe} />
                   </Section>
-                  <AccordionSection
-                    id="export"
-                    icon={<SlidersHorizontal size={12} />}
-                    title="Export"
-                    isOpen={openSections.export}
-                    onToggle={() => toggleSection("export")}
-                    delay={200}
-                  >
-                    <ExportSettings recipe={recipe} duration={duration} onChange={updateRecipe} />
-                  </AccordionSection>
-                  <Section icon={<Layers size={12} />} title="Image overlay" delay={120}>
-                    <ImageOverlay
-                      overlayFile={overlayFile}
-                      setOverlayFile={setOverlayFile}
-                      overlayPosition={overlayPosition}
-                      setOverlayPosition={setOverlayPosition}
-                      overlaySize={overlaySize}
-                      setOverlaySize={setOverlaySize}
-                      overlayOpacity={overlayOpacity}
-                      setOverlayOpacity={setOverlayOpacity}
-                    />
-                  </Section>
+                  {!isAudioOnly && (
+                    <>
+                      <AccordionSection
+                        id="export"
+                        icon={<SlidersHorizontal size={12} />}
+                        title="Export"
+                        isOpen={openSections.export}
+                        onToggle={() => toggleSection("export")}
+                        delay={200}
+                      >
+                        <ExportSettings recipe={recipe} duration={duration} onChange={updateRecipe} />
+                      </AccordionSection>
+                      <Section icon={<Layers size={12} />} title="Image overlay" delay={120}>
+                        <ImageOverlay
+                          overlayFile={overlayFile}
+                          setOverlayFile={setOverlayFile}
+                          overlayPosition={overlayPosition}
+                          setOverlayPosition={setOverlayPosition}
+                          overlaySize={overlaySize}
+                          setOverlaySize={setOverlaySize}
+                          overlayOpacity={overlayOpacity}
+                          setOverlayOpacity={setOverlayOpacity}
+                        />
+                      </Section>
+                    </>
+                  )}
                 </div>
               </div>
             )}
@@ -639,26 +651,28 @@ export default function VideoEditor() {
               </div>
             )}
             <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6 animate-fade-in" style={{ animationDelay: "50ms" }}>
-              <AccordionSection
-                id="resize"
-                icon={<Layers size={12} />}
-                title="Resize & Aspect Ratio"
-                isOpen={openSections.resize}
-                onToggle={() => toggleSection("resize")}
-                delay={50}
-              >
-                {recommendedPreset && (
-                  <div className="mb-4 rounded-2xl border border-film-200 bg-film-50 p-3 text-sm text-film-700">
-                    <p>
-                      We detected a {recommendedPreset.label.replace(/\s/g, "")} video → Recommended: {(recommendedPreset.platform.split("·")[0] ?? "").trim()} ({recommendedPreset.label.replace(/\s/g, "")})
-                    </p>
+              {!isAudioOnly && (
+                <AccordionSection
+                  id="resize"
+                  icon={<Layers size={12} />}
+                  title="Resize & Aspect Ratio"
+                  isOpen={openSections.resize}
+                  onToggle={() => toggleSection("resize")}
+                  delay={50}
+                >
+                  {recommendedPreset && (
+                    <div className="mb-4 rounded-2xl border border-film-200 bg-film-50 p-3 text-sm text-film-700">
+                      <p>
+                        We detected a {recommendedPreset.label.replace(/\s/g, "")} video → Recommended: {(recommendedPreset.platform.split("·")[0] ?? "").trim()} ({recommendedPreset.label.replace(/\s/g, "")})
+                      </p>
+                    </div>
+                  )}
+                  <div className="space-y-3">
+                    <PresetSelector recipe={recipe} onChange={updateRecipe} />
+                    <FramingControl recipe={recipe} onChange={updateRecipe} />
                   </div>
-                )}
-                <div className="space-y-3">
-                  <PresetSelector recipe={recipe} onChange={updateRecipe} />
-                  <FramingControl recipe={recipe} onChange={updateRecipe} />
-                </div>
-              </AccordionSection>
+                </AccordionSection>
+              )}
 
               <div className="pt-2 flex justify-center items-center gap-6">
                 <button

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -165,7 +165,7 @@ export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: n
   return filters.join(",");
 }
 
-export function buildAudioFilter(speed: number, normalizeAudio: boolean): string {
+export function buildAudioFilter(speed: number, normalizeAudio: boolean = false): string {
   if (speed <= 0) return "";
   const filters: string[] = [];
 
@@ -197,7 +197,7 @@ function buildAudioTrimFilter(recipe: EditRecipe): string {
 
 function buildArguments(
   recipe: EditRecipe,
-  format: "mp4" | "webm" | "mkv" | "gif",
+  format: EditRecipe["format"],
   outputName: string,
   inputName: string,
   targetW: number,
@@ -211,7 +211,8 @@ function buildArguments(
   hasOriginalAudio: boolean,
   videoDuration: number
 ): string[] {
-  const vf = buildVideoFilter(recipe, targetW, targetH);
+  const isAudioOnly = format === "mp3" || format === "aac";
+  const vf = isAudioOnly ? "" : buildVideoFilter(recipe, targetW, targetH);
   const audioTrim = hasOriginalAudio ? buildAudioTrimFilter(recipe) : "";
   const audioSpeed = hasOriginalAudio ? buildAudioFilter(recipe.speed, recipe.normalizeAudio ?? false) : "";
   const afParts = [audioTrim, audioSpeed].filter(Boolean);
@@ -226,23 +227,23 @@ function buildArguments(
     if (musicOptions!.loopMusic) args.push("-stream_loop", "-1");
     args.push("-i", musicInputName);
   }
-  if (hasOverlay) {
+  if (hasOverlay && !isAudioOnly) {
     args.push("-i", overlayInputName);
   }
 
-  const needsFilterComplex = hasOverlay || hasMusicTrack;
+  const needsFilterComplex = (hasOverlay && !isAudioOnly) || hasMusicTrack;
   const shouldKeepAudio = recipe.keepAudio && (hasOriginalAudio || hasMusicTrack);
 
   if (needsFilterComplex) {
     const filterParts: string[] = [];
     let videoOut = "[0:v]";
 
-    if (vf) {
+    if (vf && !isAudioOnly) {
       filterParts.push(`[0:v]${vf}[vbase]`);
       videoOut = "[vbase]";
     }
 
-    if (hasOverlay) {
+    if (hasOverlay && !isAudioOnly) {
       const scaledW = overlayOptions!.size;
       const alpha = (overlayOptions!.opacity / 100).toFixed(2);
       const posMap: Record<string, string> = {
@@ -283,7 +284,10 @@ function buildArguments(
     if (filterParts.length > 0) {
       args.push("-filter_complex", filterParts.join(";"));
     }
-    args.push("-map", videoOut === "[0:v]" ? "0:v" : videoOut);
+    
+    if (!isAudioOnly) {
+      args.push("-map", videoOut === "[0:v]" ? "0:v" : videoOut);
+    }
 
     if (!shouldKeepAudio) {
       args.push("-an");
@@ -293,7 +297,7 @@ function buildArguments(
       args.push("-map", "0:a");
     }
   } else {
-    if (vf) args.push("-vf", vf);
+    if (vf && !isAudioOnly) args.push("-vf", vf);
     if (!shouldKeepAudio) {
       args.push("-an");
     } else if (af && hasOriginalAudio) {
@@ -301,7 +305,11 @@ function buildArguments(
     }
   }
 
-  if (format === "webm") {
+  if (format === "mp3") {
+    args.push("-vn", "-c:a", "libmp3lame");
+  } else if (format === "aac") {
+    args.push("-vn", "-c:a", "aac", "-b:a", "128k");
+  } else if (format === "webm") {
     args.push(
       "-c:v", "libvpx-vp9",
       "-b:v", "0",
@@ -364,6 +372,10 @@ export async function exportVideo(
         return { filename: `output_${sessionId}.mkv`, mimeType: "video/x-matroska" };
       case "gif":
         return { filename: `output_${sessionId}.gif`, mimeType: "image/gif" };
+      case "mp3":
+        return { filename: `output_${sessionId}.mp3`, mimeType: "audio/mpeg" };
+      case "aac":
+        return { filename: `output_${sessionId}.aac`, mimeType: "audio/aac" };
       default:
         return { filename: `output_${sessionId}.mp4`, mimeType: "video/mp4" };
     }
@@ -399,6 +411,14 @@ export async function exportVideo(
   try {
     await ffmpeg.writeFile(inputName, await fetchFile(file), { signal });
 
+    const isAudioOnly = recipe.format === "mp3" || recipe.format === "aac";
+
+    const vf = isAudioOnly ? "" : buildVideoFilter(recipe, targetW, targetH);
+    const audioTrim = buildAudioTrimFilter(recipe);
+    const audioSpeed = buildAudioFilter(recipe.speed, recipe.normalizeAudio ?? false);
+
+    const afParts = [audioTrim, audioSpeed].filter(Boolean);
+    const af = afParts.join(",");
     const hasMusicTrack = !!(musicOptions?.file && recipe.keepAudio);
     const musicInputName = `music_input_${sessionId}.mp3`;
     if (hasMusicTrack) {
@@ -406,7 +426,7 @@ export async function exportVideo(
       cleanupFiles.add(musicInputName);
     }
 
-    const hasOverlay = !!overlayOptions?.file;
+    const hasOverlay = !!(overlayOptions?.file && !isAudioOnly);
     const overlayExt = overlayOptions?.file?.name.split(".").pop() ?? "png";
     const overlayInputName = `overlay_${sessionId}.${overlayExt}`;
     if (hasOverlay) {
@@ -492,7 +512,7 @@ export async function exportVideo(
     let exitCode = await ffmpeg.exec(args, undefined, { signal });
 
     // Attempt 2: Auto-recover if the file has no original audio track
-    if (exitCode !== 0 && missingAudioDetected) {
+    if (exitCode !== 0 && missingAudioDetected && !isAudioOnly) {
       missingAudioDetected = false;
       args = buildArguments(
         recipe, recipe.format, outputName, inputName, targetW, targetH,
@@ -504,6 +524,9 @@ export async function exportVideo(
 
     // Fallback Attempt 3: Switch codecs to WebM if container errors happen
     if (exitCode !== 0) {
+      if (isAudioOnly) {
+        throw new Error("Export failed");
+      }
       args = buildArguments(
         recipe, "webm", fallbackOutputName, inputName, targetW, targetH,
         hasMusicTrack, musicInputName, musicOptions,
@@ -539,7 +562,7 @@ export async function exportVideo(
       size: blob.size,
       width: targetW,
       height: targetH,
-      format: recipe.format as "mp4" | "webm" | "mkv",
+      format: recipe.format as EditRecipe["format"],
     };
   } finally {
     ffmpeg.off("progress", handleProgress);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -25,7 +25,7 @@ export interface EditRecipe {
   normalizeAudio: boolean;
   speed: number;
   quality: number;
-  format: "mp4" | "webm" | "mkv" | "gif";
+  format: "mp4" | "webm" | "mkv" | "gif" | "mp3" | "aac";
   stabilization: boolean;
   denoise: boolean;
   brightness: number;
@@ -62,7 +62,7 @@ export interface ExportResult {
   size: number;
   width: number;
   height: number;
-  format: "mp4" | "webm" | "mkv" | "gif";
+  format: "mp4" | "webm" | "mkv" | "gif" | "mp3" | "aac";
   exportDurationMs?: number;
 }
 


### PR DESCRIPTION
## Description
This PR adds functionality to extract the audio track directly from an uploaded video using the `ffmpeg` WASM engine. 

- Extended `EditRecipe` and `ExportResult` types to support `mp3` and `aac`, adding them to the UI Format Selector.
- Refactored `VideoEditor` to dynamically hide video-specific UI panels (Rotate, Adjustments, Framing, Output Size) when an audio format is chosen for a cleaner UX.
- Configured the export engine to skip the video stream (`-vn`) and mapped appropriate audio codecs (`libmp3lame` and `aac`).
- Patched a legacy CDN loading bug in `ffmpeg.ts` where the WebAssembly SIMD check attempted to fetch a deprecated `@ffmpeg/core-simd` binary instead of the standard core.

## Related Issue
Closes #134

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] GSSoC contribution

## Participant Info
- GitHub username: @choudharyms
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes
- [x] This PR is related to a valid issue 

https://github.com/user-attachments/assets/b147a9fb-b5a2-4bc0-a59f-b2aa4a47f7e2

<img width="714" height="442" alt="image" src="https://github.com/user-attachments/assets/8772cc94-c6d6-4c97-a60c-c9dc86be870f" />
<img width="982" height="308" alt="image" src="https://github.com/user-attachments/assets/e759762b-1ad0-4f85-b554-10d3fb43d9a4" />
<img width="994" height="573" alt="image" src="https://github.com/user-attachments/assets/758aee79-53d1-4d3f-9d64-f24333de2569" />
