### PR TITLE
fix: validate shared recipe URL payload before applying editor state

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -125,6 +125,14 @@ function encodeRecipe(recipe: EditRecipe): string {
 function decodeRecipe(encoded: string): Partial<EditRecipe> | null {
   try {
     const decoded = JSON.parse(atob(encoded));
+    if (!decoded || typeof decoded !== "object") return null;
+    // Validate the merged recipe before accepting any decoded values.
+    // This prevents a tampered or malformed share URL from injecting
+    // out-of-range numbers, invalid enum strings, or other unexpected
+    // values into the editor state. If any field fails, the whole link
+    // is rejected and the editor starts from safe defaults.
+    const merged = { ...DEFAULT_RECIPE, ...decoded };
+    if (!isValidRecipe(merged)) return null;
     return decoded as Partial<EditRecipe>;
   } catch {
     return null;


### PR DESCRIPTION
## Summary

- `decodeRecipe()` cast the decoded `?settings=` JSON directly to `Partial<EditRecipe>` with no structural validation
- A crafted share URL could inject arbitrary values (e.g. `speed: 9999`, `quality: -1`, `format: "exe"`) that bypassed the per-field `isValidValue()` checks applied to plain URL params, and could reach the FFmpeg build step unchecked
- Added `isValidRecipe()` validation against the merged recipe before accepting any decoded values; if validation fails the editor silently falls back to safe defaults, matching the behaviour of invalid individual URL params

## Changes

`src/hooks/useVideoEditor.ts`: added type-narrowing and `isValidRecipe` check inside `decodeRecipe()`

## Test plan

- [ ] Open a normal share URL -- settings should restore correctly
- [ ] Manually craft `?settings=` with base64-encoded JSON containing `speed: 9999` -- editor should load with default settings
- [ ] Craft a payload with `format: "exe"` or `quality: -100` -- editor should ignore the link and use defaults
- [ ] Verify that a valid share link with a text overlay round-trips correctly

Closes #1110