### PR TITLE
fix(frontend): resolve disabled export button and synchronize editor …

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -12,6 +12,7 @@ interface Props {
   currentFile: File | null;
   fileError: string;
   duration: number;
+  isLoading?: boolean;
 }
 
 export default function FileUpload({
@@ -19,6 +20,7 @@ export default function FileUpload({
   currentFile,
   fileError,
   duration,
+  isLoading = false,
 }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -259,6 +261,24 @@ export default function FileUpload({
       />
     </div>
   );
+ 
+  // ── Loading state ──
+  const LoadingState = () => (
+    <div className="flex flex-col items-center justify-center gap-4 py-12 px-6 border-2 border-dashed border-[var(--border)] rounded-xl bg-[var(--bg)] animate-pulse">
+      <div className="relative flex items-center justify-center w-16 h-16">
+        <div className="absolute w-12 h-12 rounded-full border-4 border-film-500/20 border-t-film-600 animate-spin" />
+        <Film size={20} className="text-film-600 animate-pulse" />
+      </div>
+      <div className="text-center">
+        <p className="font-heading font-semibold text-[var(--text)] text-base">
+          Processing Video
+        </p>
+        <p className="text-sm text-[var(--muted)] mt-1">
+          Extracting dimensions, aspect ratio, and metadata...
+        </p>
+      </div>
+    </div>
+  );
 
   return (
     <>
@@ -305,7 +325,7 @@ export default function FileUpload({
             {warning}
           </p>
         )}
-        {currentFile ? <FileInfo /> : <DropZone />}
+        {isLoading ? <LoadingState /> : currentFile ? <FileInfo /> : <DropZone />}
       </div>
     </>
   );

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -271,7 +271,7 @@ export default function VideoEditor() {
     }
   }, [status]);
 
-  const isProcessing = status === "loading-engine" || status === "exporting";
+  const isProcessing = status === "loading" || status === "loading-engine" || status === "exporting";
   const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
 
   const intervalSeconds = useMemo(() => {
@@ -370,7 +370,13 @@ export default function VideoEditor() {
 
           <div className="space-y-4 min-w-0">
             <div className="bg-[var(--surface)] rounded-xl p-3 border border-[var(--border)] animate-fade-in">
-              <FileUpload onFileSelect={handleFileSelect} currentFile={file} fileError={fileError} duration={duration} />
+              <FileUpload
+                onFileSelect={handleFileSelect}
+                currentFile={file}
+                fileError={fileError}
+                duration={duration}
+                isLoading={status === "loading"}
+              />
 
               {!file && (
                 <div className="text-center text-[var(--muted)] py-6">

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -353,12 +353,13 @@ export function useVideoEditor() {
 
   const handleFileSelect = useCallback(async (selectedFile: File) => {
     setResult(null);
-    setStatus("idle");
+    setStatus("loading");
     setError(null);
     setFile(null);
     setVideoMetadata(null);
     if (!selectedFile.type.startsWith("video/")) {
       setFileError("Please upload a video file only.");
+      setStatus("idle");
       return;
     }
 
@@ -411,6 +412,7 @@ export function useVideoEditor() {
       setDuration(dur);
       setVideoMetadata({ width, height, duration: dur });
       setFile(selectedFile);
+      setStatus("idle");
 
       if (dimensionCheck === "warning") {
         console.warn(`[Reframe] High resolution video detected (${width}×${height}). Export may be slow.`);
@@ -612,6 +614,26 @@ export function useVideoEditor() {
       }
     }
    },[result?.blobUrl])
+
+  // Reset export status/result/error when recipe or options change after an export/error
+  useEffect(() => {
+    if (status === "done" || status === "error") {
+      setStatus("idle");
+      setResult(null);
+      setError(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    recipe,
+    musicFile,
+    musicVolume,
+    originalAudioVolume,
+    loopMusic,
+    overlayFile,
+    overlayPosition,
+    overlaySize,
+    overlayOpacity,
+  ]);
 
   useEffect(() => {
     return () => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -68,6 +68,7 @@ export interface ExportResult {
 
 export type ExportStatus =
   | "idle"
+  | "loading"
   | "loading-engine"
   | "exporting"
   | "done"


### PR DESCRIPTION
### 📝 Summary of Changes
This pull request resolves the issue where the Export button remained disabled or locked after successfully uploading and processing valid videos, and ensures all editing parameters and export states synchronize seamlessly.

Specifically, it:
1. **Added Video Loading State:** Introduced a new `"loading"` state to `ExportStatus` that tracks the asynchronous metadata extraction and magic-byte checks after a video is selected.
2. **Added Premium Visual Loader:** Equipped `FileUpload` with an `isLoading` prop and a modern visual loader. While a video is loading, a high-quality pulsing visual is rendered rather than returning the user to the blank drop-zone, significantly improving user experience.
3. **Synchronized Controls & Buttons:** Modified `VideoEditor` to include the `"loading"` status in `isProcessing`. All controls and the Export button are appropriately disabled, displaying `"PROCESSING"` until the video file is completely parsed and loaded.
4. **Resolved Stale Export State:** Added a synchronization `useEffect` hook in `useVideoEditor` that monitors changes in the editing recipe or audio options. If the current status is `"done"` or `"error"`, any new edit resets the status back to `"idle"` and clears out old results/error banners, preventing any stale or false disabled states.

---

### 🛠️ Technical Details & Files Changed

- **`src/lib/types.ts`:** Updated the `ExportStatus` type to include the new `"loading"` state.
- **`src/hooks/useVideoEditor.ts`:**
  - Set `status` to `"loading"` at the start of `handleFileSelect` and to `"idle"` when successful.
  - Added a reactive effect to clean up old export blobs, results, and errors as soon as the user makes any adjustment to the video settings after an export or failure.
- **`src/components/FileUpload.tsx`:** Created a premium visual `LoadingState` spinner that renders when `isLoading` is true.
- **`src/components/VideoEditor.tsx`:** Passed the loading status to `FileUpload` and integrated the `"loading"` state to safely disable editor controls and update the Export button.

---

### 🧪 Verification & Testing

1. **TypeScript Compilation:** Checked by running `npx tsc --noEmit` and confirmed **zero type check or compiler errors**.
2. **Unit Tests:** Ran the Vitest test suites using `npx vitest run` and ensured all existing unit tests pass successfully.
3. **Manual Flow Verified:**
   - Selecting a video correctly renders the premium loading animation instead of resetting the drop-zone.
   - The Export button correctly toggles to `"PROCESSING"` and becomes fully enabled as `"EXPORT"` as soon as the video metadata extraction succeeds.
   - Adjusting any trim, preset, or quality slider after a completed export successfully clears the old download box and resets the state to `"idle"`.

---

### ☑️ Checklist
- [x] My code compiles successfully with no TypeScript errors
- [x] I have tested the changes locally and verified they work as expected
- [x] All unit tests pass successfully
- [x] I have verified the changes on multiple file formats