### PR TITLE
fix: calculate correct estimated size for platform presets

### DIFF
--- a/src/lib/exportEstimate.ts
+++ b/src/lib/exportEstimate.ts
@@ -1,23 +1,5 @@
 import { EditRecipe } from "./types";
-
-// ---------------------------------------------------------------------------
-// Preset dimension map
-// Keep in sync with src/lib/presets.ts. Width × height for every named preset.
-// ---------------------------------------------------------------------------
-const PRESET_DIMENSIONS: Record<string, { width: number; height: number }> = {
-  "1080p":       { width: 1920, height: 1080 },
-  "720p":        { width: 1280, height: 720  },
-  "480p":        { width: 854,  height: 480  },
-  "360p":        { width: 640,  height: 360  },
-  "4k":          { width: 3840, height: 2160 },
-  "2k":          { width: 2560, height: 1440 },
-  // Square / portrait presets
-  "square-1080": { width: 1080, height: 1080 },
-  "square-720":  { width: 720,  height: 720  },
-  "portrait-1080": { width: 1080, height: 1920 },
-  "portrait-720":  { width: 720,  height: 1280 },
-  // Fallback — if a preset name is unrecognised we fall through to customWidth/H
-};
+import { getPresetById } from "./presets";
 
 /**
  * Resolve the actual output pixel dimensions for a recipe.
@@ -26,8 +8,8 @@ const PRESET_DIMENSIONS: Record<string, { width: number; height: number }> = {
  */
 function getOutputDimensions(recipe: EditRecipe): { width: number; height: number } {
   if (recipe.preset !== "custom") {
-    const dims = PRESET_DIMENSIONS[recipe.preset];
-    if (dims) return dims;
+    const preset = getPresetById(recipe.preset);
+    if (preset) return { width: preset.width, height: preset.height };
   }
   return { 
     width: recipe.customWidth || 1920, 


### PR DESCRIPTION
Fixes #766.

Removed the hardcoded, out-of-sync PRESET_DIMENSIONS map from exportEstimate.ts and replaced it with a direct lookup to getPresetById(recipe.preset). This ensures the file size estimation correctly accounts for the dimensions of the selected platform preset instead of silently ignoring it and defaulting to the custom width/height values.