### PR TITLE
fix: prevent unnecessary DOM updates in VideoPreview

### DIFF
--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -117,12 +117,12 @@ export default function VideoPreview({
   useEffect(() => {
     if (!videoRef.current || !recipe) return;
     videoRef.current.muted = !recipe.keepAudio;
-  }, [recipe, videoRef]);
+  }, [recipe?.keepAudio, videoRef]);
 
   useEffect(() => {
     if (!videoRef.current || !recipe) return;
     videoRef.current.playbackRate = recipe.speed;
-  }, [recipe, videoRef]);
+  }, [recipe?.speed, videoRef]);
 
   /**
    * Track preview container dimensions for text overlay positioning.


### PR DESCRIPTION
Fixes #768.

Narrowed the dependency arrays in the useEffect hooks responsible for synchronizing audio and speed state to the native video element. This prevents redundant DOM updates when unrelated recipe properties are adjusted.