### PR TITLE
fix: resolve FFmpeg worker MIME error on Windows

### DIFF
--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -4,11 +4,6 @@ import { buildTextFilter } from "./text-overlay";
 
 export class FFmpegLoadError extends Error {}
 
-const FFMPEG_WORKER_URL =
-  typeof window !== "undefined"
-    ? new URL("./ffmpeg.worker.ts", import.meta.url)
-    : null;
-
 type SerializedFile = {
   name: string;
   type: string;
@@ -61,11 +56,13 @@ let pendingExport: {
 let pendingProgress: ((percent: number) => void) | null = null;
 
 function createWorker(): Worker {
-  if (!FFMPEG_WORKER_URL) {
+  if (typeof window === "undefined") {
     throw new Error("Web Workers are not available in this environment.");
   }
 
-  ffmpegWorker = new Worker(FFMPEG_WORKER_URL, { type: "module" });
+  ffmpegWorker = new Worker(new URL("./ffmpeg.worker.entry.js", import.meta.url), {
+    type: "module",
+  });
   ffmpegWorker.onmessage = handleWorkerMessage;
   ffmpegWorker.onerror = (event) => {
     const message = event.message || "FFmpeg worker error";

--- a/src/lib/ffmpeg.worker.entry.js
+++ b/src/lib/ffmpeg.worker.entry.js
@@ -1,0 +1,1 @@
+import "./ffmpeg.worker.ts";


### PR DESCRIPTION
## Description

This PR fixes the FFmpeg worker initialization failure on Windows caused by incorrect worker asset bundling and MIME type handling.

Previously, the browser attempted to load the raw `ffmpeg.worker.ts` file directly, which Windows serves with the MIME type `video/mp2t`. Browsers enforcing strict module MIME checking rejected the worker, causing FFmpeg initialization and video export to fail.

This PR updates the worker initialization flow to ensure the worker is emitted as a proper JavaScript bundle across environments.

## Related Issue

Closes #1140

## Type of Contribution

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [x] Refactor
* [x] GSSoC contribution

## Participant Info

* GitHub username: YLaxmikanth
* Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Checklist

* [x] I have read the contribution guidelines
* [x] My changes follow the project structure
* [ ] I have tested my changes in Chrome, Firefox, and Safari
* [x] `bun run lint` passes (no ESLint errors)
* [x] `bunx tsc --noEmit` passes (no TypeScript errors)
* [x] New interactive elements have `aria-label` / accessible names
* [x] No `console.log` statements left in
* [x] This PR is related to a valid issue
* [ ] **Screen recording attached above** (required for UI/feature/design changes)

---

## Root Cause

The FFmpeg worker URL was previously created using an intermediate variable:

```ts id="bq41mz"
const FFMPEG_WORKER_URL = new URL("./ffmpeg.worker.ts", import.meta.url)

new Worker(FFMPEG_WORKER_URL, {
  type: "module"
})
```

This indirect pattern prevented Webpack/Next.js from reliably recognizing and bundling the worker asset.

As a result:

* the raw `.ts` worker file was emitted
* Windows served it as `video/mp2t`
* browsers rejected it due to strict module MIME checks
* FFmpeg initialization failed

---

## Fix Implemented

### Worker initialization refactor

Updated worker creation to use an inline statically analyzable worker URL:

```ts id="zry4dt"
new Worker(
  new URL("./ffmpeg.worker.entry.js", import.meta.url),
  {
    type: "module"
  }
)
```

### Added JS worker entrypoint

Introduced:

* `src/lib/ffmpeg.worker.entry.js`

This file imports the actual TypeScript worker implementation:

```js id="rb0z6t"
import "./ffmpeg.worker.ts";
```

This ensures:

* the emitted worker asset is bundled as JavaScript
* browsers receive a valid JS module
* MIME type issues are eliminated

---

## Files Modified

### Updated

* `src/lib/ffmpeg.ts`

### Added

* `src/lib/ffmpeg.worker.entry.js`

---

## Validation

### Build

* `npm run build` ✅

### Lint

* `npm run lint` ✅

### TypeScript

* `npx tsc --noEmit` ✅

### Tests

* `npm run test` ✅
* 77 tests passing

---

## Expected Outcome

* FFmpeg worker initializes successfully on Windows
* No `video/mp2t` MIME type errors
* Video export/download flow works correctly
* Worker bundling becomes stable across environments
* Cross-browser FFmpeg initialization reliability improves
