### PR TITLE
Add reusable video filter preset system

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "wasm-feature-detect": "^1.8.0",
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.0.0",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "@types/bun": "^1.3.14",
@@ -38,6 +39,8 @@
     },
   },
   "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
+
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
@@ -217,6 +220,8 @@
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
     "@testing-library/dom": ["@testing-library/dom@9.3.4", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.1.3", "chalk": "^4.1.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "pretty-format": "^27.0.2" } }, "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
 
     "@testing-library/react": ["@testing-library/react@14.3.1", "", { "dependencies": { "@babel/runtime": "^7.12.5", "@testing-library/dom": "^9.0.0", "@types/react-dom": "^18.0.0" }, "peerDependencies": { "react": "^18.0.0", "react-dom": "^18.0.0" } }, "sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ=="],
 
@@ -420,6 +425,8 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "cssstyle": ["cssstyle@3.0.0", "", { "dependencies": { "rrweb-cssom": "^0.6.0" } }, "sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg=="],
@@ -458,7 +465,7 @@
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
-    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "domexception": ["domexception@4.0.0", "", { "dependencies": { "webidl-conversions": "^7.0.0" } }, "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw=="],
 
@@ -612,6 +619,8 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
@@ -762,6 +771,8 @@
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
@@ -880,6 +891,8 @@
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
     "reframe": ["reframe@root:", {}],
@@ -967,6 +980,8 @@
     "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
+
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
@@ -1083,6 +1098,8 @@
     "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
     "@testing-library/dom/aria-query": ["aria-query@5.1.3", "", { "dependencies": { "deep-equal": "^2.0.5" } }, "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ=="],
+
+    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "@testing-library/react/@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -33,7 +33,7 @@ export default function ContactPage() {
           </a>
           <p className="opacity-70 mt-1">For bug reports and feature requests.</p>
         </div>
-
+    
         <div>
           <a
             href="https://github.com/magic-peach/reframe/discussions"

--- a/src/components/DownloadResult.tsx
+++ b/src/components/DownloadResult.tsx
@@ -59,8 +59,9 @@ export default function DownloadResult({ result, onReset, soundOnCompletion, onT
     aria-label={soundOnCompletion ? "Mute completion sound" : "Unmute completion sound"}
     className="p-2 rounded-lg border border-[var(--border)] text-[var(--muted)] hover:bg-[var(--bg)] transition-colors"
     title={soundOnCompletion ? "Sound on" : "Sound off"}
-  >
-    {soundOnCompletion ? <Volume2 size={14} /> : <VolumeX size={14} />}
+        >
+          {/* “What happens if I click?” */}
+    {soundOnCompletion ?  <VolumeX size={14} /> : <Volume2 size={14} /> }
   </button>
 </div>
 

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -51,10 +51,25 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
                         <h2 className="text-3xl font-bold">
                             Something went wrong
                         </h2>
+                        
+                {/* to see actual error stack/debug info. */}
+                        <div className="space-y-3">
+                            <p className="text-sm opacity-80">
+                                {this.state.error?.message || "An unexpected error occurred."}
+                            </p>
 
-                        <p className="text-sm opacity-80">
-                            {this.state.error?.message || "An unexpected error occurred."}
-                        </p>
+                            {this.state.error?.stack && (
+                                <details className="rounded-lg border p-3 text-left text-xs opacity-80">
+                                    <summary className="cursor-pointer font-semibold">
+                                        Technical Details
+                                    </summary>
+
+                                    <pre className="mt-3 overflow-auto whitespace-pre-wrap break-words">
+                                        {this.state.error.stack}
+                                    </pre>
+                                </details>
+                            )}
+                        </div>
 
                         <div className="flex flex-wrap items-center justify-center gap-3">
                             <button

--- a/src/components/ExportSettings.tsx
+++ b/src/components/ExportSettings.tsx
@@ -12,6 +12,8 @@ import {
   formatEstimatedSize,
 } from "@/lib/exportEstimate";
 
+import FilterPresetSelector from "./FilterPresetSelector";
+
 interface Props {
   recipe: EditRecipe;
   duration: number;
@@ -29,8 +31,8 @@ export default function ExportSettings({
     recipe.quality <= 21
       ? "High"
       : recipe.quality <= 25
-      ? "Balanced"
-      : "Small file";
+        ? "Balanced"
+        : "Small file";
 
   const isGif = recipe.format === "gif";
 
@@ -119,25 +121,25 @@ export default function ExportSettings({
         </div>
 
         {!isGif && (
-        <div className="flex items-center justify-between mt-4">
-          <label
-            htmlFor="sound-on-completion"
-            className="text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)]"
-          >
-            Sound on completion
-          </label>
+          <div className="flex items-center justify-between mt-4">
+            <label
+              htmlFor="sound-on-completion"
+              className="text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)]"
+            >
+              Sound on completion
+            </label>
 
-          <input
-            id="sound-on-completion"
-            type="checkbox"
-            checked={recipe.soundOnCompletion}
-            onChange={(e) =>
-              onChange({ soundOnCompletion: e.target.checked })
-            }
-            aria-label="Play sound when export completes"
-            className="accent-film-600 cursor-pointer"
-          />
-        </div>
+            <input
+              id="sound-on-completion"
+              type="checkbox"
+              checked={recipe.soundOnCompletion}
+              onChange={(e) =>
+                onChange({ soundOnCompletion: e.target.checked })
+              }
+              aria-label="Play sound when export completes"
+              className="accent-film-600 cursor-pointer"
+            />
+          </div>
         )}
       </div>
 
@@ -235,6 +237,8 @@ export default function ExportSettings({
           </span>
         </div>
       </div>
+
+      <FilterPresetSelector recipe={recipe} onChange={onChange} />
     </>
   );
 }

--- a/src/components/FilterPresetSelector.tsx
+++ b/src/components/FilterPresetSelector.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { EditRecipe } from "@/lib/types";
+import { VIDEO_FILTERS } from "@/lib/videoFilters";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  recipe: EditRecipe;
+  onChange: (patch: Partial<EditRecipe>) => void;
+}
+
+export default function FilterPresetSelector({
+  recipe,
+  onChange,
+}: Props) {
+  return (
+    <div>
+      <div className="text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)] mb-3">
+        Video Filter
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        {VIDEO_FILTERS.map((filter) => {
+          const active = recipe.filterPreset === filter.id;
+
+          return (
+            <button
+              key={filter.id}
+              type="button"
+              onClick={() =>
+                onChange({ filterPreset: filter.id })
+              }
+              className={cn(
+                "rounded-lg border px-3 py-2 text-xs font-heading font-semibold transition-all",
+                active
+                  ? "border-film-600 bg-film-50 text-film-700"
+                  : "border-[var(--border)] bg-[var(--surface)] text-[var(--muted)] hover:border-film-400"
+              )}
+            >
+              {filter.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -15,6 +15,7 @@ export const DEFAULT_RECIPE: EditRecipe = {
   speed: 1,
   quality: 23,
   format: "mp4",
+  filterPreset: "none",
   brightness: 0,
   contrast: 1,
   saturation: 1,

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -3,12 +3,13 @@ import { fetchFile, toBlobURL } from "@ffmpeg/util";
 import { EditRecipe, ExportResult, BackgroundMusicOptions, ImageOverlayOptions } from "./types";
 import { getPresetById } from "./presets";
 import { simd } from "wasm-feature-detect";
+import { VIDEO_FILTERS } from "./videoFilters";
 
 const CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd";
 
 // Added from main branch for subresource security verification
 const SRI_HASHES: Record<string, string> = {
-  "ffmpeg-core.js":   "sha384-sKfkiFtvUk+vexk+0EUhEh366190/4WpgUAsUvaxEfyg7+E1Zt5Y5hrsU808g8Q9",
+  "ffmpeg-core.js": "sha384-sKfkiFtvUk+vexk+0EUhEh366190/4WpgUAsUvaxEfyg7+E1Zt5Y5hrsU808g8Q9",
   "ffmpeg-core.wasm": "sha384-U1VDhkPYrM3wTCT4/vjSpSsKqG/UjljYrYCI4hBSJ02svbCkxuCi6U6u/peg5vpW",
 };
 
@@ -132,8 +133,8 @@ export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: n
   }
 
   if (recipe.speed !== 1) {
-  const pts = (1 / recipe.speed).toFixed(4);
-  filters.push(`setpts=${pts}*PTS`);
+    const pts = (1 / recipe.speed).toFixed(4);
+    filters.push(`setpts=${pts}*PTS`);
   }
 
   if (recipe.denoise) {
@@ -143,10 +144,18 @@ export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: n
   filters.push(
     `eq=brightness=${recipe.brightness}:contrast=${recipe.contrast}:saturation=${recipe.saturation}`
   );
+  
+  const preset = VIDEO_FILTERS.find(
+    (p) => p.id === recipe.filterPreset
+  );
+
+  if (preset) {
+    filters.push(...preset.ffmpeg);
+  }
   return filters.join(",");
 }
 
- export function buildAudioFilter(speed: number, normalizeAudio: boolean): string {
+export function buildAudioFilter(speed: number, normalizeAudio: boolean): string {
   if (speed <= 0) return "";
   const filters: string[] = [];
 
@@ -161,7 +170,7 @@ export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: n
     remaining /= 2.0;
   }
 
- if (Math.abs(remaining - 1.0) > 0.001) {
+  if (Math.abs(remaining - 1.0) > 0.001) {
     filters.push(`atempo=${Number(remaining.toFixed(4))}`);
   }
 
@@ -226,9 +235,9 @@ function buildArguments(
       const scaledW = overlayOptions!.size;
       const alpha = (overlayOptions!.opacity / 100).toFixed(2);
       const posMap: Record<string, string> = {
-        "top-left":     "20:20",
-        "top-right":    "W-w-20:20",
-        "bottom-left":  "20:H-h-20",
+        "top-left": "20:20",
+        "top-right": "W-w-20:20",
+        "bottom-left": "20:H-h-20",
         "bottom-right": "W-w-20:H-h-20",
       };
       const pos = posMap[overlayOptions!.position] ?? "W-w-20:H-h-20";
@@ -242,7 +251,7 @@ function buildArguments(
       if (hasMusicTrack) {
         const musicVol = (musicOptions!.musicVolume / 100).toFixed(2);
         if (hasOriginalAudio) {
-          const origVol  = (musicOptions!.originalAudioVolume / 100).toFixed(2);
+          const origVol = (musicOptions!.originalAudioVolume / 100).toFixed(2);
           const origChain = afParts.length > 0
             ? `[0:a]${afParts.join(",")},volume=${origVol}[orig]`
             : `[0:a]volume=${origVol}[orig]`;
@@ -349,11 +358,11 @@ export async function exportVideo(
     await ffmpeg.writeFile(inputName, await fetchFile(file), { signal });
 
     const vf = buildVideoFilter(recipe, targetW, targetH);
-  const audioTrim = buildAudioTrimFilter(recipe);
-  const audioSpeed = buildAudioFilter(recipe.speed, recipe.normalizeAudio ?? false);
+    const audioTrim = buildAudioTrimFilter(recipe);
+    const audioSpeed = buildAudioFilter(recipe.speed, recipe.normalizeAudio ?? false);
 
-  const afParts = [audioTrim, audioSpeed].filter(Boolean);
-  const af = afParts.join(",");
+    const afParts = [audioTrim, audioSpeed].filter(Boolean);
+    const af = afParts.join(",");
     const hasMusicTrack = !!(musicOptions?.file && recipe.keepAudio);
     const musicInputName = `music_input_${sessionId}.mp3`;
     if (hasMusicTrack) {
@@ -488,7 +497,7 @@ export async function exportVideo(
     for (const path of cleanupFiles) {
       try {
         await ffmpeg.deleteFile(path);
-      } catch {}
+      } catch { }
     }
   }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,6 +20,7 @@ export interface EditRecipe {
   saturation: number;
   soundOnCompletion: boolean;
   version: number;
+  filterPreset: "none" | "cinematic" | "vintage" | "noir" | 'retro90s';
 }
 
 export type OverlayPosition =
@@ -81,6 +82,7 @@ export function isValidRecipe(value: unknown): value is EditRecipe {
   if (typeof v.speed !== "number" || !isFinite(v.speed)) return false;
   if (typeof v.quality !== "number" || !isFinite(v.quality)) return false;
   if (!["mp4", "webm", "mkv", "gif"].includes(v.format)) return false;
+  if (!["none", "cinematic", "vintage", "noir", "retro90s"].includes(v.filterPreset)) return false;
   if (typeof v.stabilization !== "boolean") return false;
   if (typeof v.brightness !== "number" || !isFinite(v.brightness)) return false;
   if (typeof v.contrast !== "number" || !isFinite(v.contrast)) return false;

--- a/src/lib/videoFilters.ts
+++ b/src/lib/videoFilters.ts
@@ -1,0 +1,46 @@
+// Other filter can be futher can be added
+export interface VideoFilterPresent{
+    id: 'none' | 'cinematic' | 'vintage' | 'noir' | 'Retro-90',
+    label: string,
+    ffmpeg: string[],
+}
+
+export const VIDEO_FILTERS: VideoFilterPresent[] = [
+    {
+        id: 'none',
+        label: "None",
+        ffmpeg: [],
+    },
+     {
+        id: 'cinematic',
+        label: "Cinematic",
+         ffmpeg: [
+            "eq=contrast=1.1:saturation=0.9:brightness=-0.02"
+        ],
+    },
+     {
+        id: 'vintage',
+        label: "Vintage",
+         ffmpeg: [
+      "eq=saturation=0.7:contrast=0.95:brightness=0.03"
+        ],
+    },
+     {
+        id: 'noir',
+        label: "Noir",
+         ffmpeg: [
+      "hue=s=0",
+      "eq=contrast=1.2"
+        ],
+    },
+        {
+  id: "retro90s",
+  label: "90s Retro",
+  ffmpeg: [
+    "eq=saturation=1.3:contrast=1.1:brightness=0.03",
+    "noise=alls=6:allf=t",
+    "gblur=sigma=0.3"
+  ],
+
+    }
+]


### PR DESCRIPTION
## Description
## Related Issue
## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: 
- Contribution level (Beginner/Intermediate/Advanced): 

## Screen Recording
> **How to record:** run `bun run dev` → open http://localhost:3000 → demonstrate the full working flow of your change, including any edge cases.
>
> - **macOS**: `Cmd + Shift + 5` → Record Selected Portion, or use QuickTime Player
> - **Windows**: `Win + G` → Xbox Game Bar → Capture
> - **Linux**: OBS Studio, GNOME Screenshot tool, or `kazam`
> - **Any OS**: [Loom](https://loom.com) (free screen recorder, great for sharing)

**Recording / Loom link:** ## Checklist
- [ ] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [ ] `bun run lint` passes (no ESLint errors)
- [ ] `bunx tsc --noEmit` passes (no TypeScript errors)
- [ ] New interactive elements have `aria-label` / accessible names
- [ ] No `console.log` statements left in
- [ ] This PR is related to a valid issue
- [ ] **Screen recording attached above** (required for UI/feature/design changes)