### PR TITLE
Feature clear editor reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "next": "^15.1.8",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "reframe": ".",
     "tailwind-merge": "^3.6.0",
     "wasm-feature-detect": "^1.8.0"
   },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,6 +12,8 @@
   --accent: #3b82f6;
   --accent-hover: #1d4ed8;
   --accent-muted: rgba(59, 130, 246, 0.12);
+  --focus-ring: var(--accent);
+  --focus-ring-glow: rgba(59, 130, 246, 0.45);
   --radius: 10px;
   --shadow: 0 2px 12px rgba(15, 23, 42, 0.12);
   --film-600: #e63946;
@@ -33,6 +35,8 @@
   --accent: #4f6ef7;
   --accent-hover: #3a57d4;
   --accent-muted: rgba(79, 110, 247, 0.12);
+  --focus-ring: var(--accent);
+  --focus-ring-glow: rgba(79, 110, 247, 0.55);
   --radius: 10px;
   --shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
   --warning: #fbbf24;
@@ -54,6 +58,8 @@
   --accent: #FFFF00;
   --accent-hover: #FFFF00;
   --accent-muted: rgba(255, 255, 0, 0.22);
+  --focus-ring: var(--accent);
+  --focus-ring-glow: rgba(255, 255, 0, 0.55);
   --radius: 10px;
   --shadow: none;
 
@@ -125,8 +131,8 @@ textarea {
 input:focus,
 select:focus,
 textarea:focus {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-muted);
+  border-color: var(--focus-ring);
+  box-shadow: 0 0 0 4px var(--focus-ring-glow);
   outline: none;
 }
 
@@ -139,8 +145,33 @@ textarea:focus {
   transition-duration: 200ms;
 }
 
-:focus-visible {
-  outline: 0;
-  box-shadow: 0 0 0 3px var(--accent-muted);
-  border-radius: var(--radius);
+/*
+ * Keyboard focus — rules follow @tailwind utilities so they apply app-wide.
+ * Uses --focus-ring / --focus-ring-glow for light, dark, and high-contrast themes.
+ */
+button:focus-visible:not(:disabled),
+a:focus-visible,
+[role="button"]:focus-visible,
+[role="slider"]:focus-visible,
+[role="tab"]:focus-visible,
+summary:focus-visible,
+label:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px var(--focus-ring-glow);
+}
+
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 0;
+  border-color: var(--focus-ring);
+  box-shadow: 0 0 0 4px var(--focus-ring-glow);
+}
+
+input[type="range"]:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px var(--focus-ring-glow);
 }

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -9,6 +9,7 @@ import { MAX_FILE_SIZE, WARNING_FILE_SIZE } from "@/lib/types";
 
 interface Props {
   onFileSelect: (file: File) => void;
+  onClear: () => void;
   currentFile: File | null;
   fileError: string;
   duration: number;
@@ -16,6 +17,7 @@ interface Props {
 
 export default function FileUpload({
   onFileSelect,
+  onClear,
   currentFile,
   fileError,
   duration,
@@ -125,6 +127,13 @@ export default function FileUpload({
     if (file) handleFile(file);
   };
 
+  const handleClear = () => {
+    setError("");
+    setWarning("");
+    if (inputRef.current) inputRef.current.value = "";
+    onClear();
+  };
+
   // ── File info (shown after upload) ───────────────────
   const FileInfo = () => (
     <div className="px-4 py-3 bg-[var(--surface)] border border-[var(--border)] rounded-[var(--radius)] shadow-[var(--shadow)]">
@@ -158,14 +167,28 @@ export default function FileUpload({
           </div>
         </div>
 
-        <button
-          type="button"
-          onClick={() => inputRef.current?.click()}
-          className="text-xs font-semibold text-film-600 hover:text-film-700 uppercase tracking-wide"
-        >
-          Change
-          <span className="text-[var(--muted)] ml-1">(Ctrl+O)</span>
-        </button>
+        <div className="flex flex-wrap items-center gap-2 shrink-0">
+          <button
+            type="button"
+            onClick={() => inputRef.current?.click()}
+            className="text-xs font-semibold text-film-600 hover:text-film-700 uppercase tracking-wide"
+            aria-label="Change video file"
+          >
+            Change
+            <span className="text-[var(--muted)] ml-1">(Ctrl+O)</span>
+          </button>
+          <span className="text-[var(--border)]" aria-hidden="true">
+            |
+          </span>
+          <button
+            type="button"
+            onClick={handleClear}
+            className="text-xs font-semibold uppercase tracking-wide px-2.5 py-1 rounded-md border border-[var(--error-border)] text-[var(--error)] bg-[var(--error-bg)] hover:bg-[var(--error-hover)] transition-colors"
+            aria-label="Clear uploaded video and reset editor"
+          >
+            Clear
+          </button>
+        </div>
       </div>
 
       <p className="text-xs text-[var(--muted)] mt-3 break-words">

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { cn, focusRing } from "@/lib/utils";
 import { useTheme } from "./ThemeProvider";
 
 export function ThemeToggle() {
@@ -11,17 +12,12 @@ export function ThemeToggle() {
        type="button"
        onClick={toggleTheme}
        aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
-      className="
-        relative flex items-center justify-center
-        w-9 h-9 rounded-full
-        bg-[var(--surface)]
-        text-[var(--text)]
-        border border-[var(--border)]
-        hover:border-[var(--accent)] hover:bg-[var(--accent-muted)]
-        focus:outline-none focus:ring-2 focus:ring-[var(--accent)] focus:ring-offset-2
-        focus:ring-offset-[var(--bg)]
-        transition-all duration-200
-      "
+      className={cn(
+        "relative flex items-center justify-center w-9 h-9 rounded-full",
+        "bg-[var(--surface)] text-[var(--text)] border border-[var(--border)]",
+        "hover:border-[var(--accent)] hover:bg-[var(--accent-muted)] transition-all duration-200",
+        focusRing
+      )}
     >
       {isDark ? (
         <svg

--- a/src/components/ThumbnailStrip.tsx
+++ b/src/components/ThumbnailStrip.tsx
@@ -391,6 +391,13 @@ export default function ThumbnailStrip({
           z-index: 2;
         }
 
+        .thumb-btn:focus-visible {
+          outline: 2px solid var(--focus-ring);
+          outline-offset: 2px;
+          box-shadow: 0 0 0 4px var(--focus-ring-glow), var(--shadow);
+          z-index: 2;
+        }
+
         .thumb-btn.active {
           outline-color: var(--accent);
           box-shadow: 0 0 0 2px var(--accent), var(--shadow);

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useMemo } from "react";
+import { useState, useRef, useEffect, useMemo, useCallback } from "react";
 import { useVideoEditor } from "@/hooks/useVideoEditor";
 import { TextOverlay } from "@/lib/types";
 import FileUpload from "./FileUpload";
@@ -239,6 +239,22 @@ export default function VideoEditor() {
     setOpenSections((prev) => ({ ...prev, [key]: !prev[key] }));
   const downloadRef = useRef<HTMLDivElement>(null);
 
+  const handleClearUpload = useCallback(() => {
+    if (status === "loading-engine" || status === "exporting") {
+      cancelExport();
+    }
+    reset();
+    setSelectedTextId(null);
+    setOpenSections({
+      resize: true,
+      trim: false,
+      rotation: false,
+      text: false,
+      audio: false,
+      export: false,
+    });
+  }, [reset, cancelExport, status]);
+
   /**
    * Updates a text overlay property and syncs with recipe.
    */
@@ -370,7 +386,13 @@ export default function VideoEditor() {
 
           <div className="space-y-4 min-w-0">
             <div className="bg-[var(--surface)] rounded-xl p-3 border border-[var(--border)] animate-fade-in">
-              <FileUpload onFileSelect={handleFileSelect} currentFile={file} fileError={fileError} duration={duration} />
+              <FileUpload
+                onFileSelect={handleFileSelect}
+                onClear={handleClearUpload}
+                currentFile={file}
+                fileError={fileError}
+                duration={duration}
+              />
 
               {!file && (
                 <div className="text-center text-[var(--muted)] py-6">

--- a/src/components/components.tsx
+++ b/src/components/components.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode } from "react";
+import { cn, focusRing, focusRingInput } from "@/lib/utils";
 
 interface CardProps {
   title: string;
@@ -63,16 +64,15 @@ export function Button({ variant = "primary", className = "", children, ...props
 
   return (
     <button
-      className={`
-        inline-flex items-center justify-center gap-2
-        rounded-[var(--radius)] px-4 py-2 text-sm font-medium
-        focus:outline-none focus:ring-2 focus:ring-offset-2
-        focus:ring-offset-[var(--bg)]
-        transition-all duration-200
-        disabled:opacity-50 disabled:cursor-not-allowed
-        ${variants[variant]}
-        ${className}
-      `}
+      className={cn(
+        "inline-flex items-center justify-center gap-2",
+        "rounded-[var(--radius)] px-4 py-2 text-sm font-medium",
+        "transition-all duration-200",
+        "disabled:opacity-50 disabled:cursor-not-allowed",
+        focusRing,
+        variants[variant],
+        className
+      )}
       {...props}
     >
       {children}
@@ -86,13 +86,12 @@ export function Button({ variant = "primary", className = "", children, ...props
 export function Input({ className = "", ...props }: React.InputHTMLAttributes<HTMLInputElement>) {
   return (
     <input
-      className={`
-        w-full rounded-[var(--radius)] border border-[var(--border)] bg-[var(--bg)] px-3 py-2 text-sm text-[var(--text)]
-        placeholder:text-[var(--muted)]
-        focus:border-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-muted)]
-        transition-all duration-200
-        ${className}
-      `}
+      className={cn(
+        "w-full rounded-[var(--radius)] border border-[var(--border)] bg-[var(--bg)] px-3 py-2 text-sm text-[var(--text)]",
+        "placeholder:text-[var(--muted)] transition-all duration-200",
+        focusRingInput,
+        className
+      )}
       {...props}
     />
   );

--- a/src/components/ui/BaseButton.tsx
+++ b/src/components/ui/BaseButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn } from "@/lib/utils";
+import { cn, focusRing } from "@/lib/utils";
 import { ButtonHTMLAttributes, forwardRef } from "react";
 
 interface BaseButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -39,6 +39,7 @@ const BaseButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, BaseButtonP
         className={cn(
           "flex items-center justify-center gap-2 rounded-lg transition-all duration-200",
           "hover:scale-[1.02] active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed disabled:scale-100",
+          focusRing,
           variants[variant],
           sizes[size],
           className

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -640,18 +640,49 @@ export function useVideoEditor() {
 
 
   const reset = useCallback(() => {
+    exportCancelledRef.current = true;
+    exportAbortControllerRef.current?.abort();
+    exportAbortControllerRef.current = null;
+    terminateFFmpeg();
+
     if (result?.blobUrl) URL.revokeObjectURL(result.blobUrl);
+
     setFile(null);
     setVideoMetadata(null);
     setDuration(0);
-    setRecipe(DEFAULT_RECIPE);
+    setCurrentTime(0);
+    setFileError("");
+    setRecipe({
+      ...DEFAULT_RECIPE,
+      soundOnCompletion:
+        typeof window !== "undefined" &&
+        localStorage.getItem("soundOnCompletion") === "true",
+    });
     setStatus("idle");
     setProgress(0);
     setResult(null);
     setError(null);
     setExportStartedAt(null);
+
+    setMusicFile(null);
+    setMusicVolume(70);
+    setOriginalAudioVolume(40);
+    setLoopMusic(false);
+    setOverlayFile(null);
+    setOverlayPosition("bottom-right");
+    setOverlaySize(150);
+    setOverlayOpacity(100);
+
+    const video = videoRef.current;
+    if (video) {
+      video.pause();
+      video.removeAttribute("src");
+      video.load();
+    }
+
     try {
       localStorage.removeItem(STORAGE_KEY);
+      localStorage.removeItem("reframe-settings");
     } catch {
       // ignore
     }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,6 +6,17 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+/**
+ * Visible keyboard focus ring — uses theme tokens from globals.css
+ * (--focus-ring, --focus-ring-glow). Apply to buttons, links, and custom controls.
+ */
+export const focusRing =
+  "outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus-ring)] focus-visible:shadow-[0_0_0_4px_var(--focus-ring-glow)]";
+
+/** Focus ring for text fields and selects (slightly tighter offset). */
+export const focusRingInput =
+  "outline-none focus-visible:border-[var(--focus-ring)] focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-[var(--focus-ring)] focus-visible:shadow-[0_0_0_4px_var(--focus-ring-glow)]";
+
 export function formatBytes(bytes: number, decimals = 1) {
   if (bytes === 0) return "0 Bytes";
 


### PR DESCRIPTION
## Description

Added a dedicated Clear button to fully reset the video editor state without requiring a page refresh.

The Clear action now:

* removes the uploaded video
* clears editor/export state
* resets trim, rotation, overlays, and generated frames
* restores the editor to its initial empty upload state
* keeps existing Change/upload functionality intact

## Related Issue

Closes #699

## Type of Contribution

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [x] Refactor
* [x] GSSoC contribution

## Participant Info

* GitHub username: Charan-Mugada
* Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Screen Recording


https://github.com/user-attachments/assets/797a95f6-f903-4d4d-b5ed-4cc7078546a9



## Checklist

* [x] I have read the contribution guidelines
* [x] My changes follow the project structure
* [x] I have tested my changes in Chrome, Firefox, and Safari
* [ ] `bun run lint` passes (no ESLint errors)
* [x] `bunx tsc --noEmit` passes (no TypeScript errors)
* [x] New interactive elements have `aria-label` / accessible names
* [x] No `console.log` statements left in
* [x] This PR is related to a valid issue
* [x] **Screen recording attached above** (required for UI/feature/design changes)