### PR TITLE
fix: make normalizeAudio parameter optional to fix test compilation

### DIFF
--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -165,7 +165,7 @@ export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: n
   return filters.join(",");
 }
 
-export function buildAudioFilter(speed: number, normalizeAudio: boolean): string {
+export function buildAudioFilter(speed: number, normalizeAudio: boolean = false): string {
   if (speed <= 0) return "";
   const filters: string[] = [];
 


### PR DESCRIPTION
Fixes #764.

Made the normalizeAudio parameter in buildAudioFilter optional with a default value of false to fix TypeScript compilation errors in the unit tests after the recent audio normalization commit.