### PR TITLE
fix: Unicode-safe base64 encoding for shared recipe URLs

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -251,7 +251,7 @@ export default function VideoEditor() {
 
   const handleCopyLink = () => {
     if (typeof window === "undefined") return;
-    const encoded = btoa(JSON.stringify(recipe));
+    const encoded = btoa(unescape(encodeURIComponent(JSON.stringify(recipe))));
     const url = new URL(window.location.href);
     url.searchParams.set("settings", encoded);
     history.replaceState(null, "", url.toString());

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -119,12 +119,15 @@ function validateRecipe(recipe: EditRecipe, duration: number ): string | null {
 }
 
 function encodeRecipe(recipe: EditRecipe): string {
-  return btoa(JSON.stringify(recipe));
+  // encodeURIComponent handles the full Unicode range; unescape maps it back to
+  // a Latin-1 string that btoa can safely encode without throwing on emoji or
+  // other non-Latin-1 characters in text overlays.
+  return btoa(unescape(encodeURIComponent(JSON.stringify(recipe))));
 }
 
 function decodeRecipe(encoded: string): Partial<EditRecipe> | null {
   try {
-    const decoded = JSON.parse(atob(encoded));
+    const decoded = JSON.parse(decodeURIComponent(escape(atob(encoded))));
     return decoded as Partial<EditRecipe>;
   } catch {
     return null;


### PR DESCRIPTION
## Summary

- `btoa()` accepts only Latin-1 (code points 0-255); passing a JSON string that contains non-Latin-1 characters (emoji, CJK, accented letters in text overlays) throws a `DOMException`
- The Copy Link button silently failed whenever a recipe included such characters in a text overlay
- Fixed by wrapping the encode path with `btoa(unescape(encodeURIComponent(...)))` and the decode path with `JSON.parse(decodeURIComponent(escape(atob(...))))` so the full Unicode range is handled correctly

## Changes

- `src/hooks/useVideoEditor.ts`: updated `encodeRecipe` and `decodeRecipe` helpers
- `src/components/VideoEditor.tsx`: updated `handleCopyLink` which had an identical inline `btoa` call

## Test plan

- [ ] Add a text overlay containing emoji or non-ASCII characters (e.g. "50% 🎬 合")
- [ ] Click Copy Link -- no console error should appear
- [ ] Open the copied URL in a new tab -- the overlay text should be restored correctly
- [ ] Verify that pure-ASCII recipes still round-trip correctly

Closes #1111