### PR TITLE
fix: remove hardcoded 500MB upload limit to allow 2GB files

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -92,10 +92,6 @@ export default function FileUpload({
       return;
     }
 
-    if (file.size > 500 * 1024 * 1024) {
-      setError("File size exceeds 500MB limit. Please select a smaller video.");
-      return;
-    }
 
     if (file.size > MAX_FILE_SIZE) {
       setError(


### PR DESCRIPTION
Fixes #1089.

Removed a hardcoded 500MB error check in FileUpload.tsx that was unconditionally blocking large files and preventing the actual MAX_FILE_SIZE (2 GB) and WARNING_FILE_SIZE logic from ever running.