### PR TITLE
feat: add preferences menu for custom theme colors

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import ErrorBoundary from "@/components/ErrorBoundary";
 import "./globals.css";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { ThemeToggle } from "@/components/ThemeToggle";
+import { Preferences } from "@/components/Preferences";
 import ScrollToTop from "@/components/ScrollToTop";
 import BrandLogo from "@/components/BrandLogo";
 
@@ -84,7 +85,10 @@ export default function RootLayout({
                 <BrandLogo size={24} />
                 <h1 className="text-lg font-semibold">Reframe</h1>
               </div>
-              <ThemeToggle />
+              <div className="flex items-center gap-2">
+                <ThemeToggle />
+                <Preferences />
+              </div>
             </header>
             <main id="main-content" tabIndex={-1}>
               {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ export default function Home() {
         href="https://github.com/magic-peach/reframe"
         target="_blank"
         rel="noopener noreferrer"
-        className="hidden min-[300px]:flex fixed top-4 right-16 z-50 items-center gap-1.5 px-3 py-1.5 rounded-lg border border-[var(--border)] bg-[var(--surface)] text-[10px] font-heading font-semibold uppercase tracking-wider transition-all duration-200 ease-in-out hover:scale-105 hover:border-[var(--accent)] hover:bg-[var(--accent-muted)] hover:shadow-[var(--shadow)]"
+        className="hidden min-[300px]:flex fixed top-4 right-[110px] z-50 items-center gap-1.5 px-3 py-1.5 rounded-lg border border-[var(--border)] bg-[var(--surface)] text-[10px] font-heading font-semibold uppercase tracking-wider transition-all duration-200 ease-in-out hover:scale-105 hover:border-[var(--accent)] hover:bg-[var(--accent-muted)] hover:shadow-[var(--shadow)]"
       >
         ⭐ Star on GitHub
       </a>

--- a/src/components/Preferences.tsx
+++ b/src/components/Preferences.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { useTheme } from "./ThemeProvider";
+
+const PASTEL_COLORS = [
+  { name: "Default Blue", value: "" }, // Default is empty string which clears custom property
+  { name: "Pastel Pink", value: "#f472b6" },
+  { name: "Pastel Orange", value: "#fb923c" },
+  { name: "Pastel Green", value: "#4ade80" },
+  { name: "Pastel Purple", value: "#c084fc" },
+];
+
+export function Preferences() {
+  const { accentColor, setAccentColor } = useTheme();
+  const [isOpen, setIsOpen] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (popoverRef.current && !popoverRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen]);
+
+  return (
+    <div className="relative" ref={popoverRef}>
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        aria-label="Preferences"
+        aria-expanded={isOpen}
+        className="
+          relative flex items-center justify-center
+          w-9 h-9 rounded-full
+          bg-[var(--surface)]
+          text-[var(--text)]
+          border border-[var(--border)]
+          hover:border-[var(--accent)] hover:bg-[var(--accent-muted)]
+          focus:outline-none focus:ring-2 focus:ring-[var(--accent)] focus:ring-offset-2
+          focus:ring-offset-[var(--bg)]
+          transition-all duration-200
+        "
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="w-4 h-4"
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="3" />
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 mt-2 w-64 rounded-xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-[var(--shadow)] z-50">
+          <h3 className="mb-3 text-sm font-semibold text-[var(--text)]">Theme Color</h3>
+          <div className="grid grid-cols-5 gap-2 mb-4">
+            {PASTEL_COLORS.map((c) => {
+              const isSelected = accentColor === c.value || (!accentColor && c.value === "");
+              return (
+                <button
+                  key={c.name}
+                  onClick={() => setAccentColor(c.value)}
+                  className={`h-8 w-8 rounded-full border-2 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-[var(--surface)] transition-transform hover:scale-110 ${
+                    isSelected ? "border-[var(--text)]" : "border-transparent"
+                  }`}
+                  style={{ backgroundColor: c.value || "#3b82f6" }}
+                  title={c.name}
+                />
+              );
+            })}
+          </div>
+          
+          <div className="flex items-center justify-between border-t border-[var(--border)] pt-3">
+            <span className="text-sm text-[var(--text)] font-medium">Custom Color</span>
+            <div className="relative w-8 h-8 rounded-full overflow-hidden border border-[var(--border)] hover:scale-110 transition-transform focus-within:ring-2 focus-within:ring-[var(--accent)] focus-within:ring-offset-2 focus-within:ring-offset-[var(--surface)]">
+              <input
+                type="color"
+                value={accentColor || "#3b82f6"}
+                onChange={(e) => setAccentColor(e.target.value)}
+                className="absolute -top-2 -left-2 w-12 h-12 cursor-pointer border-0 p-0"
+                title="Choose custom color"
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -15,6 +15,8 @@ interface ThemeContextValue {
   theme: Theme;
   toggleTheme: () => void;
   setTheme: (theme: Theme) => void;
+  accentColor: string;
+  setAccentColor: (color: string) => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
@@ -31,6 +33,7 @@ function getCurrentTheme(): Theme {
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setThemeState] = useState<Theme>(getCurrentTheme);
+  const [accentColor, setAccentColorState] = useState<string>("");
 
   const applyTheme = useCallback(
     (next: Theme, persist = true) => {
@@ -47,8 +50,30 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     []
   );
 
+  const applyAccentColor = useCallback((color: string) => {
+    setAccentColorState(color);
+    if (typeof document !== "undefined") {
+      if (color) {
+        document.documentElement.style.setProperty("--accent", color);
+        document.documentElement.style.setProperty("--accent-hover", color);
+        document.documentElement.style.setProperty("--accent-muted", `${color}1f`);
+        localStorage.setItem("accentColor", color);
+      } else {
+        document.documentElement.style.removeProperty("--accent");
+        document.documentElement.style.removeProperty("--accent-hover");
+        document.documentElement.style.removeProperty("--accent-muted");
+        localStorage.removeItem("accentColor");
+      }
+    }
+  }, []);
+
   useEffect(() => {
     setThemeState(getCurrentTheme());
+
+    const savedAccent = localStorage.getItem("accentColor");
+    if (savedAccent) {
+      applyAccentColor(savedAccent);
+    }
 
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
     const handler = (e: MediaQueryListEvent) => {
@@ -58,7 +83,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     };
     mq.addEventListener("change", handler);
     return () => mq.removeEventListener("change", handler);
-  }, [applyTheme]);
+  }, [applyTheme, applyAccentColor]);
 
   const toggleTheme = useCallback(() => {
     applyTheme(theme === "light" ? "dark" : "light");
@@ -70,7 +95,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   );
 
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme, setTheme }}>
+    <ThemeContext.Provider value={{ theme, toggleTheme, setTheme, accentColor, setAccentColor: applyAccentColor }}>
       {children}
     </ThemeContext.Provider>
   );


### PR DESCRIPTION
## Description
This PR adds a **Preferences** button (palette icon) to the top right of the navigation header, positioned beside the dark mode toggle. 

**Key Features:**
- **Matching Theme Popover**: Opens a dropdown panel with options to customize the primary theme accent color.
- **Premium Pastel Color Options**: Provides preset premium-looking pastel colors (Pink, Orange, Green, Purple, and default Blue).
- **Custom Color Wheel**: Includes a native color wheel picker allowing users to choose any custom accent color.
- **Dynamic Application**: Dynamically overrides the `--accent`, `--accent-hover`, and `--accent-muted` CSS variables instantly across all UI components.
- **Layout Compatibility**: Automatically adjusts the spacing of the "Star on GitHub" button to prevent visual overlap on header menus.



## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: ksrikarsai
- Contribution level (Beginner/Intermediate/Advanced): Intermediate


**Recording:**

https://github.com/user-attachments/assets/7e9aeec1-0de4-401b-b575-2a4b6ea0781f


Closes #1137 

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)