### PR TITLE
fix: cancel in-progress export when a new file is dropped

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -352,6 +352,15 @@ export function useVideoEditor() {
   }, [videoMetadata]);
 
   const handleFileSelect = useCallback(async (selectedFile: File) => {
+    // If an export is running, cancel it before replacing the file so that
+    // the previous FFmpeg worker does not write a result for the old file
+    // after the new file has already been loaded.
+    if (exportAbortControllerRef.current) {
+      exportCancelledRef.current = true;
+      exportAbortControllerRef.current.abort();
+      exportAbortControllerRef.current = null;
+    }
+
     setResult(null);
     setStatus("idle");
     setError(null);


### PR DESCRIPTION
## Summary

- While an export was running, dropping a new file did not stop the active FFmpeg worker
- The worker could complete the old export and call `setResult` / `setStatus` after the new file had loaded, overwriting the current editing state with stale output
- Added an explicit abort at the start of `handleFileSelect`: if `exportAbortControllerRef.current` is set, its signal is aborted and `exportCancelledRef` is set to `true` before any state is reset
- The existing `exportCancelledRef.current` guard in `handleExport` then suppresses the stale result, so no side-effects leak through

## Changes

`src/hooks/useVideoEditor.ts`: three-line guard at the top of `handleFileSelect`

## Test plan

- [ ] Start a long export, then immediately drop a new video file
- [ ] Confirm the export overlay disappears and the editor resets to the new file
- [ ] Confirm no result from the cancelled export appears after the file switch
- [ ] Confirm a normal export (no file drop) still completes successfully

Closes #1113