### PR TITLE
fix: escape percent signs in FFmpeg drawtext filter

### DIFF
--- a/src/lib/text-overlay.ts
+++ b/src/lib/text-overlay.ts
@@ -69,7 +69,8 @@ export function buildTextFilter(
   const escapedText = overlay.text
     .replace(/\\/g, "\\\\")
     .replace(/'/g, "\\'")
-    .replace(/:/g, "\\:");
+    .replace(/:/g, "\\:")
+    .replace(/%/g, "%%");
 
   // Convert percentage position to pixel position
   const pixelX = Math.round((overlay.x / 100) * targetWidth);


### PR DESCRIPTION
## Summary

- The `drawtext` FFmpeg filter treats `%{...}` and `%n` as expansion sequences
- Overlay text containing `%` (e.g. "50% off") caused garbled output or a filter parse error
- Added `.replace(/%/g, '%%')` to the escape chain in `buildTextFilter()` so literal percent signs are doubled before the filter string is built

## Changes

`src/lib/text-overlay.ts`: added `%` -> `%%` to the existing escape sequence alongside `\\`, `'`, and `:`

## Test plan

- [ ] Add a text overlay with content like "50% off" and export a video
- [ ] Confirm the overlay text renders correctly with a literal percent sign
- [ ] Confirm export completes without an FFmpeg filter parse error
- [ ] Confirm overlays with no percent signs are unaffected

Closes #1112