### PR TITLE
fix: resolve hydration mismatches on initial load

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -194,6 +194,7 @@ export default function FileUpload({
     <div
       id="upload-zone"
       role="button"
+      suppressHydrationWarning
       tabIndex={0}
       aria-label="Video upload area. Drag and drop a video file or press Enter to browse."
       onDragOver={(e) => {

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,9 +1,34 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useTheme } from "./ThemeProvider";
 
 export function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <button
+        type="button"
+        aria-label="Toggle theme"
+        className="
+          relative flex items-center justify-center
+          w-9 h-9 rounded-full
+          bg-[var(--surface)]
+          text-[var(--text)]
+          border border-[var(--border)]
+        "
+      >
+        <div className="w-4 h-4" />
+      </button>
+    );
+  }
+
   const isDark = theme === "dark";
 
   return (

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -14,3 +14,25 @@ Object.defineProperty(window, 'matchMedia', {
     dispatchEvent: () => false,
   }),
 })
+
+const localStorageMock = (function () {
+  let store: Record<string, string> = {}
+  return {
+    getItem(key: string) {
+      return store[key] || null
+    },
+    setItem(key: string, value: string) {
+      store[key] = value.toString()
+    },
+    clear() {
+      store = {}
+    },
+    removeItem(key: string) {
+      delete store[key]
+    },
+  }
+})()
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+})


### PR DESCRIPTION
## Description
This PR resolves two hydration mismatches that occur on the initial page load, and fixes a failing test in the suite:
- Added a `mounted` state to `ThemeToggle` to render a neutral placeholder during SSR, preventing aria-label attribute mismatch.
- Added `suppressHydrationWarning` to the `FileUpload` DropZone to handle third-party browser extensions (like FormDin) that inject the `fdprocessedid` attribute.
- Added a `localStorage` mock polyfill in `vitest.setup.ts` to fix the `TypeError: localStorage.clear is not a function` error in the `ThemeToggle.test.tsx` test.

## Related Issue
Fixes #1154 

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- **GitHub username:** @aspartic-gthb


## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [ ] **Screen recording attached above**