### PR TITLE
fix:video download

### DIFF
--- a/src/components/DownloadResult.tsx
+++ b/src/components/DownloadResult.tsx
@@ -135,22 +135,31 @@ export default function DownloadResult({ result, onReset, soundOnCompletion, onT
       </div>
 
       <div className="flex flex-wrap gap-2 pt-2">
-        <a
-          href={isValid ? result.blobUrl : undefined}
-          download={isValid ? filename : undefined}
+        <button
+          type="button"
+          disabled={!isValid}
           className={cn(
             "flex-1 min-w-[10rem] flex items-center justify-center gap-2 py-3 text-sm font-heading font-bold uppercase tracking-wide rounded-lg transition-all",
             isValid 
               ? "bg-[var(--accent)] text-white hover:bg-[var(--accent-hover)] hover:scale-[1.02] active:scale-[0.99] cursor-pointer"
               : "bg-[var(--border)] text-[var(--muted)] cursor-not-allowed"
           )}
-          onClick={(e) => {
-            if (!isValid) e.preventDefault();
+          onClick={() => {
+            if (!isValid) return;
+            const a = document.createElement("a");
+            a.style.display = "none";
+            a.href = result.blobUrl;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            setTimeout(() => {
+              document.body.removeChild(a);
+            }, 100);
           }}
         >
           <Download size={15} aria-hidden="true" />
           Download {result.format.toUpperCase()}
-        </a>
+        </button>
         <NativeShareButton 
           file={result.blob}
           fileName={filename}

--- a/src/components/__tests__/DownloadResult.test.tsx
+++ b/src/components/__tests__/DownloadResult.test.tsx
@@ -1,0 +1,185 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DownloadResult from '../DownloadResult'
+import { ExportResult } from '@/lib/types'
+
+// Mock NativeShareButton since it relies on navigator.share which might not be in test env
+vi.mock('../NativeShareButton', () => ({
+  NativeShareButton: () => React.createElement('button', null, 'Share')
+}))
+
+// Mock LottiePlayer
+vi.mock('../LottiePlayer', () => ({
+  default: () => React.createElement('div', null, 'Success Animation')
+}))
+
+describe('DownloadResult', () => {
+  const mockResult: ExportResult = {
+    blobUrl: 'blob:http://localhost:3000/some-uuid',
+    blob: new Blob(['test-video'], { type: 'video/mp4' }),
+    size: 1024 * 1024 * 5, // 5MB
+    width: 1920,
+    height: 1080,
+    format: 'mp4',
+    exportDurationMs: 12000 // 12 seconds
+  }
+
+  const mockOnReset = vi.fn()
+  const mockOnToggleSound = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Mock URL.createObjectURL and URL.revokeObjectURL
+    global.URL.createObjectURL = vi.fn(() => 'blob:mock-url')
+    global.URL.revokeObjectURL = vi.fn()
+    
+    // Mock window.confirm
+    global.window.confirm = vi.fn(() => true)
+
+    // Mock HTMLAudioElement constructor
+    global.Audio = function() {
+      return {
+        play: vi.fn().mockResolvedValue(undefined)
+      }
+    } as any
+  })
+
+  it('renders resolution, file size and export duration correctly', () => {
+    render(
+      React.createElement(DownloadResult, {
+        result: mockResult,
+        onReset: mockOnReset,
+        soundOnCompletion: false,
+        onToggleSound: mockOnToggleSound
+      })
+    )
+
+    expect(screen.getByText('1920 × 1080')).toBeInTheDocument()
+    expect(screen.getByText(/5(\.0)?\s*MB/i)).toBeInTheDocument()
+    expect(screen.getByText('Exported in 12 sec')).toBeInTheDocument()
+  })
+
+  it('renders input for filename with default value and reacts to invalid chars', async () => {
+    render(
+      React.createElement(DownloadResult, {
+        result: mockResult,
+        onReset: mockOnReset,
+        soundOnCompletion: false,
+        onToggleSound: mockOnToggleSound
+      })
+    )
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    expect(input.value).toBe('reframe_1920x1080')
+
+    // Clear and type invalid char
+    await userEvent.clear(input)
+    await userEvent.type(input, 'my:video')
+
+    expect(screen.getByText(/contains invalid characters/)).toBeInTheDocument()
+  })
+
+  it('programmatically triggers download when Download button is clicked', async () => {
+    let capturedAnchor: HTMLAnchorElement | null = null;
+    const originalAppend = document.body.appendChild.bind(document.body)
+    const originalRemove = document.body.removeChild.bind(document.body)
+
+    const appendSpy = vi.spyOn(document.body, 'appendChild').mockImplementation((el) => {
+      if (el instanceof HTMLAnchorElement) {
+        capturedAnchor = el;
+        // Mock the click method so it doesn't navigate
+        vi.spyOn(capturedAnchor, 'click').mockImplementation(() => {});
+      }
+      return originalAppend(el);
+    })
+    const removeSpy = vi.spyOn(document.body, 'removeChild').mockImplementation((el) => {
+      return originalRemove(el);
+    })
+
+    render(
+      React.createElement(DownloadResult, {
+        result: mockResult,
+        onReset: mockOnReset,
+        soundOnCompletion: false,
+        onToggleSound: mockOnToggleSound
+      })
+    )
+
+    const downloadBtn = screen.getByRole('button', { name: /Download/i })
+    await userEvent.click(downloadBtn)
+
+    expect(appendSpy).toHaveBeenCalled()
+    expect(capturedAnchor).not.toBeNull()
+    expect(capturedAnchor!.href).toContain(mockResult.blobUrl)
+    expect(capturedAnchor!.download).toBe('reframe_1920x1080.mp4')
+    expect(capturedAnchor!.click).toHaveBeenCalled()
+    
+    // Wait for the setTimeout cleanup
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    expect(removeSpy).toHaveBeenCalled()
+
+    appendSpy.mockRestore()
+    removeSpy.mockRestore()
+  })
+
+  it('triggers onReset when clicking New button and confirming', async () => {
+    render(
+      React.createElement(DownloadResult, {
+        result: mockResult,
+        onReset: mockOnReset,
+        soundOnCompletion: false,
+        onToggleSound: mockOnToggleSound
+      })
+    )
+
+    const newBtn = screen.getByRole('button', { name: /New/i })
+    await userEvent.click(newBtn)
+
+    expect(global.window.confirm).toHaveBeenCalledWith(
+      'This will clear the current video and all settings. Continue?'
+    )
+    expect(mockOnReset).toHaveBeenCalled()
+  })
+
+  it('triggers onToggleSound when clicking completion sound button', async () => {
+    render(
+      React.createElement(DownloadResult, {
+        result: mockResult,
+        onReset: mockOnReset,
+        soundOnCompletion: true,
+        onToggleSound: mockOnToggleSound
+      })
+    )
+
+    const soundBtn = screen.getByRole('button', { name: /Mute completion sound/i })
+    await userEvent.click(soundBtn)
+
+    expect(mockOnToggleSound).toHaveBeenCalled()
+  })
+
+  it('renders correct fallback filename layout for custom resolutions', () => {
+    const customResult = {
+      ...mockResult,
+      width: 1080,
+      height: 1920,
+      format: 'gif' as const
+    }
+
+    render(
+      React.createElement(DownloadResult, {
+        result: customResult,
+        onReset: mockOnReset,
+        soundOnCompletion: false,
+        onToggleSound: mockOnToggleSound
+      })
+    )
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    expect(input.value).toBe('reframe_1080x1920')
+    expect(screen.getByText('.gif')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Download GIF/i })).toBeInTheDocument()
+  })
+})

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -61,11 +61,11 @@ let pendingExport: {
 let pendingProgress: ((percent: number) => void) | null = null;
 
 function createWorker(): Worker {
-  if (!FFMPEG_WORKER_URL) {
+  if (typeof window === "undefined") {
     throw new Error("Web Workers are not available in this environment.");
   }
 
-  ffmpegWorker = new Worker(FFMPEG_WORKER_URL, { type: "module" });
+  ffmpegWorker = new Worker(new URL("./ffmpeg.worker.ts", import.meta.url), { type: "module" });
   ffmpegWorker.onmessage = handleWorkerMessage;
   ffmpegWorker.onerror = (event) => {
     const message = event.message || "FFmpeg worker error";

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -80,6 +80,9 @@ function createWorker(): Worker {
     workerReadyReject = reject;
   });
 
+  // Start the ffmpeg loading process immediately
+  ffmpegWorker.postMessage({ type: "load" });
+
   return ffmpegWorker;
 }
 
@@ -165,10 +168,6 @@ export async function loadFFmpeg(
   if (workerReady && workerReadyResolve === null) {
     onProgress?.(100);
     return;
-  }
-
-  if (!workerReady) {
-    ffmpegWorker!.postMessage({ type: "load" });
   }
 
   pendingProgress = onProgress ?? null;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config'
+import path from 'path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   oxc: {
     jsx: {
       runtime: 'automatic',


### PR DESCRIPTION
## Description
This PR resolves two major bugs related to the WebAssembly-based FFmpeg.wasm processing engine, and implements a robust programmatic download flow for the export page:

1. **Windows Web Worker MIME Mismatch**: Fixed a Windows-specific registry issue where `.ts` files are served as `video/mp2t` (MPEG-2 TS). Inlined the worker's URL instantiation inside the `Worker` constructor so Webpack successfully bundles the TypeScript worker into a standard Javascript file during local development.
2. **Engine Stuck at 0% (Logic Bug)**: Fixed a hidden bug in `loadFFmpeg` where `if (!workerReady)` was always evaluating to false (since `workerReady` was instantiated just before). Changed the code to immediately send `{ type: "load" }` to the worker upon creation.
3. **Safe Programmatic Downloads**: Modified `DownloadResult.tsx` to handle downloads programmatically. It dynamically creates and clicks an invisible anchor tag, which avoids strict browser sandbox/iframe blockages.



## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: ksrikarsai
- Contribution level (Beginner/Intermediate/Advanced): Advanced



**Recording / Loom link:** 

https://github.com/user-attachments/assets/03b96fbd-563a-4a10-9d50-a6c5b4352983

Closes #1140 

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)