### PR TITLE
feat: add advanced Chroma Key (Green Screen) background removal

### DIFF
--- a/src/components/ChromaKeyControl.tsx
+++ b/src/components/ChromaKeyControl.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { EditRecipe } from "@/lib/types";
+import { Palette, Info } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  recipe: EditRecipe;
+  onChange: (patch: Partial<EditRecipe>) => void;
+}
+
+export default function ChromaKeyControl({ recipe, onChange }: Props) {
+  return (
+    <div className="bg-[var(--surface-dim)] rounded-xl p-4 border border-[var(--border)]">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <Palette size={16} className="text-film-500" />
+          <div className="text-xs font-heading font-bold uppercase tracking-wider text-[var(--foreground)]">
+            Chroma Key (Green Screen)
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => onChange({ chromaKeyEnabled: !recipe.chromaKeyEnabled })}
+          className={cn(
+            "relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center justify-center rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-film-500 focus-visible:ring-offset-2",
+            recipe.chromaKeyEnabled ? "bg-film-600" : "bg-gray-400"
+          )}
+          role="switch"
+          aria-checked={recipe.chromaKeyEnabled}
+        >
+          <span
+            aria-hidden="true"
+            className={cn(
+              "pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out",
+              recipe.chromaKeyEnabled ? "translate-x-4" : "translate-x-0"
+            )}
+          />
+        </button>
+      </div>
+
+      {recipe.chromaKeyEnabled && (
+        <div className="space-y-5 animate-in slide-in-from-top-2 fade-in duration-200">
+          <div>
+            <div className="flex items-center justify-between mb-1.5">
+              <label className="text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)]">
+                Key Color
+              </label>
+              <span className="text-xs font-mono text-[var(--muted)]">
+                {recipe.chromaKeyColor.toUpperCase()}
+              </span>
+            </div>
+            <div className="flex gap-2">
+              <input
+                type="color"
+                value={recipe.chromaKeyColor}
+                onChange={(e) => onChange({ chromaKeyColor: e.target.value })}
+                className="w-10 h-10 rounded cursor-pointer border-0 p-0"
+                aria-label="Select chroma key color"
+              />
+              <div className="flex flex-1 gap-1">
+                {["#00FF00", "#0000FF", "#FFFFFF", "#000000"].map((presetColor) => (
+                  <button
+                    key={presetColor}
+                    type="button"
+                    onClick={() => onChange({ chromaKeyColor: presetColor })}
+                    className={cn(
+                      "flex-1 rounded border-2 transition-all",
+                      recipe.chromaKeyColor.toLowerCase() === presetColor.toLowerCase()
+                        ? "border-film-500"
+                        : "border-transparent hover:border-[var(--border)]"
+                    )}
+                    style={{ backgroundColor: presetColor }}
+                    aria-label={`Select preset color ${presetColor}`}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <div className="flex justify-between items-center mb-1.5">
+              <label className="text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)]">
+                Similarity
+              </label>
+              <span className="text-[10px] text-[var(--muted)] font-mono">
+                {Math.round(recipe.chromaKeySimilarity * 100)}%
+              </span>
+            </div>
+            <input
+              type="range"
+              min="0.01"
+              max="1.0"
+              step="0.01"
+              value={recipe.chromaKeySimilarity}
+              onChange={(e) => onChange({ chromaKeySimilarity: parseFloat(e.target.value) })}
+              className="w-full accent-film-500"
+            />
+          </div>
+
+          <div>
+            <div className="flex justify-between items-center mb-1.5">
+              <label className="text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)]">
+                Smoothness / Blend
+              </label>
+              <span className="text-[10px] text-[var(--muted)] font-mono">
+                {Math.round(recipe.chromaKeyBlend * 100)}%
+              </span>
+            </div>
+            <input
+              type="range"
+              min="0.0"
+              max="1.0"
+              step="0.01"
+              value={recipe.chromaKeyBlend}
+              onChange={(e) => onChange({ chromaKeyBlend: parseFloat(e.target.value) })}
+              className="w-full accent-film-500"
+            />
+          </div>
+
+          {recipe.format === "mp4" && (
+            <div className="mt-3 flex items-start gap-2 bg-yellow-500/10 border border-yellow-500/20 text-yellow-700 dark:text-yellow-400 rounded-lg p-2.5">
+              <Info size={14} className="mt-0.5 shrink-0" />
+              <p className="text-[10px] leading-tight">
+                <strong>MP4 doesn't support transparency.</strong> Keyed out areas will appear black. Export as <strong>WebM</strong> or <strong>GIF</strong> for a transparent background.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -17,6 +17,7 @@ import ExportSettings from "./ExportSettings";
 import ExportOverlay from "./ExportOverlay";
 import DownloadResult from "./DownloadResult";
 import ImageOverlay from "./ImageOverlay"
+import ChromaKeyControl from "./ChromaKeyControl"
 import { getPresetById } from "@/lib/presets";
 
 import { cn } from "@/lib/utils";
@@ -553,6 +554,7 @@ export default function VideoEditor() {
                       </div>
                     </div>
                   </Section>
+                  <ChromaKeyControl recipe={recipe} onChange={updateRecipe} />
                   <Section icon={<SlidersHorizontal size={12} />} title="Output format" delay={190}>
                     <FormatSelector recipe={recipe} onChange={updateRecipe} />
                   </Section>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -23,5 +23,9 @@ export const DEFAULT_RECIPE: EditRecipe = {
   soundOnCompletion: false,
   normalizeAudio: false,
   textOverlays: [],
+  chromaKeyEnabled: false,
+  chromaKeyColor: "#00FF00",
+  chromaKeySimilarity: 0.3,
+  chromaKeyBlend: 0.1,
   version: RECIPE_VERSION,
 };

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -331,6 +331,10 @@ export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: n
     filters.push(`trim=start=${recipe.trimStart}:end=${end}`);
   }
 
+  if (recipe.chromaKeyEnabled && recipe.chromaKeyColor) {
+    filters.push(`colorkey=${recipe.chromaKeyColor}:${recipe.chromaKeySimilarity}:${recipe.chromaKeyBlend}`);
+  }
+
   if (recipe.stabilization) {
     filters.push("deshake");
   }

--- a/src/lib/ffmpeg.worker.ts
+++ b/src/lib/ffmpeg.worker.ts
@@ -84,6 +84,10 @@ function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number):
     filters.push(`trim=start=${recipe.trimStart}:end=${end}`);
   }
 
+  if (recipe.chromaKeyEnabled && recipe.chromaKeyColor) {
+    filters.push(`colorkey=${recipe.chromaKeyColor}:${recipe.chromaKeySimilarity}:${recipe.chromaKeyBlend}`);
+  }
+
   if (recipe.stabilization) {
     filters.push("deshake");
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -33,6 +33,10 @@ export interface EditRecipe {
   saturation: number;
   soundOnCompletion: boolean;
   textOverlays: TextOverlay[];
+  chromaKeyEnabled: boolean;
+  chromaKeyColor: string;
+  chromaKeySimilarity: number;
+  chromaKeyBlend: number;
   version: number;
 }
 
@@ -102,6 +106,11 @@ export function isValidRecipe(value: unknown): value is EditRecipe {
   if (typeof v.saturation !== "number" || !isFinite(v.saturation)) return false;
   if (typeof v.soundOnCompletion !== "boolean") return false;
   if (!Array.isArray(v.textOverlays)) return false;
+  
+  if (typeof v.chromaKeyEnabled !== "boolean") return false;
+  if (typeof v.chromaKeyColor !== "string") return false;
+  if (typeof v.chromaKeySimilarity !== "number" || !isFinite(v.chromaKeySimilarity)) return false;
+  if (typeof v.chromaKeyBlend !== "number" || !isFinite(v.chromaKeyBlend)) return false;
 
   return true;
 }


### PR DESCRIPTION
## Description
This PR implements an advanced, native **Chroma Key (Green Screen) background removal tool** directly in the browser's video editing pipeline. It enables creators to select and key out any solid color background from their videos before export.

### Key Changes
1. **Types & Config**: Extended the edit recipe configurations in `src/lib/types.ts` and `src/lib/constants.ts` to manage chroma key settings state (`chromaKeyEnabled`, `chromaKeyColor`, `chromaKeySimilarity`, `chromaKeyBlend`).
2. **FFmpeg WebAssembly Integration**: Updated `buildVideoFilter` inside both `src/lib/ffmpeg.ts` and `src/lib/ffmpeg.worker.ts` to natively inject the high-performance FFmpeg `colorkey` filter.
3. **Advanced Chroma Key UI**: Designed and integrated a full custom `ChromaKeyControl` component containing:
   - A native hex color picker.
   - Quick-select presets for standard Chroma screens (Green, Blue, White, Black).
   - Precision sliders for matching similarity tolerances and smoothness/blend factors.
   - Helpful context warnings advising the user to export as WebM/GIF since MP4 (H.264) does not support alpha-channel transparency.
4. **App Settings Integration**: Beautifully integrated the controls inside the video editor settings sidebar directly under Adjustments.


## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: ksrikarsai
- Contribution level (Beginner/Intermediate/Advanced): Advanced

## Screen Recording

https://github.com/user-attachments/assets/72697e7a-b038-4889-ae34-3431e1551f53


Closes #1145 


## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)