### PR TITLE
Added clear button to reset editor state

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -9,6 +9,7 @@ import { MAX_FILE_SIZE, WARNING_FILE_SIZE } from "@/lib/types";
 
 interface Props {
   onFileSelect: (file: File) => void;
+  onClear: () => void;
   currentFile: File | null;
   fileError: string;
   duration: number;
@@ -16,6 +17,7 @@ interface Props {
 
 export default function FileUpload({
   onFileSelect,
+  onClear,
   currentFile,
   fileError,
   duration,
@@ -125,6 +127,13 @@ export default function FileUpload({
     if (file) handleFile(file);
   };
 
+  const handleClear = () => {
+    setError("");
+    setWarning("");
+    if (inputRef.current) inputRef.current.value = "";
+    onClear();
+  };
+
   // ── File info (shown after upload) ───────────────────
   const FileInfo = () => (
     <div className="px-4 py-3 bg-[var(--surface)] border border-[var(--border)] rounded-[var(--radius)] shadow-[var(--shadow)]">
@@ -158,14 +167,28 @@ export default function FileUpload({
           </div>
         </div>
 
-        <button
-          type="button"
-          onClick={() => inputRef.current?.click()}
-          className="text-xs font-semibold text-film-600 hover:text-film-700 uppercase tracking-wide"
-        >
-          Change
-          <span className="text-[var(--muted)] ml-1">(Ctrl+O)</span>
-        </button>
+        <div className="flex flex-wrap items-center gap-2 shrink-0">
+          <button
+            type="button"
+            onClick={() => inputRef.current?.click()}
+            className="text-xs font-semibold text-film-600 hover:text-film-700 uppercase tracking-wide"
+            aria-label="Change video file"
+          >
+            Change
+            <span className="text-[var(--muted)] ml-1">(Ctrl+O)</span>
+          </button>
+          <span className="text-[var(--border)]" aria-hidden="true">
+            |
+          </span>
+          <button
+            type="button"
+            onClick={handleClear}
+            className="text-xs font-semibold uppercase tracking-wide px-2.5 py-1 rounded-md border border-[var(--error-border)] text-[var(--error)] bg-[var(--error-bg)] hover:bg-[var(--error-hover)] transition-colors"
+            aria-label="Clear uploaded video and reset editor"
+          >
+            Clear
+          </button>
+        </div>
       </div>
 
       <p className="text-xs text-[var(--muted)] mt-3 break-words">

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useMemo } from "react";
+import { useState, useRef, useEffect, useMemo, useCallback } from "react";
 import { useVideoEditor } from "@/hooks/useVideoEditor";
 import { TextOverlay } from "@/lib/types";
 import FileUpload from "./FileUpload";
@@ -239,6 +239,22 @@ export default function VideoEditor() {
     setOpenSections((prev) => ({ ...prev, [key]: !prev[key] }));
   const downloadRef = useRef<HTMLDivElement>(null);
 
+  const handleClearUpload = useCallback(() => {
+    if (status === "loading-engine" || status === "exporting") {
+      cancelExport();
+    }
+    reset();
+    setSelectedTextId(null);
+    setOpenSections({
+      resize: true,
+      trim: false,
+      rotation: false,
+      text: false,
+      audio: false,
+      export: false,
+    });
+  }, [reset, cancelExport, status]);
+
   /**
    * Updates a text overlay property and syncs with recipe.
    */
@@ -370,7 +386,13 @@ export default function VideoEditor() {
 
           <div className="space-y-4 min-w-0">
             <div className="bg-[var(--surface)] rounded-xl p-3 border border-[var(--border)] animate-fade-in">
-              <FileUpload onFileSelect={handleFileSelect} currentFile={file} fileError={fileError} duration={duration} />
+              <FileUpload
+                onFileSelect={handleFileSelect}
+                onClear={handleClearUpload}
+                currentFile={file}
+                fileError={fileError}
+                duration={duration}
+              />
 
               {!file && (
                 <div className="text-center text-[var(--muted)] py-6">

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -640,18 +640,49 @@ export function useVideoEditor() {
 
 
   const reset = useCallback(() => {
+    exportCancelledRef.current = true;
+    exportAbortControllerRef.current?.abort();
+    exportAbortControllerRef.current = null;
+    terminateFFmpeg();
+
     if (result?.blobUrl) URL.revokeObjectURL(result.blobUrl);
+
     setFile(null);
     setVideoMetadata(null);
     setDuration(0);
-    setRecipe(DEFAULT_RECIPE);
+    setCurrentTime(0);
+    setFileError("");
+    setRecipe({
+      ...DEFAULT_RECIPE,
+      soundOnCompletion:
+        typeof window !== "undefined" &&
+        localStorage.getItem("soundOnCompletion") === "true",
+    });
     setStatus("idle");
     setProgress(0);
     setResult(null);
     setError(null);
     setExportStartedAt(null);
+
+    setMusicFile(null);
+    setMusicVolume(70);
+    setOriginalAudioVolume(40);
+    setLoopMusic(false);
+    setOverlayFile(null);
+    setOverlayPosition("bottom-right");
+    setOverlaySize(150);
+    setOverlayOpacity(100);
+
+    const video = videoRef.current;
+    if (video) {
+      video.pause();
+      video.removeAttribute("src");
+      video.load();
+    }
+
     try {
       localStorage.removeItem(STORAGE_KEY);
+      localStorage.removeItem("reframe-settings");
     } catch {
       // ignore
     }


### PR DESCRIPTION
## Description

feat:  Added a dedicated **Clear** button to fully reset the editor state without refreshing the page.

### Changes made

* Added a Clear button beside the existing Change button
* Connected the existing `reset()` function to the upload UI
* Reset uploaded video, editor settings, overlays, and export state
* Added accessible labels for the new button
* Maintained existing upload/change functionality

## Related Issue

Closes #699

## Type of Contribution

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [x] Refactor
* [x] GSSoC contribution

## Participant Info

* GitHub username: Charan-Mugada
* Contribution level (Beginner/Intermediate/Advanced): Advanced

## Screen Recording


https://github.com/user-attachments/assets/8b6213fd-0785-4127-bf7e-f24079b86a1f



## Checklist

* [x] I have read the contribution guidelines
* [x] My changes follow the project structure
* [x] I have tested my changes in Chrome, Firefox, and Safari
* [x] `bun run lint` passes (no ESLint errors)
* [x] `bunx tsc --noEmit` passes (no TypeScript errors)
* [x] New interactive elements have `aria-label` / accessible names
* [x] No `console.log` statements left in
* [x] This PR is related to a valid issue
* [x] **Screen recording attached above** (required for UI/feature/design changes)
