### PR TITLE
fix: skip -t 0 when video metadata fails and playback speed is changed

### DIFF
--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -320,10 +320,16 @@ function buildArguments(
 
   // Add explicit output duration when speed != 1 to prevent slight duration
   // overshoot caused by encoder/filter pipeline frame flush at stream end.
+  // Guard against sourceDuration <= 0: if video metadata failed to load,
+  // videoDuration falls back to 0, making sourceDuration 0. Passing -t 0
+  // to FFmpeg produces a zero-length output file. Skip -t in that case so
+  // FFmpeg encodes the full stream without an artificial cap.
   if (recipe.speed !== 1) {
     const sourceDuration = (recipe.trimEnd ?? videoDuration) - recipe.trimStart;
-    const outputDuration = sourceDuration / recipe.speed;
-    args.push("-t", outputDuration.toFixed(6));
+    if (sourceDuration > 0) {
+      const outputDuration = sourceDuration / recipe.speed;
+      args.push("-t", outputDuration.toFixed(6));
+    }
   }
 
   args.push(outputName);
@@ -427,11 +433,14 @@ export async function exportVideo(
       // Add explicit output duration when speed != 1 to prevent slight duration
       // overshoot caused by encoder/filter pipeline frame flush at stream end.
       // Applied to both passes so palette and render are bounded identically.
+      // Skip -t when sourceDuration <= 0 (metadata load failure fallback) to
+      // avoid producing a zero-length GIF.
       const gifDurationArgs: string[] =
         recipe.speed !== 1
           ? (() => {
               const sourceDuration =
                 (recipe.trimEnd ?? videoDuration) - recipe.trimStart;
+              if (sourceDuration <= 0) return [];
               const outputDuration = sourceDuration / recipe.speed;
               return ["-t", outputDuration.toFixed(6)];
             })()


### PR DESCRIPTION
## Summary

- When `HTMLVideoElement.onerror` fires in `exportVideo` (e.g. the device is slow and the 5-second timeout fires, or the file is corrupt), `videoDuration` resolves to `0`
- With `recipe.trimEnd` null and `recipe.trimStart` at `0`, `sourceDuration` becomes `0`, so `-t 0.000000` was passed to FFmpeg
- FFmpeg interprets `-t 0` as "encode zero seconds", producing a silent zero-length output file with exit code 0 and no visible error message
- This only happened when `recipe.speed !== 1` (the `-t` argument is only added for speed changes)

## Changes

`src/lib/ffmpeg.ts`:
- Added `sourceDuration > 0` guard in `buildArguments` before pushing `-t`
- Same guard added to the two-pass GIF `gifDurationArgs` calculation
- When `sourceDuration` is zero or negative, `-t` is omitted entirely and FFmpeg encodes the full stream, matching the behaviour when `speed === 1`

## Test plan

- [ ] Export a video at 2x speed normally -- output duration should be halved correctly
- [ ] Export a video at 1x speed -- no change in behaviour
- [ ] Simulate a metadata failure (mock `onerror`) with speed != 1 -- export should produce a full-length file rather than a zero-byte one
- [ ] Export a GIF at non-1x speed -- confirm duration is correct

Closes #1108