### PR TITLE
fix: move FFmpeg export pipeline to web worker

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "eslint": "^9",
         "eslint-config-next": "^15.1.8",
         "eslint-plugin-jsx-a11y": "^6.10.2",
-        "jsdom": "^22.1.0",
+        "jsdom": "^29.1.1",
         "postcss": "^8",
         "tailwindcss": "^3.4.17",
         "typescript": "^5",
@@ -43,11 +43,33 @@
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
+
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.1.1", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ=="],
+
+    "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
+
+    "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@3.2.1", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.1.1", "", { "dependencies": { "@csstools/color-helpers": "^6.0.2", "@csstools/css-calc": "^3.2.1" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
+
+    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.4", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -72,6 +94,8 @@
     "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@exodus/bytes": ["@exodus/bytes@1.15.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q=="],
 
     "@ffmpeg/ffmpeg": ["@ffmpeg/ffmpeg@0.12.15", "", { "dependencies": { "@ffmpeg/types": "^0.12.4" } }, "sha512-1C8Obr4GsN3xw+/1Ww6PFM84wSQAGsdoTuTWPOj2OizsRDLT4CXTaVjPhkw6ARyDus1B9X/L2LiXHqYYsGnRFw=="],
 
@@ -227,8 +251,6 @@
 
     "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
-    "@tootallnate/once": ["@tootallnate/once@2.0.1", "", {}, "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ=="],
-
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
@@ -323,13 +345,9 @@
 
     "@vitest/utils": ["@vitest/utils@4.1.6", "", { "dependencies": { "@vitest/pretty-format": "4.1.6", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ=="],
 
-    "abab": ["abab@2.0.6", "", {}, "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="],
-
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
-
-    "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
@@ -369,8 +387,6 @@
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
 
-    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
-
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
     "axe-core": ["axe-core@4.11.4", "", {}, "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA=="],
@@ -378,6 +394,8 @@
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
@@ -413,8 +431,6 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
-
     "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
@@ -425,17 +441,17 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
     "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
-
-    "cssstyle": ["cssstyle@3.0.0", "", { "dependencies": { "rrweb-cssom": "^0.6.0" } }, "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "damerau-levenshtein": ["damerau-levenshtein@1.0.8", "", {}, "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="],
 
-    "data-urls": ["data-urls@4.0.0", "", { "dependencies": { "abab": "^2.0.6", "whatwg-mimetype": "^3.0.0", "whatwg-url": "^12.0.0" } }, "sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g=="],
+    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
 
     "data-view-buffer": ["data-view-buffer@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ=="],
 
@@ -455,8 +471,6 @@
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
-    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
-
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "didyoumean": ["didyoumean@1.2.2", "", {}, "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="],
@@ -467,13 +481,11 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
-    "domexception": ["domexception@4.0.0", "", { "dependencies": { "webidl-conversions": "^7.0.0" } }, "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw=="],
-
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
-    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
     "es-abstract": ["es-abstract@1.24.2", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg=="],
 
@@ -561,8 +573,6 @@
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
-    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
-
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
@@ -603,13 +613,7 @@
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
-    "html-encoding-sniffer": ["html-encoding-sniffer@3.0.0", "", { "dependencies": { "whatwg-encoding": "^2.0.0" } }, "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA=="],
-
-    "http-proxy-agent": ["http-proxy-agent@5.0.0", "", { "dependencies": { "@tootallnate/once": "2", "agent-base": "6", "debug": "4" } }, "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w=="],
-
-    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
-
-    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -695,7 +699,7 @@
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
-    "jsdom": ["jsdom@22.1.0", "", { "dependencies": { "abab": "^2.0.6", "cssstyle": "^3.0.0", "data-urls": "^4.0.0", "decimal.js": "^10.4.3", "domexception": "^4.0.0", "form-data": "^4.0.0", "html-encoding-sniffer": "^3.0.0", "http-proxy-agent": "^5.0.0", "https-proxy-agent": "^5.0.1", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.4", "parse5": "^7.1.2", "rrweb-cssom": "^0.6.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^4.1.2", "w3c-xmlserializer": "^4.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^2.0.0", "whatwg-mimetype": "^3.0.0", "whatwg-url": "^12.0.1", "ws": "^8.13.0", "xml-name-validator": "^4.0.0" }, "peerDependencies": { "canvas": "^2.5.0" }, "optionalPeers": ["canvas"] }, "sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw=="],
+    "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
@@ -755,6 +759,8 @@
 
     "lottie-web": ["lottie-web@5.13.0", "", {}, "sha512-+gfBXl6sxXMPe8tKQm7qzLnUy5DUPJPKIyRHwtpCpyUEYjHYRJC/5gjUvdkuO2c3JllrPtHXH5UJJK8LRYl5yQ=="],
 
+    "lru-cache": ["lru-cache@11.5.0", "", {}, "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA=="],
+
     "lucide-react": ["lucide-react@0.469.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
@@ -763,13 +769,11 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
-
-    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
-
-    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
@@ -792,8 +796,6 @@
     "node-exports-info": ["node-exports-info@1.6.0", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
-
-    "nwsapi": ["nwsapi@2.2.23", "", {}, "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -829,7 +831,7 @@
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
-    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+    "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
@@ -871,11 +873,7 @@
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
-    "psl": ["psl@1.15.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w=="],
-
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
-
-    "querystringify": ["querystringify@2.2.0", "", {}, "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
@@ -899,7 +897,7 @@
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
 
-    "requires-port": ["requires-port@1.0.0", "", {}, "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="],
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
 
@@ -911,8 +909,6 @@
 
     "rolldown": ["rolldown@1.0.1", "", { "dependencies": { "@oxc-project/types": "=0.130.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.1", "@rolldown/binding-darwin-arm64": "1.0.1", "@rolldown/binding-darwin-x64": "1.0.1", "@rolldown/binding-freebsd-x64": "1.0.1", "@rolldown/binding-linux-arm-gnueabihf": "1.0.1", "@rolldown/binding-linux-arm64-gnu": "1.0.1", "@rolldown/binding-linux-arm64-musl": "1.0.1", "@rolldown/binding-linux-ppc64-gnu": "1.0.1", "@rolldown/binding-linux-s390x-gnu": "1.0.1", "@rolldown/binding-linux-x64-gnu": "1.0.1", "@rolldown/binding-linux-x64-musl": "1.0.1", "@rolldown/binding-openharmony-arm64": "1.0.1", "@rolldown/binding-wasm32-wasi": "1.0.1", "@rolldown/binding-win32-arm64-msvc": "1.0.1", "@rolldown/binding-win32-x64-msvc": "1.0.1" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ=="],
 
-    "rrweb-cssom": ["rrweb-cssom@0.6.0", "", {}, "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw=="],
-
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "safe-array-concat": ["safe-array-concat@1.1.4", "", { "dependencies": { "call-bind": "^1.0.9", "call-bound": "^1.0.4", "get-intrinsic": "^1.3.0", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg=="],
@@ -922,8 +918,6 @@
     "safe-push-apply": ["safe-push-apply@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "isarray": "^2.0.5" } }, "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA=="],
 
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
-
-    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
@@ -1013,11 +1007,15 @@
 
     "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
+    "tldts": ["tldts@7.1.2", "", { "dependencies": { "tldts-core": "^7.1.2" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-RUX5sQm8bl03ycwQ6nSgJiKw9FZWhA8GBzxX6X1lsG3xKzFIW+lYLLpM30FQbDD6XjTWa/VkF15VxjnAMWYJAQ=="],
+
+    "tldts-core": ["tldts-core@7.1.2", "", {}, "sha512-26EbERPLf5wkNFKW+7egxArSPN1Nqipe/PIe1nvhpNu8HqQeY2pYdOeQk4sAiADv/e03VzHkLY0PPohKv1JMAQ=="],
+
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
-    "tough-cookie": ["tough-cookie@4.1.4", "", { "dependencies": { "psl": "^1.1.33", "punycode": "^2.1.1", "universalify": "^0.2.0", "url-parse": "^1.5.3" } }, "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag=="],
+    "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
 
-    "tr46": ["tr46@4.1.1", "", { "dependencies": { "punycode": "^2.3.0" } }, "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw=="],
+    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
@@ -1041,15 +1039,13 @@
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
-    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+    "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
 
-    "universalify": ["universalify@0.2.0", "", {}, "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="],
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
-
-    "url-parse": ["url-parse@1.5.10", "", { "dependencies": { "querystringify": "^2.1.1", "requires-port": "^1.0.0" } }, "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
@@ -1057,17 +1053,15 @@
 
     "vitest": ["vitest@4.1.6", "", { "dependencies": { "@vitest/expect": "4.1.6", "@vitest/mocker": "4.1.6", "@vitest/pretty-format": "4.1.6", "@vitest/runner": "4.1.6", "@vitest/snapshot": "4.1.6", "@vitest/spy": "4.1.6", "@vitest/utils": "4.1.6", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.6", "@vitest/browser-preview": "4.1.6", "@vitest/browser-webdriverio": "4.1.6", "@vitest/coverage-istanbul": "4.1.6", "@vitest/coverage-v8": "4.1.6", "@vitest/ui": "4.1.6", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ=="],
 
-    "w3c-xmlserializer": ["w3c-xmlserializer@4.0.0", "", { "dependencies": { "xml-name-validator": "^4.0.0" } }, "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw=="],
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
     "wasm-feature-detect": ["wasm-feature-detect@1.8.0", "", {}, "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ=="],
 
-    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
+    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
 
-    "whatwg-encoding": ["whatwg-encoding@2.0.0", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg=="],
+    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
 
-    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
-
-    "whatwg-url": ["whatwg-url@12.0.1", "", { "dependencies": { "tr46": "^4.1.1", "webidl-conversions": "^7.0.0" } }, "sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ=="],
+    "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -1083,9 +1077,7 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
-
-    "xml-name-validator": ["xml-name-validator@4.0.0", "", {}, "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw=="],
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "wasm-feature-detect": "^1.8.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
     "@types/bun": "^1.3.14",
     "@types/node": "^25",
     "@types/react": "^19",
@@ -32,13 +35,10 @@
     "eslint": "^9",
     "eslint-config-next": "^15.1.8",
     "eslint-plugin-jsx-a11y": "^6.10.2",
+    "jsdom": "^29.1.1",
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
     "typescript": "^5",
-    "vitest": "^4.1.6",
-    "@testing-library/react": "^14.0.0",
-    "@testing-library/user-event": "^14.4.3",
-    "jsdom": "^22.1.0",
-    "@testing-library/jest-dom": "^6.0.0"
+    "vitest": "^4.1.6"
   }
 }

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -457,7 +457,7 @@ export function useVideoEditor() {
       if (result?.blobUrl) URL.revokeObjectURL(result.blobUrl);
       setResult(null);
 
-      const ffmpeg = await loadFFmpeg(abortController.signal);
+      await loadFFmpeg(abortController.signal, setProgress);
       if (exportCancelledRef.current) return;
 
       const startedAt = Date.now();
@@ -465,7 +465,6 @@ export function useVideoEditor() {
       setStatus("exporting");
 
       const exportResult = await exportVideo(
-        ffmpeg,
         file,
         recipe,
         setProgress,
@@ -548,13 +547,13 @@ export function useVideoEditor() {
   useEffect(() => {
     const shouldWarn =
       status === "exporting" ||
-      status === "loading-engine" ||
-      status === "done";
+      status === "loading-engine";
 
     if (!shouldWarn) return;
 
     const handler = (e: BeforeUnloadEvent) => {
       e.preventDefault();
+      e.returnValue = "";
     };
 
     window.addEventListener("beforeunload", handler);

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -1,94 +1,319 @@
-import { FFmpeg } from "@ffmpeg/ffmpeg";
-import { fetchFile, toBlobURL } from "@ffmpeg/util";
 import { EditRecipe, ExportResult, BackgroundMusicOptions, ImageOverlayOptions } from "./types";
 import { getPresetById } from "./presets";
 import { buildTextFilter } from "./text-overlay";
-import { simd } from "wasm-feature-detect";
 
-const CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd";
+export class FFmpegLoadError extends Error {}
 
-// Added from main branch for subresource security verification
-const SRI_HASHES: Record<string, string> = {
-  "ffmpeg-core.js":   "sha384-sKfkiFtvUk+vexk+0EUhEh366190/4WpgUAsUvaxEfyg7+E1Zt5Y5hrsU808g8Q9",
-  "ffmpeg-core.wasm": "sha384-U1VDhkPYrM3wTCT4/vjSpSsKqG/UjljYrYCI4hBSJ02svbCkxuCi6U6u/peg5vpW",
+const FFMPEG_WORKER_URL =
+  typeof window !== "undefined"
+    ? new URL("./ffmpeg.worker.ts", import.meta.url)
+    : null;
+
+type SerializedFile = {
+  name: string;
+  type: string;
+  data: ArrayBuffer;
 };
 
-// Added from main branch to perform secure binary verification
-async function fetchWithIntegrity(url: string, mimeType: string): Promise<string> {
-  const key = url.split("/").pop()!;
-  const integrity = SRI_HASHES[key];
+type WorkerExportRequest = {
+  type: "export";
+  id: string;
+  file: SerializedFile;
+  recipe: EditRecipe;
+  videoDuration: number;
+  musicFile?: SerializedFile;
+  musicOptions?: BackgroundMusicOptions;
+  overlayFile?: SerializedFile;
+  overlayOptions?: ImageOverlayOptions;
+};
 
-  if (!integrity) {
-    throw new Error(`[SRI] No hash found for: ${key}`);
+type WorkerLoadResponse = { type: "ready" };
+type WorkerProgressResponse = { type: "progress"; percent: number };
+type WorkerResultResponse = {
+  type: "result";
+  id: string;
+  data: ArrayBuffer;
+  mimeType: string;
+  size: number;
+  width: number;
+  height: number;
+  format: "mp4" | "webm" | "mkv" | "gif";
+};
+type WorkerErrorResponse = { type: "error"; id?: string; message: string };
+type WorkerCancelledResponse = { type: "cancelled"; id?: string };
+
+type WorkerResponse =
+  | WorkerLoadResponse
+  | WorkerProgressResponse
+  | WorkerResultResponse
+  | WorkerErrorResponse
+  | WorkerCancelledResponse;
+
+let ffmpegWorker: Worker | null = null;
+let workerReady: Promise<void> | null = null;
+let workerReadyResolve: (() => void) | null = null;
+let workerReadyReject: ((reason?: any) => void) | null = null;
+let pendingExport: {
+  id: string;
+  resolve: (result: ExportResult) => void;
+  reject: (reason: unknown) => void;
+} | null = null;
+let pendingProgress: ((percent: number) => void) | null = null;
+
+function createWorker(): Worker {
+  if (!FFMPEG_WORKER_URL) {
+    throw new Error("Web Workers are not available in this environment.");
   }
 
-  const res = await fetch(url, { integrity, credentials: "omit" });
-  const blob = new Blob([await res.arrayBuffer()], { type: mimeType });
-  return URL.createObjectURL(blob);
+  ffmpegWorker = new Worker(FFMPEG_WORKER_URL, { type: "module" });
+  ffmpegWorker.onmessage = handleWorkerMessage;
+  ffmpegWorker.onerror = (event) => {
+    const message = event.message || "FFmpeg worker error";
+    const error = new FFmpegLoadError(message);
+    workerReadyReject?.(error);
+    pendingExport?.reject(error);
+    resetWorker();
+  };
+
+  workerReady = new Promise((resolve, reject) => {
+    workerReadyResolve = resolve;
+    workerReadyReject = reject;
+  });
+
+  return ffmpegWorker;
 }
 
-let ffmpegInstance: FFmpeg | null = null;
+function resetWorker() {
+  ffmpegWorker = null;
+  workerReady = null;
+  workerReadyResolve = null;
+  workerReadyReject = null;
+  pendingExport = null;
+  pendingProgress = null;
+}
 
-/**
- * Error thrown when the FFmpeg WebAssembly core fails to load.
- */
-export class FFmpegLoadError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "FFmpegLoadError";
+function handleWorkerMessage(event: MessageEvent<WorkerResponse>) {
+  const data = event.data;
+
+  if (data.type === "ready") {
+    workerReadyResolve?.();
+    workerReadyResolve = null;
+    workerReadyReject = null;
+    pendingProgress?.(100);
+    return;
+  }
+
+  if (data.type === "progress") {
+    pendingProgress?.(data.percent);
+    return;
+  }
+
+  if (data.type === "result") {
+    if (pendingExport?.id !== data.id) return;
+    const blob = new Blob([data.data], { type: data.mimeType });
+    pendingExport.resolve({
+      blobUrl: URL.createObjectURL(blob),
+      blob,
+      size: data.size,
+      width: data.width,
+      height: data.height,
+      format: data.format,
+    });
+    pendingExport = null;
+    pendingProgress = null;
+    return;
+  }
+
+  if (data.type === "error") {
+    if (data.id && pendingExport?.id === data.id) {
+      pendingExport.reject(new Error(data.message));
+      pendingExport = null;
+      pendingProgress = null;
+      return;
+    }
+
+    workerReadyReject?.(new FFmpegLoadError(data.message));
+    workerReady = null;
+    workerReadyResolve = null;
+    workerReadyReject = null;
+    resetWorker();
+    return;
+  }
+
+  if (data.type === "cancelled") {
+    if (data.id && pendingExport?.id === data.id) {
+      pendingExport.reject(new DOMException("Export cancelled", "AbortError"));
+      pendingExport = null;
+      pendingProgress = null;
+    }
+    return;
+  }
+}
+
+async function ensureWorker() {
+  if (!ffmpegWorker) {
+    createWorker();
   }
 }
 
 export async function loadFFmpeg(
   signal?: AbortSignal,
   onProgress?: (percent: number) => void
-): Promise<FFmpeg> {
-  if (ffmpegInstance?.loaded) {
+): Promise<void> {
+  await ensureWorker();
+
+  if (workerReady && workerReadyResolve === null) {
     onProgress?.(100);
-    return ffmpegInstance;
+    return;
   }
 
-  const ffmpeg = ffmpegInstance ?? new FFmpeg();
-  ffmpegInstance = ffmpeg;
+  if (!workerReady) {
+    ffmpegWorker!.postMessage({ type: "load" });
+  }
 
-  const handleProgress = ({ progress }: { progress: number }) => {
-    onProgress?.(Math.round(progress * 100));
+  pendingProgress = onProgress ?? null;
+
+  if (signal?.aborted) {
+    ffmpegWorker?.postMessage({ type: "cancel" });
+    throw new DOMException("Aborted", "AbortError");
+  }
+
+  const cleanup = () => {
+    signal?.removeEventListener("abort", onAbort);
   };
 
+  const onAbort = () => {
+    ffmpegWorker?.postMessage({ type: "cancel" });
+    workerReadyReject?.(new DOMException("Aborted", "AbortError"));
+    cleanup();
+  };
+
+  signal?.addEventListener("abort", onAbort, { once: true });
+
   try {
-    ffmpeg.on("progress", handleProgress);
-
-    const isIsolated = typeof self !== "undefined" && self.crossOriginIsolated;
-    const baseURL = isIsolated
-      ? "https://unpkg.com/@ffmpeg/core-mt@0.12.6/dist/esm"
-      : "https://unpkg.com/@ffmpeg/core@0.12.6/dist/esm";
-
-    await ffmpeg.load({
-      coreURL: await toBlobURL(`${baseURL}/ffmpeg-core.js`, "text/javascript"),
-      wasmURL: await toBlobURL(`${baseURL}/ffmpeg-core.wasm`, "application/wasm"),
-      ...(isIsolated && {
-        workerURL: await toBlobURL(
-          `${baseURL}/ffmpeg-core.worker.js`,
-          "text/javascript"
-        ),
-      }),
-    }, { signal });
-
-    onProgress?.(100);
-    return ffmpeg;
-  } catch (err) {
-    if (ffmpegInstance === ffmpeg) {
-      ffmpegInstance = null;
-    }
-    throw new FFmpegLoadError("Failed to load the FFmpeg engine. Check your internet connection.");
+    await workerReady;
   } finally {
-    ffmpeg.off("progress", handleProgress);
+    cleanup();
   }
 }
 
+function cancelPendingExport(reason?: unknown) {
+  if (pendingExport) {
+    pendingExport.reject(reason ?? new DOMException("Export cancelled", "AbortError"));
+    pendingExport = null;
+  }
+  pendingProgress = null;
+}
+
+export async function exportVideo(
+  file: File,
+  recipe: EditRecipe,
+  onProgress: (percent: number) => void,
+  signal?: AbortSignal,
+  musicOptions?: BackgroundMusicOptions,
+  overlayOptions?: ImageOverlayOptions
+): Promise<ExportResult> {
+  await loadFFmpeg(signal, onProgress);
+
+  if (!ffmpegWorker) {
+    throw new Error("FFmpeg worker is not available.");
+  }
+
+  const sessionId = buildSessionId();
+  const arrayBuffer = await file.arrayBuffer();
+  const filePayload: SerializedFile = {
+    name: file.name,
+    type: file.type || "video/mp4",
+    data: arrayBuffer,
+  };
+
+  const musicFilePayload = musicOptions?.file
+    ? {
+        name: musicOptions.file.name,
+        type: musicOptions.file.type || "audio/mpeg",
+        data: await musicOptions.file.arrayBuffer(),
+      }
+    : undefined;
+
+  const overlayFilePayload = overlayOptions?.file
+    ? {
+        name: overlayOptions.file.name,
+        type: overlayOptions.file.type || "image/png",
+        data: await overlayOptions.file.arrayBuffer(),
+      }
+    : undefined;
+
+  const sanitizedMusicOptions = musicOptions
+    ? { ...musicOptions, file: null }
+    : undefined;
+  const sanitizedOverlayOptions = overlayOptions
+    ? { ...overlayOptions, file: null }
+    : undefined;
+
+  pendingProgress = onProgress;
+
+  const exportPromise = new Promise<ExportResult>((resolve, reject) => {
+    pendingExport = { id: sessionId, resolve, reject };
+  });
+
+  if (signal?.aborted) {
+    ffmpegWorker.postMessage({ type: "cancel" });
+    cancelPendingExport(new DOMException("Aborted", "AbortError"));
+    throw new DOMException("Aborted", "AbortError");
+  }
+
+  const onAbort = () => {
+    ffmpegWorker?.postMessage({ type: "cancel" });
+    cancelPendingExport(new DOMException("Aborted", "AbortError"));
+  };
+  signal?.addEventListener("abort", onAbort, { once: true });
+
+  const transfers: Transferable[] = [arrayBuffer];
+  if (musicFilePayload) transfers.push(musicFilePayload.data);
+  if (overlayFilePayload) transfers.push(overlayFilePayload.data);
+
+  ffmpegWorker.postMessage(
+    {
+      type: "export",
+      id: sessionId,
+      file: filePayload,
+      recipe,
+      videoDuration: await getVideoDuration(file),
+      musicFile: musicFilePayload,
+      musicOptions: sanitizedMusicOptions,
+      overlayFile: overlayFilePayload,
+      overlayOptions: sanitizedOverlayOptions,
+    } as WorkerExportRequest,
+    transfers
+  );
+
+  try {
+    return await exportPromise;
+  } finally {
+    signal?.removeEventListener("abort", onAbort);
+  }
+}
+
+async function getVideoDuration(file: File): Promise<number> {
+  return new Promise((resolve) => {
+    const video = document.createElement("video");
+    video.preload = "metadata";
+    video.onloadedmetadata = () => {
+      URL.revokeObjectURL(video.src);
+      resolve(video.duration);
+    };
+    video.onerror = () => resolve(0);
+    video.src = URL.createObjectURL(file);
+  });
+}
+
 export function terminateFFmpeg() {
-  ffmpegInstance?.terminate();
-  ffmpegInstance = null;
+  if (ffmpegWorker) {
+    ffmpegWorker.postMessage({ type: "terminate" });
+    ffmpegWorker.terminate();
+  }
+  cancelPendingExport(new DOMException("Export cancelled", "AbortError"));
+  resetWorker();
 }
 
 function buildSessionId(): string {
@@ -328,227 +553,6 @@ function buildArguments(
 
   args.push(outputName);
   return args;
-}
-
-export async function exportVideo(
-  ffmpeg: FFmpeg,
-  file: File,
-  recipe: EditRecipe,
-  onProgress: (percent: number) => void,
-  signal?: AbortSignal,
-  musicOptions?: BackgroundMusicOptions,
-  overlayOptions?: ImageOverlayOptions
-): Promise<ExportResult> {
-  const sessionId = buildSessionId();
-  let targetW: number, targetH: number;
-  if (recipe.preset === "custom") {
-    targetW = recipe.customWidth;
-    targetH = recipe.customHeight;
-  } else {
-    const preset = getPresetById(recipe.preset);
-    targetW = preset?.width ?? 1920;
-    targetH = preset?.height ?? 1080;
-  }
-
-  targetW = Math.round(targetW / 2) * 2;
-  targetH = Math.round(targetH / 2) * 2;
-
-  const ext = file.name.split(".").pop() ?? "mp4";
-  const inputName = `input_${sessionId}.${ext}`;
-
-  const getOutputConfig = (format: string) => {
-    switch (format) {
-      case "webm":
-        return { filename: `output_${sessionId}.webm`, mimeType: "video/webm" };
-      case "mkv":
-        return { filename: `output_${sessionId}.mkv`, mimeType: "video/x-matroska" };
-      case "gif":
-        return { filename: `output_${sessionId}.gif`, mimeType: "image/gif" };
-      default:
-        return { filename: `output_${sessionId}.mp4`, mimeType: "video/mp4" };
-    }
-  };
-
-  const { filename: outputName, mimeType } = getOutputConfig(recipe.format);
-  const fallbackOutputName = `fallback_${sessionId}.webm`;
-  const paletteName = `palette_${sessionId}.png`;
-  const cleanupFiles = new Set<string>([inputName, outputName, fallbackOutputName, paletteName]);
-
-  const handleProgress = ({ progress }: { progress: number }) => {
-    onProgress(Math.min(99, Math.round(progress * 100)));
-  };
-
-  // Read actual video duration via HTMLVideoElement so we can correctly
-  // compute output duration when trimEnd is null (no trim set by user).
-  // Falls back to trimEnd if metadata loading fails.
-  const videoDuration = await new Promise<number>((resolve) => {
-    const video = document.createElement("video");
-    video.preload = "metadata";
-    video.onloadedmetadata = () => {
-      URL.revokeObjectURL(video.src);
-      resolve(video.duration);
-    };
-    video.onerror = () => {
-      // Safe fallback: use trimEnd if available, otherwise 0 which
-      // will produce no -t argument and leave duration uncapped.
-      resolve(recipe.trimEnd ?? 0);
-    };
-    video.src = URL.createObjectURL(file);
-  });
-
-  try {
-    await ffmpeg.writeFile(inputName, await fetchFile(file), { signal });
-
-    const hasMusicTrack = !!(musicOptions?.file && recipe.keepAudio);
-    const musicInputName = `music_input_${sessionId}.mp3`;
-    if (hasMusicTrack) {
-      await ffmpeg.writeFile(musicInputName, await fetchFile(musicOptions!.file!), { signal });
-      cleanupFiles.add(musicInputName);
-    }
-
-    const hasOverlay = !!overlayOptions?.file;
-    const overlayExt = overlayOptions?.file?.name.split(".").pop() ?? "png";
-    const overlayInputName = `overlay_${sessionId}.${overlayExt}`;
-    if (hasOverlay) {
-      await ffmpeg.writeFile(overlayInputName, await fetchFile(overlayOptions!.file!), { signal });
-      cleanupFiles.add(overlayInputName);
-    }
-
-    ffmpeg.on("progress", handleProgress);
-
-    // ── Two-pass GIF export ──────────────────────────────────────────────────
-    if (recipe.format === "gif") {
-      const vf = buildVideoFilter(recipe, targetW, targetH);
-      const vfWithPalette = vf ? `${vf},palettegen` : "palettegen";
-      const vfWithPaletteUse = vf
-        ? `[0:v]${vf}[x];[x][1:v]paletteuse`
-        : "[0:v][1:v]paletteuse";
-
-      // Add explicit output duration when speed != 1 to prevent slight duration
-      // overshoot caused by encoder/filter pipeline frame flush at stream end.
-      // Applied to both passes so palette and render are bounded identically.
-      const gifDurationArgs: string[] =
-        recipe.speed !== 1
-          ? (() => {
-              const sourceDuration =
-                (recipe.trimEnd ?? videoDuration) - recipe.trimStart;
-              const outputDuration = sourceDuration / recipe.speed;
-              return ["-t", outputDuration.toFixed(6)];
-            })()
-          : [];
-
-      // Pass 1: generate colour palette
-      const pass1Code = await ffmpeg.exec(
-        ["-i", inputName, "-vf", vfWithPalette, ...gifDurationArgs, "-y", paletteName],
-        undefined,
-        { signal }
-      );
-      if (pass1Code !== 0) throw new Error("GIF palette generation failed");
-
-      // Pass 2: render GIF using the palette
-      const pass2Code = await ffmpeg.exec(
-        ["-i", inputName, "-i", paletteName, "-lavfi", vfWithPaletteUse, ...gifDurationArgs, "-y", outputName],
-        undefined,
-        { signal }
-      );
-      if (pass2Code !== 0) throw new Error("GIF export failed");
-
-      const data = await ffmpeg.readFile(outputName, undefined, { signal });
-      const blob = new Blob([new Uint8Array(data as Uint8Array)], { type: "image/gif" });
-
-      ffmpeg.off("progress", handleProgress);
-      onProgress(100);
-      return {
-        blobUrl: URL.createObjectURL(blob),
-        blob,
-        size: blob.size,
-        width: targetW,
-        height: targetH,
-        format: "gif" as const,
-      };
-    }
-    // ────────────────────────────────────────────────────────────────────────
-
-    let missingAudioDetected = false;
-    const logListener = ({ message }: { message: string }) => {
-      const msg = message.toLowerCase();
-      if (
-        msg.includes("matches no streams") ||
-        msg.includes("specifier '0:a'") ||
-        msg.includes("input pad 0 on filter src")
-      ) {
-        missingAudioDetected = true;
-      }
-    };
-    ffmpeg.on("log", logListener);
-
-    // Attempt 1: Process with standard audio streams
-    let args = buildArguments(
-      recipe, recipe.format, outputName, inputName, targetW, targetH,
-      hasMusicTrack, musicInputName, musicOptions,
-      hasOverlay, overlayInputName, overlayOptions, true, videoDuration
-    );
-
-    let exitCode = await ffmpeg.exec(args, undefined, { signal });
-
-    // Attempt 2: Auto-recover if the file has no original audio track
-    if (exitCode !== 0 && missingAudioDetected) {
-      missingAudioDetected = false;
-      args = buildArguments(
-        recipe, recipe.format, outputName, inputName, targetW, targetH,
-        hasMusicTrack, musicInputName, musicOptions,
-        hasOverlay, overlayInputName, overlayOptions, false, videoDuration
-      );
-      exitCode = await ffmpeg.exec(args, undefined, { signal });
-    }
-
-    // Fallback Attempt 3: Switch codecs to WebM if container errors happen
-    if (exitCode !== 0) {
-      args = buildArguments(
-        recipe, "webm", fallbackOutputName, inputName, targetW, targetH,
-        hasMusicTrack, musicInputName, musicOptions,
-        hasOverlay, overlayInputName, overlayOptions, !missingAudioDetected, videoDuration
-      );
-
-      const fallbackCode = await ffmpeg.exec(args, undefined, { signal });
-      if (fallbackCode !== 0) throw new Error("Export failed");
-
-      const data = await ffmpeg.readFile(fallbackOutputName, undefined, { signal });
-      const blob = new Blob([new Uint8Array(data as Uint8Array)], { type: "video/webm" });
-
-      ffmpeg.off("log", logListener);
-      onProgress(100);
-      return {
-        blobUrl: URL.createObjectURL(blob),
-        blob,
-        size: blob.size,
-        width: targetW,
-        height: targetH,
-        format: "webm",
-      };
-    }
-
-    const data = await ffmpeg.readFile(outputName, undefined, { signal });
-    const blob = new Blob([new Uint8Array(data as Uint8Array)], { type: mimeType });
-
-    ffmpeg.off("log", logListener);
-    onProgress(100);
-    return {
-      blobUrl: URL.createObjectURL(blob),
-      blob,
-      size: blob.size,
-      width: targetW,
-      height: targetH,
-      format: recipe.format as "mp4" | "webm" | "mkv",
-    };
-  } finally {
-    ffmpeg.off("progress", handleProgress);
-    for (const path of cleanupFiles) {
-      try {
-        await ffmpeg.deleteFile(path);
-      } catch {}
-    }
-  }
 }
 
 export function formatBytes(bytes: number): string {

--- a/src/lib/ffmpeg.worker.ts
+++ b/src/lib/ffmpeg.worker.ts
@@ -1,0 +1,680 @@
+import { FFmpeg } from "@ffmpeg/ffmpeg";
+import { toBlobURL } from "@ffmpeg/util";
+import { EditRecipe, BackgroundMusicOptions, ImageOverlayOptions } from "./types";
+import { getPresetById } from "./presets";
+import { buildTextFilter } from "./text-overlay";
+
+const CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd";
+const MT_CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core-mt@0.12.6/dist/esm";
+const SRI_HASHES: Record<string, string> = {
+  "ffmpeg-core.js":   "sha384-sKfkiFtvUk+vexk+0EUhEh366190/4WpgUAsUvaxEfyg7+E1Zt5Y5hrsU808g8Q9",
+  "ffmpeg-core.wasm": "sha384-U1VDhkPYrM3wTCT4/vjSpSsKqG/UjljYrYCI4hBSJ02svbCkxuCi6U6u/peg5vpW",
+};
+
+type SerializedFile = {
+  name: string;
+  type: string;
+  data: ArrayBuffer;
+};
+
+type ExportRequest = {
+  type: "export";
+  id: string;
+  file: SerializedFile;
+  recipe: EditRecipe;
+  videoDuration: number;
+  musicFile?: SerializedFile;
+  musicOptions?: BackgroundMusicOptions;
+  overlayFile?: SerializedFile;
+  overlayOptions?: ImageOverlayOptions;
+};
+
+type LoadRequest = { type: "load" };
+
+type CancelRequest = { type: "cancel" };
+
+type TerminateRequest = { type: "terminate" };
+
+type WorkerCommand = LoadRequest | ExportRequest | CancelRequest | TerminateRequest;
+
+type ProgressPayload = { type: "progress"; percent: number };
+
+type ReadyPayload = { type: "ready" };
+
+type ResultPayload = {
+  type: "result";
+  id: string;
+  data: ArrayBuffer;
+  mimeType: string;
+  size: number;
+  width: number;
+  height: number;
+  format: "mp4" | "webm" | "mkv" | "gif";
+};
+
+type ErrorPayload = { type: "error"; id?: string; message: string };
+
+type CancelledPayload = { type: "cancelled"; id?: string };
+
+type WorkerResponse = ProgressPayload | ReadyPayload | ResultPayload | ErrorPayload | CancelledPayload;
+
+let ffmpeg: FFmpeg | null = null;
+let ffmpegLoaded = false;
+let activeExportAbortController: AbortController | null = null;
+let activeExportId: string | null = null;
+
+async function fetchWithIntegrity(url: string, mimeType: string): Promise<string> {
+  const key = url.split("/").pop()!;
+  const integrity = SRI_HASHES[key];
+
+  if (!integrity) {
+    throw new Error(`[SRI] No hash found for: ${key}`);
+  }
+
+  const response = await fetch(url, { integrity, credentials: "omit" });
+  const blob = new Blob([await response.arrayBuffer()], { type: mimeType });
+  return URL.createObjectURL(blob);
+}
+
+function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number): string {
+  const filters: string[] = [];
+
+  if (recipe.trimStart > 0 || recipe.trimEnd !== null) {
+    const end = recipe.trimEnd !== null ? recipe.trimEnd : 999999;
+    filters.push(`trim=start=${recipe.trimStart}:end=${end}`);
+  }
+
+  if (recipe.stabilization) {
+    filters.push("deshake");
+  }
+
+  if (recipe.rotate === 90) {
+    filters.push("transpose=1");
+  } else if (recipe.rotate === 180) {
+    filters.push("transpose=1,transpose=1");
+  } else if (recipe.rotate === 270) {
+    filters.push("transpose=2");
+  }
+
+  if (recipe.framing === "fit") {
+    filters.push(
+      `scale=${targetW}:${targetH}:force_original_aspect_ratio=decrease`,
+      `pad=${targetW}:${targetH}:(ow-iw)/2:(oh-ih)/2:color=black`
+    );
+  } else {
+    filters.push(
+      `scale=${targetW}:${targetH}:force_original_aspect_ratio=increase`,
+      `crop=${targetW}:${targetH}`
+    );
+  }
+
+  if (recipe.trimStart > 0 || recipe.trimEnd !== null || recipe.speed !== 1) {
+    filters.push("setpts=PTS-STARTPTS");
+  }
+
+  if (recipe.speed !== 1) {
+    const pts = (1 / recipe.speed).toFixed(4);
+    filters.push(`setpts=${pts}*PTS`);
+  }
+
+  if (recipe.denoise) {
+    filters.push("hqdn3d=1.5:1.5:6:6");
+  }
+
+  const needsEq =
+    recipe.brightness !== 0 ||
+    recipe.contrast !== 1 ||
+    recipe.saturation !== 1;
+
+  if (needsEq) {
+    filters.push(
+      `eq=brightness=${recipe.brightness}:contrast=${recipe.contrast}:saturation=${recipe.saturation}`
+    );
+  }
+
+  const textOverlays = recipe.textOverlays || [];
+  textOverlays.forEach((overlay) => {
+    filters.push(buildTextFilter(overlay, targetW, targetH));
+  });
+
+  return filters.join(",");
+}
+
+function buildAudioFilter(speed: number, normalizeAudio: boolean): string {
+  if (speed <= 0) return "";
+  const filters: string[] = [];
+
+  let remaining = speed;
+  while (remaining < 0.5) {
+    filters.push("atempo=0.5");
+    remaining /= 0.5;
+  }
+
+  while (remaining > 2.0) {
+    filters.push("atempo=2.0");
+    remaining /= 2.0;
+  }
+
+  if (Math.abs(remaining - 1.0) > 0.001) {
+    filters.push(`atempo=${Number(remaining.toFixed(4))}`);
+  }
+
+  if (normalizeAudio) filters.push("loudnorm=I=-14:TP=-1.5:LRA=11");
+
+  return filters.join(",");
+}
+
+function buildAudioTrimFilter(recipe: EditRecipe): string {
+  if (recipe.trimStart === 0 && recipe.trimEnd === null) return "";
+  const end = recipe.trimEnd !== null ? recipe.trimEnd : 999999;
+  return `atrim=start=${recipe.trimStart}:end=${end},asetpts=PTS-STARTPTS`;
+}
+
+function buildArguments(
+  recipe: EditRecipe,
+  format: "mp4" | "webm" | "mkv" | "gif",
+  outputName: string,
+  inputName: string,
+  targetW: number,
+  targetH: number,
+  hasMusicTrack: boolean,
+  musicInputName: string,
+  musicOptions: BackgroundMusicOptions | undefined,
+  hasOverlay: boolean,
+  overlayInputName: string,
+  overlayOptions: ImageOverlayOptions | undefined,
+  hasOriginalAudio: boolean,
+  videoDuration: number
+): string[] {
+  const vf = buildVideoFilter(recipe, targetW, targetH);
+  const audioTrim = hasOriginalAudio ? buildAudioTrimFilter(recipe) : "";
+  const audioSpeed = hasOriginalAudio ? buildAudioFilter(recipe.speed, recipe.normalizeAudio ?? false) : "";
+  const afParts = [audioTrim, audioSpeed].filter(Boolean);
+  const af = afParts.join(",");
+
+  const musicIdx = 1;
+  const overlayIdx = hasMusicTrack ? 2 : 1;
+
+  const args: string[] = [];
+  args.push("-i", inputName);
+  if (hasMusicTrack) {
+    if (musicOptions!.loopMusic) args.push("-stream_loop", "-1");
+    args.push("-i", musicInputName);
+  }
+  if (hasOverlay) {
+    args.push("-i", overlayInputName);
+  }
+
+  const needsFilterComplex = hasOverlay || hasMusicTrack;
+  const shouldKeepAudio = recipe.keepAudio && (hasOriginalAudio || hasMusicTrack);
+
+  if (needsFilterComplex) {
+    const filterParts: string[] = [];
+    let videoOut = "[0:v]";
+
+    if (vf) {
+      filterParts.push(`[0:v]${vf}[vbase]`);
+      videoOut = "[vbase]";
+    }
+
+    if (hasOverlay) {
+      const scaledW = overlayOptions!.size;
+      const alpha = (overlayOptions!.opacity / 100).toFixed(2);
+      const posMap: Record<string, string> = {
+        "top-left":     "20:20",
+        "top-right":    "W-w-20:20",
+        "bottom-left":  "20:H-h-20",
+        "bottom-right": "W-w-20:H-h-20",
+      };
+      const pos = posMap[overlayOptions!.position] ?? "W-w-20:H-h-20";
+      filterParts.push(`[${overlayIdx}:v]scale=${scaledW}:-2,format=rgba,colorchannelmixer=aa=${alpha}[logo]`);
+      filterParts.push(`${videoOut}[logo]overlay=${pos}[vout]`);
+      videoOut = "[vout]";
+    }
+
+    let audioOut = "";
+    if (shouldKeepAudio) {
+      if (hasMusicTrack) {
+        const musicVol = (musicOptions!.musicVolume / 100).toFixed(2);
+        if (hasOriginalAudio) {
+          const origVol = (musicOptions!.originalAudioVolume / 100).toFixed(2);
+          const origChain = afParts.length > 0
+            ? `[0:a]${afParts.join(",")},volume=${origVol}[orig]`
+            : `[0:a]volume=${origVol}[orig]`;
+          filterParts.push(origChain);
+          filterParts.push(`[${musicIdx}:a]volume=${musicVol}[music]`);
+          filterParts.push(`[orig][music]amix=inputs=2:duration=first:dropout_transition=0[aout]`);
+          audioOut = "[aout]";
+        } else {
+          filterParts.push(`[${musicIdx}:a]volume=${musicVol}[aout]`);
+          audioOut = "[aout]";
+        }
+      } else if (hasOriginalAudio && af) {
+        filterParts.push(`[0:a]${af}[aout]`);
+        audioOut = "[aout]";
+      }
+    }
+
+    if (filterParts.length > 0) {
+      args.push("-filter_complex", filterParts.join(";"));
+    }
+    args.push("-map", videoOut === "[0:v]" ? "0:v" : videoOut);
+
+    if (!shouldKeepAudio) {
+      args.push("-an");
+    } else if (audioOut) {
+      args.push("-map", audioOut);
+    } else if (hasOriginalAudio) {
+      args.push("-map", "0:a");
+    }
+  } else {
+    if (vf) args.push("-vf", vf);
+    if (!shouldKeepAudio) {
+      args.push("-an");
+    } else if (af && hasOriginalAudio) {
+      args.push("-af", af);
+    }
+  }
+
+  if (format === "webm") {
+    args.push(
+      "-c:v", "libvpx-vp9",
+      "-b:v", "0",
+      "-crf", String(recipe.quality),
+      "-cpu-used", "4",
+      "-deadline", "realtime"
+    );
+    if (shouldKeepAudio) args.push("-c:a", "libopus");
+  } else if (format === "mkv") {
+    args.push("-c:v", "libx264", "-crf", String(recipe.quality), "-preset", "ultrafast");
+    if (shouldKeepAudio) args.push("-c:a", "aac", "-b:a", "128k");
+  } else {
+    args.push("-c:v", "libx264", "-crf", String(recipe.quality), "-preset", "ultrafast", "-movflags", "+faststart");
+    if (shouldKeepAudio) args.push("-c:a", "aac", "-b:a", "128k");
+  }
+
+  if (recipe.speed !== 1) {
+    const sourceDuration = (recipe.trimEnd ?? videoDuration) - recipe.trimStart;
+    const outputDuration = sourceDuration / recipe.speed;
+    args.push("-t", outputDuration.toFixed(6));
+  }
+
+  args.push(outputName);
+  return args;
+}
+
+async function loadCore(onProgress?: (percent: number) => void): Promise<void> {
+  if (ffmpegLoaded) {
+    onProgress?.(100);
+    return;
+  }
+
+  ffmpeg = new FFmpeg();
+
+  const isIsolated = typeof self !== "undefined" && self.crossOriginIsolated;
+  const baseURL = isIsolated ? MT_CORE_BASE_URL : CORE_BASE_URL;
+
+  const handleProgress = ({ progress }: { progress: number }) => {
+    onProgress?.(Math.round(progress * 100));
+  };
+
+  ffmpeg.on("progress", handleProgress);
+
+  try {
+    await ffmpeg.load({
+      coreURL: await fetchWithIntegrity(`${baseURL}/ffmpeg-core.js`, "text/javascript"),
+      wasmURL: await fetchWithIntegrity(`${baseURL}/ffmpeg-core.wasm`, "application/wasm"),
+      ...(isIsolated && {
+        workerURL: await fetchWithIntegrity(`${baseURL}/ffmpeg-core.worker.js`, "text/javascript"),
+      }),
+    });
+
+    ffmpegLoaded = true;
+    onProgress?.(100);
+  } finally {
+    ffmpeg.off("progress", handleProgress);
+  }
+}
+
+function serializeFileBuffer(file: SerializedFile): Uint8Array {
+  return new Uint8Array(file.data);
+}
+
+function getOutputConfig(format: string, sessionId: string) {
+  switch (format) {
+    case "webm":
+      return { filename: `output_${sessionId}.webm`, mimeType: "video/webm" };
+    case "mkv":
+      return { filename: `output_${sessionId}.mkv`, mimeType: "video/x-matroska" };
+    case "gif":
+      return { filename: `output_${sessionId}.gif`, mimeType: "image/gif" };
+    default:
+      return { filename: `output_${sessionId}.mp4`, mimeType: "video/mp4" };
+  }
+}
+
+async function removeFile(path: string) {
+  if (!ffmpeg) return;
+  try {
+    await ffmpeg.deleteFile(path);
+  } catch {
+    // ignore cleanup failures
+  }
+}
+
+async function runExport(request: ExportRequest): Promise<ResultPayload> {
+  if (!ffmpeg) throw new Error("FFmpeg engine is not loaded.");
+  if (activeExportAbortController?.signal.aborted) {
+    throw new Error("Export cancelled");
+  }
+
+  const sessionId = request.id;
+  const recipe = request.recipe;
+  let targetW: number;
+  let targetH: number;
+
+  if (recipe.preset === "custom") {
+    targetW = recipe.customWidth;
+    targetH = recipe.customHeight;
+  } else {
+    const preset = getPresetById(recipe.preset);
+    targetW = preset?.width ?? 1920;
+    targetH = preset?.height ?? 1080;
+  }
+
+  targetW = Math.round(targetW / 2) * 2;
+  targetH = Math.round(targetH / 2) * 2;
+
+  const ext = request.file.name.split(".").pop() ?? "mp4";
+  const inputName = `input_${sessionId}.${ext}`;
+
+  const { filename: outputName, mimeType } = getOutputConfig(recipe.format, sessionId);
+  const fallbackOutputName = `fallback_${sessionId}.webm`;
+  const paletteName = `palette_${sessionId}.png`;
+  const cleanupFiles = new Set<string>([inputName, outputName, fallbackOutputName, paletteName]);
+
+  const fileBytes = serializeFileBuffer(request.file);
+  await ffmpeg.writeFile(inputName, fileBytes, { signal: activeExportAbortController?.signal });
+
+  const hasMusicTrack = !!(request.musicFile && recipe.keepAudio);
+  const musicInputName = `music_input_${sessionId}.mp3`;
+  if (hasMusicTrack) {
+    cleanupFiles.add(musicInputName);
+    await ffmpeg.writeFile(musicInputName, serializeFileBuffer(request.musicFile!), {
+      signal: activeExportAbortController?.signal,
+    });
+  }
+
+  const hasOverlay = !!request.overlayFile;
+  const overlayExt = request.overlayFile?.name.split(".").pop() ?? "png";
+  const overlayInputName = `overlay_${sessionId}.${overlayExt}`;
+  if (hasOverlay) {
+    cleanupFiles.add(overlayInputName);
+    await ffmpeg.writeFile(overlayInputName, serializeFileBuffer(request.overlayFile!), {
+      signal: activeExportAbortController?.signal,
+    });
+  }
+
+  const videoDuration = request.videoDuration;
+
+  const handleProgress = ({ progress }: { progress: number }) => {
+    if (activeExportId !== sessionId) return;
+    postMessage({ type: "progress", percent: Math.min(99, Math.round(progress * 100)) });
+  };
+
+  let logListener: ((event: { message: string }) => void) | null = null;
+  ffmpeg.on("progress", handleProgress);
+
+  try {
+    if (recipe.format === "gif") {
+      const vf = buildVideoFilter(recipe, targetW, targetH);
+      const vfWithPalette = vf ? `${vf},palettegen` : "palettegen";
+      const vfWithPaletteUse = vf
+        ? `[0:v]${vf}[x];[x][1:v]paletteuse`
+        : "[0:v][1:v]paletteuse";
+
+      const gifDurationArgs = recipe.speed !== 1
+        ? (() => {
+            const sourceDuration = (recipe.trimEnd ?? videoDuration) - recipe.trimStart;
+            const outputDuration = sourceDuration / recipe.speed;
+            return ["-t", outputDuration.toFixed(6)];
+          })()
+        : [];
+
+      const pass1Code = await ffmpeg.exec(
+        ["-i", inputName, "-vf", vfWithPalette, ...gifDurationArgs, "-y", paletteName],
+        undefined,
+        { signal: activeExportAbortController?.signal }
+      );
+      if (pass1Code !== 0) throw new Error("GIF palette generation failed");
+
+      const pass2Code = await ffmpeg.exec(
+        ["-i", inputName, "-i", paletteName, "-lavfi", vfWithPaletteUse, ...gifDurationArgs, "-y", outputName],
+        undefined,
+        { signal: activeExportAbortController?.signal }
+      );
+      if (pass2Code !== 0) throw new Error("GIF export failed");
+
+      const data = await ffmpeg.readFile(outputName, undefined, {
+        signal: activeExportAbortController?.signal,
+      });
+      const payload = (data as Uint8Array).buffer as ArrayBuffer;
+      return {
+        type: "result",
+        id: sessionId,
+        data: payload,
+        mimeType: "image/gif",
+        size: payload.byteLength,
+        width: targetW,
+        height: targetH,
+        format: "gif",
+      };
+    }
+
+    let missingAudioDetected = false;
+    const logListener = ({ message }: { message: string }) => {
+      const msg = message.toLowerCase();
+      if (
+        msg.includes("matches no streams") ||
+        msg.includes("specifier '0:a'") ||
+        msg.includes("input pad 0 on filter src")
+      ) {
+        missingAudioDetected = true;
+      }
+    };
+    ffmpeg.on("log", logListener);
+
+    let args = buildArguments(
+      recipe,
+      recipe.format,
+      outputName,
+      inputName,
+      targetW,
+      targetH,
+      hasMusicTrack,
+      musicInputName,
+      request.musicOptions,
+      hasOverlay,
+      overlayInputName,
+      request.overlayOptions,
+      true,
+      videoDuration
+    );
+
+    let exitCode = await ffmpeg.exec(args, undefined, {
+      signal: activeExportAbortController?.signal,
+    });
+
+    if (exitCode !== 0 && missingAudioDetected) {
+      missingAudioDetected = false;
+      args = buildArguments(
+        recipe,
+        recipe.format,
+        outputName,
+        inputName,
+        targetW,
+        targetH,
+        hasMusicTrack,
+        musicInputName,
+        request.musicOptions,
+        hasOverlay,
+        overlayInputName,
+        request.overlayOptions,
+        false,
+        videoDuration
+      );
+      exitCode = await ffmpeg.exec(args, undefined, {
+        signal: activeExportAbortController?.signal,
+      });
+    }
+
+    if (exitCode !== 0) {
+      args = buildArguments(
+        recipe,
+        "webm",
+        fallbackOutputName,
+        inputName,
+        targetW,
+        targetH,
+        hasMusicTrack,
+        musicInputName,
+        request.musicOptions,
+        hasOverlay,
+        overlayInputName,
+        request.overlayOptions,
+        !missingAudioDetected,
+        videoDuration
+      );
+
+      const fallbackCode = await ffmpeg.exec(args, undefined, {
+        signal: activeExportAbortController?.signal,
+      });
+      if (fallbackCode !== 0) throw new Error("Export failed");
+
+      const data = await ffmpeg.readFile(fallbackOutputName, undefined, {
+        signal: activeExportAbortController?.signal,
+      });
+      const payload = (data as Uint8Array).buffer as ArrayBuffer;
+      return {
+        type: "result",
+        id: sessionId,
+        data: payload,
+        mimeType: "video/webm",
+        size: payload.byteLength,
+        width: targetW,
+        height: targetH,
+        format: "webm",
+      };
+    }
+
+    const data = await ffmpeg.readFile(outputName, undefined, {
+      signal: activeExportAbortController?.signal,
+    });
+    const payload = (data as Uint8Array).buffer as ArrayBuffer;
+    return {
+      type: "result",
+      id: sessionId,
+      data: payload,
+      mimeType: mimeType,
+      size: payload.byteLength,
+      width: targetW,
+      height: targetH,
+      format: recipe.format,
+    };
+  } finally {
+    ffmpeg.off("progress", handleProgress);
+    if (logListener) ffmpeg.off("log", logListener);
+    for (const path of cleanupFiles) {
+      await removeFile(path);
+    }
+  }
+}
+
+function handleWorkerMessage(event: MessageEvent<WorkerResponse>) {
+  const data = event.data;
+  if (data.type === "progress") {
+    postMessage(data);
+    return;
+  }
+  if (data.type === "ready") {
+    postMessage(data);
+    return;
+  }
+  if (data.type === "result") {
+    postMessage(data);
+    return;
+  }
+  if (data.type === "error") {
+    postMessage(data);
+    return;
+  }
+  if (data.type === "cancelled") {
+    postMessage(data);
+    return;
+  }
+}
+
+async function handleCommand(message: WorkerCommand) {
+  switch (message.type) {
+    case "load": {
+      try {
+        await loadCore();
+        postMessage({ type: "ready" });
+      } catch (error) {
+        postMessage({ type: "error", message: (error as Error).message });
+      }
+      return;
+    }
+    case "export": {
+      if (!ffmpeg) {
+        postMessage({ type: "error", id: message.id, message: "FFmpeg engine is not loaded." });
+        return;
+      }
+      if (activeExportAbortController?.signal.aborted) {
+        postMessage({ type: "cancelled", id: message.id });
+        return;
+      }
+
+      activeExportAbortController = new AbortController();
+      activeExportId = message.id;
+
+      try {
+        const result = await runExport(message);
+        if (activeExportAbortController?.signal.aborted) {
+          postMessage({ type: "cancelled", id: message.id });
+          return;
+        }
+        postMessage({ ...result }, [result.data]);
+      } catch (error) {
+        if (activeExportAbortController?.signal.aborted) {
+          postMessage({ type: "cancelled", id: message.id });
+        } else {
+          postMessage({ type: "error", id: message.id, message: (error as Error).message });
+        }
+      } finally {
+        activeExportAbortController = null;
+        activeExportId = null;
+      }
+      return;
+    }
+    case "cancel": {
+      if (activeExportAbortController && !activeExportAbortController.signal.aborted) {
+        activeExportAbortController.abort();
+      }
+      return;
+    }
+    case "terminate": {
+      if (ffmpeg) ffmpeg.terminate();
+      ffmpeg = null;
+      ffmpegLoaded = false;
+      self.close();
+      return;
+    }
+  }
+}
+
+self.addEventListener("message", (event) => {
+  handleCommand(event.data as WorkerCommand).catch((error) => {
+    postMessage({ type: "error", message: (error as Error).message });
+  });
+});


### PR DESCRIPTION
## Description

This PR fixes the browser freezing issue caused by running FFmpeg.wasm exports on the main browser thread.

The export pipeline has been migrated to a dedicated Web Worker architecture so large video exports no longer block the UI thread. The UI now remains responsive during export operations, with improved progress handling and cancellation support.

## Related Issue

Closes #804

## Type of Contribution

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [x] Refactor
* [x] GSSoC contribution

## Participant Info

* GitHub username: YLaxmikanth
* Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Checklist

* [x] I have read the contribution guidelines
* [x] My changes follow the project structure
* [ ] I have tested my changes in Chrome, Firefox, and Safari
* [x] `bun run lint` passes (no ESLint errors)
* [x] `bunx tsc --noEmit` passes (no TypeScript errors)
* [x] New interactive elements have `aria-label` / accessible names
* [x] No `console.log` statements left in
* [x] This PR is related to a valid issue
* [ ] **Screen recording attached above** (required for UI/feature/design changes)

---

## Technical Changes

### Worker-based FFmpeg architecture

* Added dedicated `ffmpeg.worker.ts`
* Moved FFmpeg processing off the main thread
* Added worker communication flow for export lifecycle events

### Progress handling

* Preserved real-time export progress updates
* Improved worker → UI progress synchronization

### Cancellation support

* Added proper cancellation handling using worker termination
* Prevents UI lockups during long exports

### Memory & cleanup improvements

* Sanitized worker payloads before posting
* Reduced unnecessary cloning of large objects
* Improved worker cleanup and error handling

### UX improvements

* `beforeunload` warning only appears during active exports/loading
* UI remains interactive during export operations

## Validation

### Build

* `npm run build` ✅

### Lint

* `npm run lint` ✅

### Tests

* `npm run test` ✅
* 77 tests passing

## Files Modified

* `src/lib/ffmpeg.worker.ts`
* `src/lib/ffmpeg.ts`
* `src/hooks/useVideoEditor.ts`
* `package.json`
* `bun.lock`

## Expected Outcome

* Browser tab no longer freezes during export
* Progress UI updates smoothly
* Cancel flow works properly
* Reduced “Page Unresponsive” crashes
* Better responsiveness for large exports
