### PR TITLE
fix(timeline): resolve duplicate trailing timestamps and key collisions on frames strip

### DIFF
--- a/src/components/ThumbnailStrip.tsx
+++ b/src/components/ThumbnailStrip.tsx
@@ -83,11 +83,23 @@ export default function ThumbnailStrip({
       canvas.height = thumbH;
 
       const times: number[] = [];
+      const seenTimestamps = new Set<string>();
+
       for (let t = 0; t <= duration; t += intervalSeconds) {
-        times.push(Math.min(t, duration - 0.1));
+        const roundedTime = Math.min(t, duration - 0.1);
+        const formatted = formatTime(roundedTime);
+        
+        if (!seenTimestamps.has(formatted)) {
+          seenTimestamps.add(formatted);
+          times.push(roundedTime);
+        }
       }
-      if ((times[times.length - 1] ?? 0) < duration - 0.5) {
-        times.push(duration - 0.1);
+
+      // Check if the final second boundary is missing from the timeline display
+      const finalTime = duration - 0.1;
+      const finalFormatted = formatTime(finalTime);
+      if (!seenTimestamps.has(finalFormatted) && finalTime > (times[times.length - 1] ?? 0)) {
+        times.push(finalTime);
       }
 
       const captured: Thumbnail[] = [];


### PR DESCRIPTION
Description
This PR resolves a systemic rounding flaw in the `ThumbnailStrip` component where trailing video frames output duplicate formatted timestamps (e.g., displaying `0:10` twice on an 11-second video or creating structural layout duplication). 

The mathematical bounding constraints previously introduced collision states when video durations did not divide cleanly into the set interval steps. This fix introduces a string-based tracking layout using a native `Set` against the formatted output of `formatTime()`, ensuring every generated frame is strictly unique in both value and presentation.

Related Issue
Fixes #1069

Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

 Participant Info
- GitHub username: trivikramkalagi91-commits
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

Screenshots:
BEFORE:
one extra frame
<img width="1402" height="898" alt="image" src="https://github.com/user-attachments/assets/f642cffd-d3a9-4308-89ab-d5e55ed2386a" />
AFTER:
only 3 frames
<img width="1368" height="876" alt="image" src="https://github.com/user-attachments/assets/4d311d4b-1cc1-4bfd-be51-6ebbb1296ea0" />
<img width="1390" height="864" alt="image" src="https://github.com/user-attachments/assets/d2b5f3cb-ea9e-4cdf-acba-719d1efb797d" />



Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue


note: i admit that i used ai for doing all comments raising a pull request as my english is not that good as to explain the next person but whatever changes i made i understand it clearly and then do it. 