### PR TITLE
fix: wire up SRI integrity verification for FFmpeg WASM loading

### DIFF
--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -1,5 +1,5 @@
 import { FFmpeg } from "@ffmpeg/ffmpeg";
-import { fetchFile, toBlobURL } from "@ffmpeg/util";
+import { fetchFile } from "@ffmpeg/util";
 import { EditRecipe, ExportResult, BackgroundMusicOptions, ImageOverlayOptions } from "./types";
 import { getPresetById } from "./presets";
 import { buildTextFilter } from "./text-overlay";
@@ -58,20 +58,13 @@ export async function loadFFmpeg(
   try {
     ffmpeg.on("progress", handleProgress);
 
-    const isIsolated = typeof self !== "undefined" && self.crossOriginIsolated;
-    const baseURL = isIsolated
-      ? "https://unpkg.com/@ffmpeg/core-mt@0.12.6/dist/esm"
-      : "https://unpkg.com/@ffmpeg/core@0.12.6/dist/esm";
-
+    // Load the engine from CORE_BASE_URL so the SRI hashes in SRI_HASHES
+    // match the actual files being fetched. fetchWithIntegrity verifies each
+    // resource against its sha384 hash before creating the blob URL, aborting
+    // the load if the CDN returns tampered bytes.
     await ffmpeg.load({
-      coreURL: await toBlobURL(`${baseURL}/ffmpeg-core.js`, "text/javascript"),
-      wasmURL: await toBlobURL(`${baseURL}/ffmpeg-core.wasm`, "application/wasm"),
-      ...(isIsolated && {
-        workerURL: await toBlobURL(
-          `${baseURL}/ffmpeg-core.worker.js`,
-          "text/javascript"
-        ),
-      }),
+      coreURL: await fetchWithIntegrity(`${CORE_BASE_URL}/ffmpeg-core.js`, "text/javascript"),
+      wasmURL: await fetchWithIntegrity(`${CORE_BASE_URL}/ffmpeg-core.wasm`, "application/wasm"),
     }, { signal });
 
     onProgress?.(100);


### PR DESCRIPTION
## Summary

- `fetchWithIntegrity()` and `SRI_HASHES` were added to `ffmpeg.ts` but never called
- `loadFFmpeg()` used `toBlobURL()` with `unpkg.com` URLs (version 0.12.6) that had no matching hashes, so the CDN content was fetched and executed with no integrity verification
- A compromised or malicious CDN response could have caused arbitrary WASM execution in the user's browser with no detection
- Fixed by switching `loadFFmpeg()` to call `fetchWithIntegrity()` with `CORE_BASE_URL` (`cdn.jsdelivr.net / @ffmpeg/core@0.12.10 / dist/umd`), whose sha384 hashes are already in `SRI_HASHES`
- The native `fetch()` `integrity` option aborts the load and throws if the CDN returns bytes that do not match the expected hash
- Removed the now-unused `toBlobURL` import

## Changes

`src/lib/ffmpeg.ts`:
- Replaced `toBlobURL` calls with `fetchWithIntegrity` for `coreURL` and `wasmURL`
- Removed the `isIsolated` / multi-threaded branch (those CDN URLs have no verified hashes; can be re-added once hashes are confirmed)
- Removed unused `toBlobURL` import

## Test plan

- [ ] Load the app and trigger an export -- FFmpeg should load successfully from the CDN
- [ ] Verify no console errors about integrity or CORS
- [ ] (Optional) Tamper with the URL in `SRI_HASHES` to a wrong hash -- the load should throw `FFmpegLoadError`

Closes #1109