### PR TITLE
fix: preserve dark mode after page refresh

### DIFF
--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -20,17 +20,23 @@ interface ThemeContextValue {
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
 function getCurrentTheme(): Theme {
-  if (
-    typeof document !== "undefined" &&
-    document.documentElement.classList.contains("dark")
-  ) {
-    return "dark";
+  if (typeof window !== "undefined") {
+    const savedTheme = localStorage.getItem("theme");
+
+    if (savedTheme === "dark" || savedTheme === "light") {
+      return savedTheme;
+    }
+
+    if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+      return "dark";
+    }
   }
+
   return "light";
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setThemeState] = useState<Theme>(getCurrentTheme);
+  const [theme, setThemeState] = useState<Theme>("light");;
 
   const applyTheme = useCallback(
     (next: Theme, persist = true) => {
@@ -49,6 +55,8 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     setThemeState(getCurrentTheme());
+    const currentTheme = getCurrentTheme();
+    applyTheme(currentTheme, false);
 
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
     const handler = (e: MediaQueryListEvent) => {


### PR DESCRIPTION
Partially fixes #1038

## Changes Made

- Fixed dark mode resetting to light mode after page refresh
- Applied persisted theme immediately on reload
- Synced ThemeProvider state with stored theme preference

## Testing

- Verified dark mode persists after refresh
- Verified toggle functionality still works correctly