### PR TITLE
feat : added a  preview frame  feature

### DIFF
--- a/src/components/PreviewPanel.tsx
+++ b/src/components/PreviewPanel.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Image as ImageIcon } from "lucide-react";
+import BaseButton from "./ui/BaseButton";
+import { cn } from "@/lib/utils";
+
+interface PreviewPanelProps {
+  previewUrl: string | null;
+  isPreviewing: boolean;
+  onGeneratePreview: () => void;
+}
+
+export default function PreviewPanel({
+  previewUrl,
+  isPreviewing,
+  onGeneratePreview,
+}: PreviewPanelProps) {
+  return (
+    <div className="space-y-3 animate-fade-in">
+      <div className="flex items-center gap-2">
+        <span className="text-film-500 opacity-80">
+          <ImageIcon size={16} />
+        </span>
+        <h3 className="text-sm font-heading font-bold uppercase tracking-widest text-[var(--muted)]">
+          Preview
+        </h3>
+        <div className="flex-1 h-px bg-[var(--border)]" />
+      </div>
+
+      <BaseButton
+        onClick={onGeneratePreview}
+        disabled={isPreviewing}
+        variant="secondary"
+        size="md"
+        className="w-full"
+      >
+        {isPreviewing ? (
+          <>
+            <svg
+              className="w-4 h-4 animate-spin"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+            Generating...
+          </>
+        ) : (
+          <>
+            <ImageIcon size={16} />
+            Preview Frame
+          </>
+        )}
+      </BaseButton>
+
+      {previewUrl && (
+        <div className="rounded-lg overflow-hidden border border-[var(--border)] bg-[var(--bg)]">
+          <img
+            src={previewUrl}
+            alt="Frame preview"
+            className="w-full h-auto object-contain"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/PreviewPanel.tsx
+++ b/src/components/PreviewPanel.tsx
@@ -3,6 +3,7 @@
 import { Image as ImageIcon } from "lucide-react";
 import BaseButton from "./ui/BaseButton";
 import { cn } from "@/lib/utils";
+import Image from "next/image";
 
 interface PreviewPanelProps {
   previewUrl: string | null;
@@ -68,9 +69,11 @@ export default function PreviewPanel({
 
       {previewUrl && (
         <div className="rounded-lg overflow-hidden border border-[var(--border)] bg-[var(--bg)]">
-          <img
+          <Image
             src={previewUrl}
             alt="Frame preview"
+            width={1920}
+            height={1080}
             className="w-full h-auto object-contain"
           />
         </div>

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -17,6 +17,7 @@ import ExportSettings from "./ExportSettings";
 import ExportOverlay from "./ExportOverlay";
 import DownloadResult from "./DownloadResult";
 import ImageOverlay from "./ImageOverlay"
+import PreviewPanel from "./PreviewPanel";
 import { getPresetById } from "@/lib/presets";
 
 import { cn } from "@/lib/utils";
@@ -210,6 +211,9 @@ export default function VideoEditor() {
     recommendedPreset,
     currentTime,
     toggleSound,
+    previewUrl,
+    isPreviewing,
+    generatePreview,
   } = useVideoEditor();
 
   useKeyboardShortcuts({
@@ -680,6 +684,16 @@ export default function VideoEditor() {
                 </button>
               </div>
             </div>
+
+            {file && (
+              <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 animate-fade-in" style={{ animationDelay: "100ms" }}>
+                <PreviewPanel
+                  previewUrl={previewUrl}
+                  isPreviewing={isPreviewing}
+                  onGeneratePreview={generatePreview}
+                />
+              </div>
+            )}
 
             <KeyboardShortcutsPanel />
 

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -561,7 +561,7 @@ export function useVideoEditor() {
     } finally {
       setIsPreviewing(false);
     }
-  }, [file, recipe, previewUrl]);
+  }, [file, recipe, previewUrl,isPreviewing]);
 
   useEffect(() => {
     if (status === "exporting") {

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -4,7 +4,7 @@ import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { EditRecipe, ExportResult, ExportStatus, MAX_FILE_SIZE, OverlayPosition, isValidRecipe } from "@/lib/types";
 import { DEFAULT_RECIPE, SPEED_STEPS } from "@/lib/constants";
 import { getPresetById } from "@/lib/presets";
-import { loadFFmpeg, exportVideo, terminateFFmpeg, FFmpegLoadError } from "@/lib/ffmpeg";
+import { loadFFmpeg, exportVideo, terminateFFmpeg, FFmpegLoadError, generatePreviewFrame } from "@/lib/ffmpeg";
 import { suggestPreset } from "@/lib/presetSuggestion";
 import { validateDimensions, getDownscaledDimensions } from "@/utils/video-validation";
 
@@ -174,6 +174,10 @@ export function useVideoEditor() {
   const [overlaySize, setOverlaySize] = useState(150);
   const [overlayOpacity, setOverlayOpacity] = useState(100);
   const [currentTime, setCurrentTime] = useState(0);
+
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [isPreviewing, setIsPreviewing] = useState(false);
+
  const updateRecipe = useCallback((patch: Partial<EditRecipe>) => {
   setRecipe((prev) => {
     const next = { ...prev, ...patch };
@@ -527,6 +531,37 @@ export function useVideoEditor() {
     status,
   ]);
 
+  const generatePreview = useCallback(async () => {
+    if (!file) return;
+    if (isPreviewing) return;
+
+    const abortController = new AbortController();
+
+    try {
+      setIsPreviewing(true);
+      setError(null);
+
+      const ffmpeg = await loadFFmpeg(abortController.signal);
+
+      const newPreviewUrl = await generatePreviewFrame(ffmpeg, file, recipe, abortController.signal);
+
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
+      setPreviewUrl(newPreviewUrl);
+    } catch (err) {
+      console.error("preview generation failed:", err);
+      if (err instanceof FFmpegLoadError) {
+        setError(err.message);
+      } else if (err instanceof Error) {
+        setError(`Failed to generate preview: ${err.message}`);
+      } else {
+        setError("Failed to generate preview. Please try again.");
+      }
+    } finally {
+      setIsPreviewing(false);
+    }
+  }, [file, recipe, previewUrl]);
 
   useEffect(() => {
     if (status === "exporting") {
@@ -612,6 +647,14 @@ export function useVideoEditor() {
       }
     }
    },[result?.blobUrl])
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    };
+  }, [previewUrl]);
 
   useEffect(() => {
     return () => {
@@ -716,5 +759,8 @@ export function useVideoEditor() {
     recommendedPreset,
     currentTime,
     toggleSound,
+    previewUrl,
+    isPreviewing,
+    generatePreview,
   };
 }

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -27,6 +27,68 @@ async function fetchWithIntegrity(url: string, mimeType: string): Promise<string
   return URL.createObjectURL(blob);
 }
 
+export async function generatePreviewFrame(ffmpeg:FFmpeg,file:File,recipe:EditRecipe,signal?:AbortSignal):Promise<string>{
+
+  let targetH:number,targetW:number;
+  if (recipe.preset === "custom") {
+    targetW = recipe.customWidth;
+    targetH = recipe.customHeight;
+  } else {
+    const preset = getPresetById(recipe.preset);
+    targetW = preset?.width ?? 1920;
+    targetH = preset?.height ?? 1080;
+  }
+
+  targetW = Math.round(targetW / 2) * 2;
+  targetH = Math.round(targetH / 2) * 2;
+
+
+  const videoDuration = await new Promise<number>((resolve) => {
+    const video = document.createElement("video");
+    video.preload = "metadata";
+    video.onloadedmetadata = () => {
+      URL.revokeObjectURL(video.src);
+      resolve(video.duration);
+    };
+    video.onerror = () => resolve(recipe.trimEnd ?? 0);
+    video.src = URL.createObjectURL(file);
+  });
+
+  
+  const end = recipe.trimEnd ?? videoDuration;
+   const mid = recipe.trimStart + (end-recipe.trimStart)/2;
+
+    const sessionId = buildSessionId();
+  const ext = file.name.split(".").pop() ?? "mp4";
+  const inputName = `preview_input_${sessionId}.${ext}`;
+  const outputName = `preview_output_${sessionId}.jpg`;
+
+  try {
+    await ffmpeg.writeFile(inputName, await fetchFile(file), { signal });
+        const vf = buildVideoFilter(recipe, targetW, targetH);
+        const args = [
+      "-ss", String(mid),   
+      "-i", inputName,           
+      ...(vf ? ["-vf", vf] : []), 
+      "-frames:v", "1",           
+      "-f", "image2",             
+      "-vcodec", "mjpeg",         
+      "-y",                       
+      outputName,
+    ];
+    const exitCode = await ffmpeg.exec(args,undefined,{signal});
+    if(exitCode!==0) throw new Error("Could not load Preview ")
+   const data = await ffmpeg.readFile(outputName,undefined,{signal})
+    const blob = new Blob([new Uint8Array(data as Uint8Array)], { type: "image/jpeg" });
+    return URL.createObjectURL(blob);
+  } finally {
+    for (const path of [inputName, outputName]) {
+      try { await ffmpeg.deleteFile(path); } catch {}
+    }
+  }
+
+}
+
 let ffmpegInstance: FFmpeg | null = null;
 
 /**
@@ -60,12 +122,12 @@ export async function loadFFmpeg(
 
     const isIsolated = typeof self !== "undefined" && self.crossOriginIsolated;
     const baseURL = isIsolated
-      ? "https://unpkg.com/@ffmpeg/core-mt@0.12.6/dist/esm"
-      : "https://unpkg.com/@ffmpeg/core@0.12.6/dist/esm";
+  ? "https://cdn.jsdelivr.net/npm/@ffmpeg/core-mt@0.12.10/dist/umd"
+  : CORE_BASE_URL;
 
     await ffmpeg.load({
-      coreURL: await toBlobURL(`${baseURL}/ffmpeg-core.js`, "text/javascript"),
-      wasmURL: await toBlobURL(`${baseURL}/ffmpeg-core.wasm`, "application/wasm"),
+      coreURL: await fetchWithIntegrity(`${baseURL}/ffmpeg-core.js`, "text/javascript"),
+      wasmURL: await fetchWithIntegrity(`${baseURL}/ffmpeg-core.wasm`, "application/wasm"),
       ...(isIsolated && {
         workerURL: await toBlobURL(
           `${baseURL}/ffmpeg-core.worker.js`,


### PR DESCRIPTION
## Description

Implements #1052 — adds a **Preview Frame** button that extracts a single
frame at the midpoint of the trimmed range using FFmpeg.wasm, applying the
full filter chain (crop, rotation, speed, color) so users can verify
settings before a full export.

**Files changed:**
- `src/lib/ffmpeg.ts` — added `generatePreviewFrame()`
- `src/hooks/useVideoEditor.ts` — added preview state + action
- `src/components/PreviewPanel.tsx` — new preview component
- `src/components/VideoEditor.tsx` — integrated PreviewPanel into sidebar

Also fixes FFmpeg loading to use `fetchWithIntegrity()` with jsdelivr URLs
introduced in this [PR](https://github.com/magic-peach/reframe/pull/624 )  was still pointing to unpkg.com causing
exports to fail locally.

## Related Issue
Closes #1052

## Type of Contribution
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] GSSoC contribution

## Participant Info
- GitHub username: aarishmansur
- Contribution level: Advanced

## Screen Recording

https://github.com/user-attachments/assets/b035cd54-7bc7-42bd-8774-cac153e61ce1



## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes
- [x] `bunx tsc --noEmit` passes
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above**