### PR TITLE
feat: Add Captions/Subtitles Support with Custom Styling Options #991

### DIFF
--- a/src/components/ComparisonPreview.tsx
+++ b/src/components/ComparisonPreview.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 "use client";
 
-import { useEffect, useRef, useState, useCallback, RefObject } from "react";
+import { useEffect, useRef, useState, useCallback, useMemo, RefObject } from "react";
 import { EditRecipe } from "@/lib/types";
 import { getPresetById } from "@/lib/presets";
 import { cn } from "@/lib/utils";
@@ -18,6 +18,15 @@ export default function ComparisonPreview({ file, recipe, videoRef }: Props) {
   const [sliderPosition, setSliderPosition] = useState(50);
   const [isDragging, setIsDragging] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  const aspectStyle = useMemo(() => {
+    if (!recipe) return undefined;
+    const preset = recipe.preset === "custom"
+      ? { width: recipe.customWidth, height: recipe.customHeight }
+      : getPresetById(recipe.preset);
+    if (!preset) return undefined;
+    return { aspectRatio: `${preset.width} / ${preset.height}` };
+  }, [recipe]);
 
   // Calculate overlay for the right (reframed) side
   const overlay = (() => {
@@ -166,7 +175,8 @@ export default function ComparisonPreview({ file, recipe, videoRef }: Props) {
   return (
     <div
       ref={containerRef}
-      className="relative w-full rounded-lg overflow-hidden bg-[#0a0a0a] aspect-video"
+      className="relative w-full rounded-lg overflow-hidden bg-[#0a0a0a] mx-auto max-h-[60vh] object-contain"
+      style={aspectStyle || { aspectRatio: "16 / 9" }}
       role="group"
       aria-label="Video comparison preview"
     >

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -12,6 +12,7 @@ interface Props {
   currentFile: File | null;
   fileError: string;
   duration: number;
+  isLoading?: boolean;
 }
 
 export default function FileUpload({
@@ -19,6 +20,7 @@ export default function FileUpload({
   currentFile,
   fileError,
   duration,
+  isLoading = false,
 }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -259,6 +261,24 @@ export default function FileUpload({
       />
     </div>
   );
+ 
+  // ── Loading state ──
+  const LoadingState = () => (
+    <div className="flex flex-col items-center justify-center gap-4 py-12 px-6 border-2 border-dashed border-[var(--border)] rounded-xl bg-[var(--bg)] animate-pulse">
+      <div className="relative flex items-center justify-center w-16 h-16">
+        <div className="absolute w-12 h-12 rounded-full border-4 border-film-500/20 border-t-film-600 animate-spin" />
+        <Film size={20} className="text-film-600 animate-pulse" />
+      </div>
+      <div className="text-center">
+        <p className="font-heading font-semibold text-[var(--text)] text-base">
+          Processing Video
+        </p>
+        <p className="text-sm text-[var(--muted)] mt-1">
+          Extracting dimensions, aspect ratio, and metadata...
+        </p>
+      </div>
+    </div>
+  );
 
   return (
     <>
@@ -305,7 +325,7 @@ export default function FileUpload({
             {warning}
           </p>
         )}
-        {currentFile ? <FileInfo /> : <DropZone />}
+        {isLoading ? <LoadingState /> : currentFile ? <FileInfo /> : <DropZone />}
       </div>
     </>
   );

--- a/src/components/SubtitleControls.tsx
+++ b/src/components/SubtitleControls.tsx
@@ -1,0 +1,366 @@
+"use client";
+
+import { EditRecipe } from "@/lib/types";
+import { SubtitleItem } from "@/lib/subtitles";
+import { Upload, Trash2, Sliders, Type, Palette, Layout, Search, Play } from "lucide-react";
+import { useMemo, useState, useRef } from "react";
+import { getPresetById } from "@/lib/presets";
+
+interface SubtitleControlsProps {
+  recipe: EditRecipe;
+  onChange: (patch: Partial<EditRecipe>) => void;
+  subtitleFile: File | null;
+  parsedSubtitles: SubtitleItem[] | null;
+  onSubtitleSelect: (file: File) => void;
+  onClearSubtitles: () => void;
+  onSeek: (time: number) => void;
+}
+
+const FONTS = [
+  { value: "Inter", label: "Inter" },
+  { value: "Outfit", label: "Outfit" },
+  { value: "Roboto", label: "Roboto" },
+  { value: "Arial", label: "Arial (Standard)" },
+  { value: "Courier New", label: "Courier New" },
+  { value: "Times New Roman", label: "Times New Roman" },
+  { value: "system-ui", label: "System UI" },
+];
+
+const PRESET_COLORS = [
+  { hex: "#ffffff", label: "White" },
+  { hex: "#ffff00", label: "Yellow" },
+  { hex: "#00ffff", label: "Cyan" },
+  { hex: "#00ff00", label: "Green" },
+  { hex: "#ff00ff", label: "Magenta" },
+  { hex: "#000000", label: "Black" },
+];
+
+const STYLES = [
+  { value: "none", label: "Plain Text" },
+  { value: "outline", label: "Black Outline" },
+  { value: "box", label: "Semi-Transparent Box" },
+  { value: "shadow", label: "Soft Shadow" },
+];
+
+export default function SubtitleControls({
+  recipe,
+  onChange,
+  subtitleFile,
+  parsedSubtitles,
+  onSubtitleSelect,
+  onClearSubtitles,
+  onSeek,
+}: SubtitleControlsProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      onSubtitleSelect(file);
+    }
+  };
+
+  const filteredSubtitles = useMemo(() => {
+    if (!parsedSubtitles) return [];
+    if (!searchQuery.trim()) return parsedSubtitles;
+    const query = searchQuery.toLowerCase();
+    return parsedSubtitles.filter((sub) => sub.text.toLowerCase().includes(query));
+  }, [parsedSubtitles, searchQuery]);
+
+  const formatTimestamp = (sec: number) => {
+    const min = Math.floor(sec / 60);
+    const s = Math.floor(sec % 60);
+    const ms = Math.floor((sec % 1) * 1000);
+    return `${String(min).padStart(2, "0")}:${String(s).padStart(2, "0")},${String(ms).padStart(3, "0")}`;
+  };
+
+  return (
+    <div className="w-full space-y-5">
+      {/* File Upload / Clear */}
+      <div className="space-y-3">
+        {!subtitleFile ? (
+          <div>
+            <input
+              type="file"
+              accept=".srt"
+              onChange={handleFileChange}
+              ref={fileInputRef}
+              className="hidden"
+              id="subtitles-file-input"
+            />
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="w-full flex flex-col items-center justify-center gap-2 p-6 rounded-xl border border-dashed border-[var(--border)] bg-[var(--surface)] hover:bg-[var(--border)] hover:border-film-500 transition-all duration-200 cursor-pointer group"
+            >
+              <Upload className="w-6 h-6 text-[var(--muted)] group-hover:text-film-500 group-hover:scale-110 transition-transform" />
+              <span className="text-sm font-semibold text-[var(--text)]">Upload SRT Subtitles</span>
+              <span className="text-xs text-[var(--muted)]">Drag and drop or browse files</span>
+            </button>
+          </div>
+        ) : (
+          <div className="flex items-center justify-between gap-3 p-3 rounded-xl border border-[var(--border)] bg-[var(--surface)]">
+            <div className="min-w-0 flex-1">
+              <p className="text-xs font-semibold text-[var(--text)] truncate">
+                {subtitleFile.name}
+              </p>
+              <p className="text-[10px] text-[var(--muted)]">
+                {parsedSubtitles?.length ?? 0} subtitle segments loaded
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onClearSubtitles}
+              className="w-8 h-8 flex items-center justify-center rounded-lg text-red-400 hover:bg-red-500/10 hover:text-red-500 transition-all shrink-0 cursor-pointer"
+              aria-label="Remove subtitle file"
+              title="Remove subtitle file"
+            >
+              <Trash2 className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+      </div>
+
+      {subtitleFile && (
+        <div className="space-y-5 pt-3 border-t border-[var(--border)] animate-fade-in">
+          {/* Typography Settings */}
+          <div className="space-y-3">
+            <h4 className="text-xs font-bold uppercase tracking-wider text-[var(--muted)] flex items-center gap-1.5">
+              <Type className="w-3.5 h-3.5 text-film-500" />
+              Typography
+            </h4>
+
+            {/* Font Family */}
+            <div className="space-y-1">
+              <label htmlFor="subtitle-font" className="text-xs text-[var(--muted)] font-medium">
+                Font Family
+              </label>
+              <select
+                id="subtitle-font"
+                value={recipe.subtitleFont}
+                onChange={(e) => onChange({ subtitleFont: e.target.value })}
+                className="w-full px-2 py-1.5 text-xs rounded border border-[var(--border)] bg-[var(--bg)] text-[var(--text)] focus:outline-none focus:ring-2 focus:ring-film-500"
+              >
+                {FONTS.map((font) => (
+                  <option key={font.value} value={font.value}>
+                    {font.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Font Size */}
+            <div className="space-y-1">
+              <div className="flex items-center justify-between">
+                <label htmlFor="subtitle-size" className="text-xs text-[var(--muted)] font-medium">
+                  Font Size
+                </label>
+                <span className="text-xs font-mono font-semibold text-film-400">
+                  {recipe.subtitleSize}px
+                </span>
+              </div>
+              <div className="flex items-center gap-3">
+                <input
+                  id="subtitle-size"
+                  type="range"
+                  min="12"
+                  max="72"
+                  step="2"
+                  value={recipe.subtitleSize}
+                  onChange={(e) => onChange({ subtitleSize: Number(e.target.value) })}
+                  className="flex-1 accent-film-600 cursor-pointer"
+                />
+                <div className="flex gap-1 shrink-0">
+                  {(["Small", "Medium", "Large"] as const).map((label, idx) => {
+                    const size = idx === 0 ? 24 : idx === 1 ? 36 : 48;
+                    const isActive = recipe.subtitleSize === size;
+                    return (
+                      <button
+                        key={label}
+                        type="button"
+                        onClick={() => onChange({ subtitleSize: size })}
+                        className={`px-1.5 py-0.5 text-[10px] rounded transition-colors cursor-pointer ${
+                          isActive
+                            ? "bg-film-600 text-white"
+                            : "bg-[var(--border)] text-[var(--muted)] hover:bg-[var(--surface)]"
+                        }`}
+                      >
+                        {label.substring(0, 1)}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Color Settings */}
+          <div className="space-y-3">
+            <h4 className="text-xs font-bold uppercase tracking-wider text-[var(--muted)] flex items-center gap-1.5">
+              <Palette className="w-3.5 h-3.5 text-film-500" />
+              Colors
+            </h4>
+
+            {/* Text Color */}
+            <div className="space-y-1.5">
+              <label htmlFor="subtitle-color" className="text-xs text-[var(--muted)] font-medium">
+                Text Color
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  id="subtitle-color"
+                  type="color"
+                  value={recipe.subtitleColor}
+                  onChange={(e) => onChange({ subtitleColor: e.target.value })}
+                  className="w-9 h-7 rounded border border-[var(--border)] cursor-pointer shrink-0 bg-transparent"
+                />
+                <input
+                  type="text"
+                  value={recipe.subtitleColor}
+                  onChange={(e) => onChange({ subtitleColor: e.target.value })}
+                  placeholder="#ffffff"
+                  className="flex-1 px-2 py-1 text-xs rounded border border-[var(--border)] bg-[var(--bg)] text-[var(--text)] font-mono focus:outline-none focus:ring-2 focus:ring-film-500"
+                  aria-label="Subtitle Hex color input"
+                />
+              </div>
+
+              {/* Curated color buttons */}
+              <div className="flex flex-wrap gap-1.5 pt-1">
+                {PRESET_COLORS.map((color) => (
+                  <button
+                    key={color.hex}
+                    type="button"
+                    onClick={() => onChange({ subtitleColor: color.hex })}
+                    className="w-5 h-5 rounded-full border border-[var(--border)] relative hover:scale-110 transition-transform cursor-pointer"
+                    style={{ backgroundColor: color.hex }}
+                    title={color.label}
+                    aria-label={`Select preset color ${color.label}`}
+                  >
+                    {recipe.subtitleColor.toLowerCase() === color.hex.toLowerCase() && (
+                      <span className="absolute inset-0 m-auto w-1.5 h-1.5 rounded-full bg-film-500 shadow-sm" />
+                    )}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Style & Box Settings */}
+          <div className="space-y-3">
+            <h4 className="text-xs font-bold uppercase tracking-wider text-[var(--muted)] flex items-center gap-1.5">
+              <Layout className="w-3.5 h-3.5 text-film-500" />
+              Background & Readability
+            </h4>
+
+            {/* Background type select */}
+            <div className="space-y-1">
+              <label htmlFor="subtitle-bg-type" className="text-xs text-[var(--muted)] font-medium">
+                Background Type
+              </label>
+              <div className="grid grid-cols-2 gap-1.5">
+                {STYLES.map((style) => {
+                  const isActive = recipe.subtitleBgType === style.value;
+                  return (
+                    <button
+                      key={style.value}
+                      type="button"
+                      onClick={() => onChange({ subtitleBgType: style.value as any })}
+                      className={`px-2 py-1.5 text-left text-xs rounded-lg border transition-all cursor-pointer ${
+                        isActive
+                          ? "border-film-500 bg-film-600/10 text-film-400"
+                          : "border-[var(--border)] bg-[var(--surface)] text-[var(--muted)] hover:bg-[var(--border)]"
+                      }`}
+                    >
+                      {style.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Background / outline color */}
+            {recipe.subtitleBgType !== "none" && (
+              <div className="space-y-1.5 pt-1.5 border-t border-[var(--border)]/40 animate-fade-in">
+                <label htmlFor="subtitle-bg-color" className="text-xs text-[var(--muted)] font-medium">
+                  {recipe.subtitleBgType === "outline" ? "Outline Color" : "Background Box/Shadow Color"}
+                </label>
+                <div className="flex items-center gap-2">
+                  <input
+                    id="subtitle-bg-color"
+                    type="color"
+                    value={recipe.subtitleBgColor}
+                    onChange={(e) => onChange({ subtitleBgColor: e.target.value })}
+                    className="w-9 h-7 rounded border border-[var(--border)] cursor-pointer shrink-0 bg-transparent"
+                  />
+                  <input
+                    type="text"
+                    value={recipe.subtitleBgColor}
+                    onChange={(e) => onChange({ subtitleBgColor: e.target.value })}
+                    placeholder="#000000"
+                    className="flex-1 px-2 py-1 text-xs rounded border border-[var(--border)] bg-[var(--bg)] text-[var(--text)] font-mono focus:outline-none focus:ring-2 focus:ring-film-500"
+                    aria-label="Subtitle Background Hex color input"
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Subtitles Navigation list */}
+          <div className="space-y-3 pt-3 border-t border-[var(--border)]">
+            <div className="flex items-center justify-between">
+              <h4 className="text-xs font-bold uppercase tracking-wider text-[var(--muted)] flex items-center gap-1.5">
+                <Play className="w-3.5 h-3.5 text-film-500" />
+                Segments
+              </h4>
+              <span className="text-[10px] text-[var(--muted)] font-mono">
+                {filteredSubtitles.length} of {parsedSubtitles?.length ?? 0}
+              </span>
+            </div>
+
+            {/* Search Input */}
+            <div className="relative">
+              <span className="absolute inset-y-0 left-0 pl-2.5 flex items-center pointer-events-none">
+                <Search className="h-3.5 w-3.5 text-[var(--muted)]" />
+              </span>
+              <input
+                type="text"
+                placeholder="Search captions..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="w-full pl-8 pr-2.5 py-1.5 text-xs rounded-lg border border-[var(--border)] bg-[var(--bg)] text-[var(--text)] placeholder-[var(--muted)] focus:outline-none focus:ring-2 focus:ring-film-500"
+              />
+            </div>
+
+            {/* Subtitle segments list */}
+            {filteredSubtitles.length > 0 ? (
+              <div className="space-y-1.5 max-h-48 overflow-y-auto rounded-lg border border-[var(--border)] p-1 bg-[var(--bg)] scrollbar-thin">
+                {filteredSubtitles.map((sub) => (
+                  <button
+                    key={sub.id}
+                    type="button"
+                    onClick={() => onSeek(sub.startTime)}
+                    className="w-full text-left p-2 rounded hover:bg-[var(--border)] transition-colors duration-150 flex flex-col gap-0.5 border border-transparent hover:border-[var(--border)] cursor-pointer"
+                    title={`Seek video to ${formatTimestamp(sub.startTime)}`}
+                  >
+                    <div className="flex items-center justify-between text-[9px] font-mono text-film-500 font-semibold uppercase">
+                      <span>{formatTimestamp(sub.startTime)}</span>
+                      <span>--&gt; {formatTimestamp(sub.endTime)}</span>
+                    </div>
+                    <p className="text-xs text-[var(--text)] font-medium leading-normal line-clamp-2">
+                      {sub.text}
+                    </p>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <div className="text-center py-4 border border-dashed border-[var(--border)] rounded-lg text-xs text-[var(--muted)] bg-[var(--bg)]">
+                No matching captions found
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TimelineEditor.tsx
+++ b/src/components/TimelineEditor.tsx
@@ -1,0 +1,655 @@
+"use client";
+ 
+import Image from "next/image";
+import { useEffect, useRef, useState, useCallback, useMemo } from "react";
+import { EditRecipe } from "@/lib/types";
+import { cn, formatDuration } from "@/lib/utils";
+import { GripVertical } from "lucide-react";
+ 
+interface Thumbnail {
+  time: number;
+  dataUrl: string;
+}
+ 
+interface TimelineEditorProps {
+  videoSrc: string | null;
+  duration: number;
+  currentTime: number;
+  recipe: EditRecipe;
+  onChange: (patch: Partial<EditRecipe>) => void;
+  onSeek: (time: number) => void;
+}
+ 
+export default function TimelineEditor({
+  videoSrc,
+  duration,
+  currentTime,
+  recipe,
+  onChange,
+  onSeek,
+}: TimelineEditorProps) {
+  const [thumbnails, setThumbnails] = useState<Thumbnail[]>([]);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [progress, setProgress] = useState(0);
+ 
+  const trackRef = useRef<HTMLDivElement>(null);
+  const draggingRef = useRef<"start" | "end" | "clip" | "playhead" | null>(null);
+  const dragStartOffsetRef = useRef<number>(0);
+  const dragStartClipRef = useRef<{ start: number; end: number }>({ start: 0, end: 0 });
+ 
+  const lastRunIdRef = useRef(0);
+  const objectUrlsRef = useRef<string[]>([]);
+  const offscreenVideoRef = useRef<HTMLVideoElement | null>(null);
+ 
+  const effectiveTrimEnd = recipe.trimEnd ?? duration;
+  const clipLength = effectiveTrimEnd - recipe.trimStart;
+ 
+  // State for snapping guide
+  const [snapGuideTime, setSnapGuideTime] = useState<number | null>(null);
+ 
+  const revokeAllObjectUrls = useCallback(() => {
+    objectUrlsRef.current.forEach((url) => URL.revokeObjectURL(url));
+    objectUrlsRef.current = [];
+  }, []);
+ 
+  const cancelThumbnailRun = useCallback(() => {
+    lastRunIdRef.current += 1;
+  }, []);
+ 
+  // Determine snap intervals
+  const snapStep = useMemo(() => {
+    if (duration <= 15) return 1;
+    if (duration <= 60) return 2;
+    if (duration <= 180) return 5;
+    return 10;
+  }, [duration]);
+ 
+  // ── Thumbnail Generation ──
+  const generateThumbnails = useCallback(async () => {
+    if (!videoSrc || duration <= 0) return;
+ 
+    const runId = ++lastRunIdRef.current;
+    setIsGenerating(true);
+    revokeAllObjectUrls();
+    setThumbnails([]);
+    setProgress(0);
+ 
+    const video = document.createElement("video");
+    offscreenVideoRef.current = video;
+ 
+    try {
+      video.src = videoSrc;
+      video.crossOrigin = "anonymous";
+      video.muted = true;
+      video.preload = "auto";
+ 
+      await new Promise<void>((resolve, reject) => {
+        video.onloadedmetadata = () => resolve();
+        video.onerror = () => reject(new Error("Video load failed"));
+        video.load();
+      });
+ 
+      if (lastRunIdRef.current !== runId) return;
+ 
+      const canvas = document.createElement("canvas");
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+ 
+      const thumbW = 160;
+      const thumbH = 90;
+      canvas.width = thumbW;
+      canvas.height = thumbH;
+ 
+      // Calculate how many frames to extract to fit perfectly on screen
+      const times: number[] = [];
+      const interval = Math.max(0.5, duration / 12); // extract up to 12 frames
+      for (let t = 0; t <= duration; t += interval) {
+        times.push(Math.min(t, duration - 0.1));
+      }
+      if ((times[times.length - 1] ?? 0) < duration - 0.2) {
+        times.push(duration - 0.1);
+      }
+ 
+      const captured: Thumbnail[] = [];
+ 
+      for (let i = 0; i < times.length; i++) {
+        if (lastRunIdRef.current !== runId) break;
+ 
+        const time = times[i] ?? 0;
+        await new Promise<void>((resolve) => {
+          const onSeeked = async () => {
+            video.removeEventListener("seeked", onSeeked);
+ 
+            if (lastRunIdRef.current !== runId) {
+              resolve();
+              return;
+            }
+ 
+            ctx.drawImage(video, 0, 0, thumbW, thumbH);
+ 
+            try {
+              const blob = await new Promise<Blob | null>((blobResolve) => {
+                canvas.toBlob((b) => blobResolve(b), "image/jpeg", 0.6);
+              });
+              if (blob && lastRunIdRef.current === runId) {
+                const url = URL.createObjectURL(blob);
+                objectUrlsRef.current.push(url);
+                captured.push({ time, dataUrl: url });
+                setThumbnails([...captured]);
+              }
+            } catch (err) {
+              console.error("Failed to generate thumbnail blob", err);
+            }
+ 
+            setProgress(Math.round(((i + 1) / times.length) * 100));
+            resolve();
+          };
+          video.addEventListener("seeked", onSeeked);
+          video.currentTime = time;
+        });
+      }
+ 
+      if (lastRunIdRef.current === runId) {
+        setIsGenerating(false);
+      }
+    } finally {
+      video.src = "";
+      if (offscreenVideoRef.current === video) {
+        offscreenVideoRef.current = null;
+      }
+    }
+  }, [videoSrc, duration, revokeAllObjectUrls]);
+ 
+  useEffect(() => {
+    if (videoSrc && duration > 0) {
+      generateThumbnails();
+    }
+    return () => {
+      cancelThumbnailRun();
+      revokeAllObjectUrls();
+    };
+  }, [cancelThumbnailRun, generateThumbnails, revokeAllObjectUrls, videoSrc, duration]);
+ 
+  // ── Drag & Drop Interactions ──
+  const xToSeconds = useCallback((clientX: number) => {
+    const track = trackRef.current;
+    if (!track || duration <= 0) return 0;
+    const { left, width } = track.getBoundingClientRect();
+    const ratio = Math.max(0, Math.min(1, (clientX - left) / width));
+    return ratio * duration;
+  }, [duration]);
+ 
+  // Snapping calculations
+  const calculateSnap = useCallback((seconds: number, threshold = 0.25) => {
+    // Candidates for snapping: start (0), end (duration), and multiples of snapStep
+    const candidates: number[] = [0, duration];
+    for (let t = snapStep; t < duration; t += snapStep) {
+      candidates.push(t);
+    }
+ 
+    let closestTime = seconds;
+    let minDistance = Infinity;
+ 
+    candidates.forEach((cand) => {
+      const dist = Math.abs(seconds - cand);
+      if (dist < minDistance && dist <= threshold) {
+        minDistance = dist;
+        closestTime = cand;
+      }
+    });
+ 
+    return {
+      time: closestTime,
+      snapped: minDistance !== Infinity && closestTime !== seconds,
+    };
+  }, [duration, snapStep]);
+ 
+  const handleDrag = useCallback((clientX: number) => {
+    if (!draggingRef.current || duration <= 0) return;
+ 
+    const currentSeconds = xToSeconds(clientX);
+ 
+    if (draggingRef.current === "playhead") {
+      const snap = calculateSnap(currentSeconds, 0.15);
+      onSeek(Math.max(0, Math.min(duration, snap.time)));
+      setSnapGuideTime(snap.snapped ? snap.time : null);
+    } else if (draggingRef.current === "start") {
+      const snap = calculateSnap(currentSeconds, 0.25);
+      const clamped = Math.max(0, Math.min(snap.time, effectiveTrimEnd - 0.1));
+      onChange({ trimStart: parseFloat(clamped.toFixed(2)) });
+      setSnapGuideTime(snap.snapped ? clamped : null);
+    } else if (draggingRef.current === "end") {
+      const snap = calculateSnap(currentSeconds, 0.25);
+      const clamped = Math.min(duration, Math.max(snap.time, recipe.trimStart + 0.1));
+      onChange({ trimEnd: parseFloat(clamped.toFixed(2)) });
+      setSnapGuideTime(snap.snapped ? clamped : null);
+    } else if (draggingRef.current === "clip") {
+      const deltaSeconds = currentSeconds - dragStartOffsetRef.current;
+      let newStart = dragStartClipRef.current.start + deltaSeconds;
+      let newEnd = dragStartClipRef.current.end + deltaSeconds;
+ 
+      // Handle boundaries
+      if (newStart < 0) {
+        newEnd -= newStart;
+        newStart = 0;
+      }
+      if (newEnd > duration) {
+        newStart -= (newEnd - duration);
+        newEnd = duration;
+      }
+ 
+      // Snap both sides together
+      const startSnap = calculateSnap(newStart, 0.25);
+      const endSnap = calculateSnap(newEnd, 0.25);
+ 
+      let activeSnapTime: number | null = null;
+      if (startSnap.snapped) {
+        const offset = startSnap.time - newStart;
+        newStart = startSnap.time;
+        newEnd = Math.min(duration, newEnd + offset);
+        activeSnapTime = startSnap.time;
+      } else if (endSnap.snapped) {
+        const offset = endSnap.time - newEnd;
+        newEnd = endSnap.time;
+        newStart = Math.max(0, newStart + offset);
+        activeSnapTime = endSnap.time;
+      }
+ 
+      onChange({
+        trimStart: parseFloat(newStart.toFixed(2)),
+        trimEnd: parseFloat(newEnd.toFixed(2)),
+      });
+      setSnapGuideTime(activeSnapTime);
+    }
+  }, [xToSeconds, duration, effectiveTrimEnd, recipe.trimStart, onChange, onSeek, calculateSnap]);
+ 
+  const handleMouseDown = (
+    e: React.MouseEvent,
+    type: "start" | "end" | "clip" | "playhead"
+  ) => {
+    e.preventDefault();
+    e.stopPropagation();
+    draggingRef.current = type;
+ 
+    const clientX = e.clientX;
+    const currentSecs = xToSeconds(clientX);
+    dragStartOffsetRef.current = currentSecs;
+    dragStartClipRef.current = { start: recipe.trimStart, end: effectiveTrimEnd };
+ 
+    if (type === "playhead") {
+      handleDrag(clientX);
+    }
+  };
+ 
+  const handleTouchStart = (
+    e: React.TouchEvent,
+    type: "start" | "end" | "clip" | "playhead"
+  ) => {
+    const touch = e.touches[0];
+    if (!touch) return;
+    e.stopPropagation();
+    draggingRef.current = type;
+ 
+    const clientX = touch.clientX;
+    const currentSecs = xToSeconds(clientX);
+    dragStartOffsetRef.current = currentSecs;
+    dragStartClipRef.current = { start: recipe.trimStart, end: effectiveTrimEnd };
+ 
+    if (type === "playhead") {
+      handleDrag(clientX);
+    }
+  };
+ 
+  useEffect(() => {
+    const onMove = (e: MouseEvent | TouchEvent) => {
+      if (!draggingRef.current) return;
+      
+      let clientX: number;
+      if ("touches" in e) {
+        const touch = e.touches[0];
+        if (!touch) return;
+        clientX = touch.clientX;
+      } else {
+        clientX = e.clientX;
+      }
+      
+      handleDrag(clientX);
+    };
+ 
+    const onUp = () => {
+      draggingRef.current = null;
+      setSnapGuideTime(null);
+    };
+ 
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+    document.addEventListener("touchmove", onMove, { passive: true });
+    document.addEventListener("touchend", onUp);
+ 
+    return () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+      document.removeEventListener("touchmove", onMove);
+      document.removeEventListener("touchend", onUp);
+    };
+  }, [handleDrag]);
+ 
+  // Grid tick markers for the time ruler
+  const ticks = useMemo(() => {
+    const result: { time: number; label: string; xPct: number }[] = [];
+    const tickInterval = snapStep;
+    for (let t = 0; t <= duration; t += tickInterval) {
+      const minutes = Math.floor(t / 60);
+      const seconds = Math.floor(t % 60);
+      result.push({
+        time: t,
+        label: `${minutes}:${seconds.toString().padStart(2, "0")}`,
+        xPct: (t / duration) * 100,
+      });
+    }
+    return result;
+  }, [duration, snapStep]);
+ 
+  if (!videoSrc || duration <= 0) return null;
+ 
+  const playheadPct = (currentTime / duration) * 100;
+  const clipLeftPct = (recipe.trimStart / duration) * 100;
+  const clipRightPct = ((duration - effectiveTrimEnd) / duration) * 100;
+ 
+  return (
+    <div className="timeline-editor-wrapper select-none animate-fade-in">
+      {/* ── Time Ruler ticks ── */}
+      <div
+        className="timeline-ruler"
+        onMouseDown={(e) => handleMouseDown(e, "playhead")}
+        onTouchStart={(e) => handleTouchStart(e, "playhead")}
+      >
+        {ticks.map((tick) => (
+          <div
+            key={tick.time}
+            className="ruler-tick"
+            style={{ left: `${tick.xPct}%` }}
+          >
+            <span className="tick-label">{tick.label}</span>
+          </div>
+        ))}
+      </div>
+ 
+      {/* ── Visual Frame Track & Interactivity ── */}
+      <div className="timeline-track-container" ref={trackRef}>
+        
+        {/* Continuous backdrop of generated thumbnails */}
+        <div className="track-thumbnails">
+          {thumbnails.length === 0 && isGenerating && (
+            <div className="track-skeleton">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div key={i} className="skeleton-frame" style={{ animationDelay: `${i * 80}ms` }} />
+              ))}
+            </div>
+          )}
+          {thumbnails.length > 0 && (
+            <div className="track-frames-inner">
+              {thumbnails.map((thumb) => (
+                <div key={thumb.time} className="track-frame">
+                  <Image
+                    src={thumb.dataUrl}
+                    alt="Timeline Frame"
+                    fill
+                    sizes="120px"
+                    unoptimized
+                    draggable={false}
+                    className="object-cover opacity-60 grayscale-[10%]"
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+ 
+        {/* Dimmer overlays for regions out of trim bounds */}
+        <div className="track-dimmer track-dimmer-left" style={{ width: `${clipLeftPct}%` }} />
+        <div className="track-dimmer track-dimmer-right" style={{ width: `${clipRightPct}%` }} />
+ 
+        {/* Draggable Active Clip Box */}
+        <div
+          className="timeline-clip-active"
+          style={{
+            left: `${clipLeftPct}%`,
+            right: `${clipRightPct}%`,
+          }}
+          onMouseDown={(e) => handleMouseDown(e, "clip")}
+          onTouchStart={(e) => handleTouchStart(e, "clip")}
+        >
+          {/* Trim Handles */}
+          <div
+            className="trim-handle trim-handle-left"
+            onMouseDown={(e) => handleMouseDown(e, "start")}
+            onTouchStart={(e) => handleTouchStart(e, "start")}
+            role="slider"
+            aria-label="Drag start trim handle"
+            aria-valuenow={recipe.trimStart}
+          >
+            <GripVertical size={14} className="text-white drop-shadow" />
+          </div>
+          
+          <div
+            className="trim-handle trim-handle-right"
+            onMouseDown={(e) => handleMouseDown(e, "end")}
+            onTouchStart={(e) => handleTouchStart(e, "end")}
+            role="slider"
+            aria-label="Drag end trim handle"
+            aria-valuenow={effectiveTrimEnd}
+          >
+            <GripVertical size={14} className="text-white drop-shadow" />
+          </div>
+        </div>
+ 
+        {/* Snap Guide Line */}
+        {snapGuideTime !== null && (
+          <div
+            className="snap-guide-line"
+            style={{ left: `${(snapGuideTime / duration) * 100}%` }}
+          />
+        )}
+ 
+        {/* Vertical Red Playhead Bar */}
+        <div
+          className="timeline-playhead-bar"
+          style={{ left: `${playheadPct}%` }}
+          onMouseDown={(e) => handleMouseDown(e, "playhead")}
+          onTouchStart={(e) => handleTouchStart(e, "playhead")}
+        >
+          <div className="playhead-head" />
+        </div>
+      </div>
+ 
+      {/* ── Metadata / Status Overlay ── */}
+      <div className="timeline-meta flex items-center justify-between text-xs px-3 py-2 bg-[var(--surface)] text-[var(--muted)] font-heading border-t border-[var(--border)]">
+        <span className="flex items-center gap-1">
+          🎬 Clip range: <span className="font-bold text-[var(--text)]">{recipe.trimStart.toFixed(1)}s – {effectiveTrimEnd.toFixed(1)}s</span>
+        </span>
+        <span className="flex items-center gap-1">
+          ⏰ Length: <span className="font-bold text-film-600">{formatDuration(clipLength)}</span> of {formatDuration(duration)}
+        </span>
+      </div>
+ 
+      <style>{`
+        .timeline-editor-wrapper {
+          width: 100%;
+          background: var(--surface);
+          border: 1px solid var(--border);
+          border-radius: var(--radius);
+          overflow: hidden;
+          box-shadow: var(--shadow);
+          font-family: inherit;
+        }
+ 
+        .timeline-ruler {
+          position: relative;
+          height: 24px;
+          background: var(--bg);
+          border-bottom: 1px solid var(--border);
+          cursor: pointer;
+        }
+ 
+        .ruler-tick {
+          position: absolute;
+          top: 0;
+          height: 100%;
+          width: 1px;
+          background: var(--border);
+        }
+ 
+        .tick-label {
+          position: absolute;
+          left: 4px;
+          bottom: 2px;
+          font-size: 8px;
+          font-family: 'SF Mono', 'Fira Code', monospace;
+          color: var(--muted);
+          font-weight: 500;
+        }
+ 
+        .timeline-track-container {
+          position: relative;
+          height: 64px;
+          background: var(--bg);
+          overflow: hidden;
+        }
+ 
+        .track-thumbnails {
+          position: absolute;
+          inset: 0;
+          display: flex;
+        }
+ 
+        .track-skeleton {
+          display: flex;
+          gap: 2px;
+          width: 100%;
+          height: 100%;
+        }
+ 
+        .skeleton-frame {
+          flex: 1;
+          height: 100%;
+          background: linear-gradient(90deg, var(--bg) 25%, var(--surface) 50%, var(--bg) 75%);
+          background-size: 200% 100%;
+          animation: shimmer 1.4s infinite;
+        }
+ 
+        .track-frames-inner {
+          display: flex;
+          width: 100%;
+          height: 100%;
+          gap: 2px;
+        }
+ 
+        .track-frame {
+          position: relative;
+          flex: 1;
+          height: 100%;
+        }
+ 
+        .track-dimmer {
+          position: absolute;
+          top: 0;
+          bottom: 0;
+          background: rgba(0, 0, 0, 0.65);
+          backdrop-filter: blur(1px);
+          z-index: 1;
+          pointer-events: none;
+        }
+ 
+        .track-dimmer-left {
+          left: 0;
+        }
+ 
+        .track-dimmer-right {
+          right: 0;
+        }
+ 
+        .timeline-clip-active {
+          position: absolute;
+          top: 2px;
+          bottom: 2px;
+          background: var(--accent-muted);
+          border: 2px solid var(--accent);
+          border-radius: 4px;
+          z-index: 2;
+          cursor: grab;
+          box-shadow: inset 0 0 10px rgba(var(--accent-rgb), 0.15), var(--shadow);
+        }
+ 
+        .timeline-clip-active:active {
+          cursor: grabbing;
+          background: var(--accent-hover-muted);
+        }
+ 
+        .trim-handle {
+          position: absolute;
+          top: 0;
+          bottom: 0;
+          width: 12px;
+          background: var(--accent);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          cursor: col-resize;
+          z-index: 3;
+        }
+ 
+        .trim-handle-left {
+          left: 0;
+          border-top-left-radius: 2px;
+          border-bottom-left-radius: 2px;
+        }
+ 
+        .trim-handle-right {
+          right: 0;
+          border-top-right-radius: 2px;
+          border-bottom-right-radius: 2px;
+        }
+ 
+        .timeline-playhead-bar {
+          position: absolute;
+          top: 0;
+          bottom: 0;
+          width: 2px;
+          background: var(--error-bg, #ef4444);
+          z-index: 10;
+          cursor: col-resize;
+          pointer-events: none;
+        }
+ 
+        .playhead-head {
+          position: absolute;
+          top: -2px;
+          left: 50%;
+          transform: translateX(-50%);
+          width: 10px;
+          height: 10px;
+          background: var(--error-bg, #ef4444);
+          border-radius: 50%;
+          box-shadow: 0 0 4px rgba(239, 68, 68, 0.6);
+        }
+ 
+        .snap-guide-line {
+          position: absolute;
+          top: 0;
+          bottom: 0;
+          width: 1.5px;
+          border-left: 1.5px dashed var(--accent);
+          z-index: 8;
+          pointer-events: none;
+          animation: pulse-guide 0.8s ease-in-out infinite;
+        }
+ 
+        @keyframes pulse-guide {
+          0%, 100% { opacity: 0.8; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/components/TimelineEditor.tsx
+++ b/src/components/TimelineEditor.tsx
@@ -363,6 +363,16 @@ export default function TimelineEditor({
         className="timeline-ruler"
         onMouseDown={(e) => handleMouseDown(e, "playhead")}
         onTouchStart={(e) => handleTouchStart(e, "playhead")}
+        role="slider"
+        aria-label="Timeline time ruler"
+        aria-valuenow={currentTime}
+        aria-valuemin={0}
+        aria-valuemax={duration}
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "ArrowLeft") onSeek(Math.max(0, currentTime - 1));
+          if (e.key === "ArrowRight") onSeek(Math.min(duration, currentTime + 1));
+        }}
       >
         {ticks.map((tick) => (
           <div
@@ -419,6 +429,21 @@ export default function TimelineEditor({
           }}
           onMouseDown={(e) => handleMouseDown(e, "clip")}
           onTouchStart={(e) => handleTouchStart(e, "clip")}
+          role="button"
+          tabIndex={0}
+          aria-label="Active video clip range"
+          onKeyDown={(e) => {
+            if (e.key === "ArrowLeft") {
+              const newStart = Math.max(0, recipe.trimStart - 0.1);
+              const offset = recipe.trimStart - newStart;
+              onChange({ trimStart: parseFloat(newStart.toFixed(2)), trimEnd: parseFloat((effectiveTrimEnd - offset).toFixed(2)) });
+            }
+            if (e.key === "ArrowRight") {
+              const newEnd = Math.min(duration, effectiveTrimEnd + 0.1);
+              const offset = newEnd - effectiveTrimEnd;
+              onChange({ trimStart: parseFloat((recipe.trimStart + offset).toFixed(2)), trimEnd: parseFloat(newEnd.toFixed(2)) });
+            }
+          }}
         >
           {/* Trim Handles */}
           <div
@@ -428,6 +453,13 @@ export default function TimelineEditor({
             role="slider"
             aria-label="Drag start trim handle"
             aria-valuenow={recipe.trimStart}
+            aria-valuemin={0}
+            aria-valuemax={duration}
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "ArrowLeft") onChange({ trimStart: Math.max(0, recipe.trimStart - 0.1) });
+              if (e.key === "ArrowRight") onChange({ trimStart: Math.min(effectiveTrimEnd - 0.1, recipe.trimStart + 0.1) });
+            }}
           >
             <GripVertical size={14} className="text-white drop-shadow" />
           </div>
@@ -439,6 +471,13 @@ export default function TimelineEditor({
             role="slider"
             aria-label="Drag end trim handle"
             aria-valuenow={effectiveTrimEnd}
+            aria-valuemin={0}
+            aria-valuemax={duration}
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "ArrowLeft") onChange({ trimEnd: Math.max(recipe.trimStart + 0.1, effectiveTrimEnd - 0.1) });
+              if (e.key === "ArrowRight") onChange({ trimEnd: Math.min(duration, effectiveTrimEnd + 0.1) });
+            }}
           >
             <GripVertical size={14} className="text-white drop-shadow" />
           </div>
@@ -458,6 +497,16 @@ export default function TimelineEditor({
           style={{ left: `${playheadPct}%` }}
           onMouseDown={(e) => handleMouseDown(e, "playhead")}
           onTouchStart={(e) => handleTouchStart(e, "playhead")}
+          role="slider"
+          aria-label="Playhead scrubber"
+          aria-valuenow={currentTime}
+          aria-valuemin={0}
+          aria-valuemax={duration}
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === "ArrowLeft") onSeek(Math.max(0, currentTime - 1));
+            if (e.key === "ArrowRight") onSeek(Math.min(duration, currentTime + 1));
+          }}
         >
           <div className="playhead-head" />
         </div>

--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -177,64 +177,7 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
 
   return (
     <div id="trim-control" className="space-y-3">
-      {duration > 0 && (
-        <div
-          role="toolbar"
-          aria-label="Trim timeline"
-          ref={trackRef}
-          className="relative h-6 flex items-center cursor-pointer select-none"
-          onClick={(e) => {
-            if (dragging.current) return;
-            const s = xToSeconds(e.clientX);
-            onChange({ trimStart: s });
-          }}
-          onKeyDown={(e) => {
-            if (e.key === "ArrowLeft") onChange({ trimStart: Math.max(0, recipe.trimStart - 0.1) });
-            if (e.key === "ArrowRight") onChange({ trimStart: Math.min((recipe.trimEnd ?? duration) - 0.1, recipe.trimStart + 0.1) });
-          }}
-        >
-          <div className="absolute inset-x-0 h-1.5 rounded-full bg-[var(--border)]" />
-          <div
-            className="absolute h-1.5 rounded-full bg-film-400 opacity-60"
-            style={{
-              left: `${(recipe.trimStart / duration) * 100}%`,
-              right: `${((duration - (recipe.trimEnd ?? duration)) / duration) * 100}%`,
-            }}
-          />
-          <div
-            role="slider"
-            aria-label="Trim start"
-            aria-valuenow={recipe.trimStart}
-            aria-valuemin={0}
-            aria-valuemax={duration}
-            tabIndex={0}
-            className="absolute w-4 h-4 rounded-full bg-white border-2 border-film-400 shadow cursor-grab active:cursor-grabbing -translate-x-1/2 focus:outline-none focus:ring-2 focus:ring-film-400"
-            style={{ left: `${(recipe.trimStart / duration) * 100}%` }}
-            onMouseDown={() => { dragging.current = "start"; }}
-            onTouchStart={() => { dragging.current = "start"; }}
-            onKeyDown={(e) => {
-              if (e.key === "ArrowLeft") onChange({ trimStart: Math.max(0, recipe.trimStart - 0.1) });
-              if (e.key === "ArrowRight") onChange({ trimStart: Math.min((recipe.trimEnd ?? duration) - 0.1, recipe.trimStart + 0.1) });
-            }}
-          />
-          <div
-            role="slider"
-            aria-label="Trim end"
-            aria-valuenow={recipe.trimEnd ?? duration}
-            aria-valuemin={0}
-            aria-valuemax={duration}
-            tabIndex={0}
-            className="absolute w-4 h-4 rounded-full bg-white border-2 border-film-400 shadow cursor-grab active:cursor-grabbing -translate-x-1/2 focus:outline-none focus:ring-2 focus:ring-film-400"
-            style={{ left: `${((recipe.trimEnd ?? duration) / duration) * 100}%` }}
-            onMouseDown={() => { dragging.current = "end"; }}
-            onTouchStart={() => { dragging.current = "end"; }}
-            onKeyDown={(e) => {
-              if (e.key === "ArrowLeft") onChange({ trimEnd: Math.max(recipe.trimStart + 0.1, (recipe.trimEnd ?? duration) - 0.1) });
-              if (e.key === "ArrowRight") onChange({ trimEnd: Math.min(duration, (recipe.trimEnd ?? duration) + 0.1) });
-            }}
-          />
-        </div>
-      )}
+
       <div className="flex gap-3">
         <div className="flex-1">
           <label

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -5,7 +5,7 @@ import { useVideoEditor } from "@/hooks/useVideoEditor";
 import { TextOverlay } from "@/lib/types";
 import FileUpload from "./FileUpload";
 import VideoPreview from "./VideoPreview";
-import ThumbnailStrip from "./ThumbnailStrip";
+import TimelineEditor from "./TimelineEditor";
 import PresetSelector from "./PresetSelector";
 import FramingControl from "./FramingControl";
 import TrimControl from "./TrimControl";
@@ -397,14 +397,13 @@ export default function VideoEditor() {
                   />
 
                   <div className="mt-3">
-                    <ThumbnailStrip
+                    <TimelineEditor
                       videoSrc={videoSrc}
                       duration={duration}
                       currentTime={currentTime}
-                      trimStart={recipe.trimStart ?? 0}
-                      trimEnd={recipe.trimEnd ?? duration}
+                      recipe={recipe}
+                      onChange={updateRecipe}
                       onSeek={seekTo}
-                      intervalSeconds={intervalSeconds}
                     />
                   </div>
                 </div>

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -17,12 +17,14 @@ import ExportSettings from "./ExportSettings";
 import ExportOverlay from "./ExportOverlay";
 import DownloadResult from "./DownloadResult";
 import ImageOverlay from "./ImageOverlay"
+import SubtitleControls from "./SubtitleControls";
 import { getPresetById } from "@/lib/presets";
 
 import { cn } from "@/lib/utils";
 import {
   Layers, Crop, Scissors, RotateCw, Volume2, Type,
-  SlidersHorizontal, Zap, AlertTriangle, Github, Copy
+  SlidersHorizontal, Zap, AlertTriangle, Github, Copy,
+  Subtitles
 } from "lucide-react";
 import OnboardingTour from "./OnboardingTour";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
@@ -210,6 +212,10 @@ export default function VideoEditor() {
     recommendedPreset,
     currentTime,
     toggleSound,
+    subtitleFile,
+    parsedSubtitles,
+    handleSubtitleSelect,
+    clearSubtitles,
   } = useVideoEditor();
 
   useKeyboardShortcuts({
@@ -231,6 +237,7 @@ export default function VideoEditor() {
     trim: false,
     rotation: false,
     text: false,
+    subtitles: false,
     audio: false,
     export: false,
   });
@@ -394,6 +401,7 @@ export default function VideoEditor() {
                     selectedTextId={selectedTextId}
                     onSelectText={setSelectedTextId}
                     onUpdateText={handleUpdateTextOverlay}
+                    parsedSubtitles={parsedSubtitles}
                   />
 
                   <div className="mt-3">
@@ -461,6 +469,25 @@ export default function VideoEditor() {
                       onChange={updateRecipe}
                       selectedTextId={selectedTextId}
                       onSelectText={setSelectedTextId}
+                    />
+                  </AccordionSection>
+
+                  <AccordionSection
+                    id="subtitles"
+                    icon={<Subtitles size={12} />}
+                    title="Subtitles / Captions"
+                    isOpen={openSections.subtitles}
+                    onToggle={() => toggleSection("subtitles")}
+                    delay={115}
+                  >
+                    <SubtitleControls
+                      recipe={recipe}
+                      onChange={updateRecipe}
+                      subtitleFile={subtitleFile}
+                      parsedSubtitles={parsedSubtitles}
+                      onSubtitleSelect={handleSubtitleSelect}
+                      onClearSubtitles={clearSubtitles}
+                      onSeek={seekTo}
                     />
                   </AccordionSection>
                 </div>

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -271,7 +271,7 @@ export default function VideoEditor() {
     }
   }, [status]);
 
-  const isProcessing = status === "loading-engine" || status === "exporting";
+  const isProcessing = status === "loading" || status === "loading-engine" || status === "exporting";
   const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
 
   const intervalSeconds = useMemo(() => {
@@ -370,7 +370,13 @@ export default function VideoEditor() {
 
           <div className="space-y-4 min-w-0">
             <div className="bg-[var(--surface)] rounded-xl p-3 border border-[var(--border)] animate-fade-in">
-              <FileUpload onFileSelect={handleFileSelect} currentFile={file} fileError={fileError} duration={duration} />
+              <FileUpload
+                onFileSelect={handleFileSelect}
+                currentFile={file}
+                fileError={fileError}
+                duration={duration}
+                isLoading={status === "loading"}
+              />
 
               {!file && (
                 <div className="text-center text-[var(--muted)] py-6">

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { Camera } from "lucide-react";
 import ComparisonPreview from "./ComparisonPreview";
 import DraggableTextOverlays from "./DraggableTextOverlays";
+import { SubtitleItem } from "@/lib/subtitles";
 
 interface Props {
   file: File | null;
@@ -16,6 +17,7 @@ interface Props {
   selectedTextId?: string | null;
   onSelectText?: (id: string | null) => void;
   onUpdateText?: (id: string, updates: Partial<TextOverlay>) => void;
+  parsedSubtitles?: SubtitleItem[] | null;
 }
 
 export default function VideoPreview({
@@ -25,7 +27,40 @@ export default function VideoPreview({
   selectedTextId = null,
   onSelectText,
   onUpdateText,
+  parsedSubtitles = null,
 }: Props) {
+  const [localCurrentTime, setLocalCurrentTime] = useState(0);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    const handleTimeUpdate = () => {
+      setLocalCurrentTime(video.currentTime);
+    };
+
+    video.addEventListener("timeupdate", handleTimeUpdate);
+    return () => {
+      video.removeEventListener("timeupdate", handleTimeUpdate);
+    };
+  }, [videoRef, file]);
+
+  const activeSub = useMemo(() => {
+    if (!parsedSubtitles || parsedSubtitles.length === 0) return null;
+    return parsedSubtitles.find(
+      (sub) => localCurrentTime >= sub.startTime && localCurrentTime <= sub.endTime
+    );
+  }, [parsedSubtitles, localCurrentTime]);
+
+  const scaledFontSize = useMemo(() => {
+    if (!recipe) return 24;
+    const preset = recipe.preset === "custom"
+      ? { width: recipe.customWidth, height: recipe.customHeight }
+      : getPresetById(recipe.preset);
+    const targetH = preset?.height ?? 1080;
+    const scale = containerDimensions.height / targetH;
+    return Math.max(12, Math.round(recipe.subtitleSize * scale));
+  }, [recipe, containerDimensions.height]);
   const lastId = useRef(0);
   const urlRef = useRef<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -287,6 +322,40 @@ export default function VideoPreview({
                 />
               </>
             )}
+          </div>
+        )}
+
+        {/* Subtitles Overlay */}
+        {activeSub && recipe && (
+          <div
+            className="absolute left-1/2 -translate-x-1/2 pointer-events-none text-center select-none z-10 max-w-[85%] font-medium transition-all"
+            style={{
+              bottom: "12%",
+              fontFamily: recipe.subtitleFont === "system-ui" ? "system-ui, sans-serif" : `'${recipe.subtitleFont}', system-ui, sans-serif`,
+              fontSize: `${scaledFontSize}px`,
+              color: recipe.subtitleColor,
+              lineHeight: 1.3,
+              whiteSpace: "pre-line",
+              paintOrder: "stroke fill",
+              ...(recipe.subtitleBgType === "box" && {
+                backgroundColor: `color-mix(in srgb, ${recipe.subtitleBgColor} 75%, transparent)`,
+                padding: "0.25em 0.6em",
+                borderRadius: "0.375em",
+                boxShadow: "0 4px 12px rgba(0,0,0,0.3)",
+              }),
+              ...(recipe.subtitleBgType === "shadow" && {
+                textShadow: `0 2px 4px rgba(0,0,0,0.5), 0 4px 12px color-mix(in srgb, ${recipe.subtitleBgColor} 60%, transparent)`,
+              }),
+              ...(recipe.subtitleBgType === "outline" && {
+                WebkitTextStroke: `1.5px ${recipe.subtitleBgColor}`,
+                textShadow: "0 2px 4px rgba(0,0,0,0.8)",
+              }),
+              ...(recipe.subtitleBgType === "none" && {
+                textShadow: "0 2px 4px rgba(0,0,0,0.8)",
+              }),
+            }}
+          >
+            {activeSub.text}
           </div>
         )}
 

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -30,6 +30,10 @@ export default function VideoPreview({
   parsedSubtitles = null,
 }: Props) {
   const [localCurrentTime, setLocalCurrentTime] = useState(0);
+  const [containerDimensions, setContainerDimensions] = useState({
+    width: 0,
+    height: 0,
+  });
 
   useEffect(() => {
     const video = videoRef.current;
@@ -66,10 +70,6 @@ export default function VideoPreview({
   const [isLoading, setIsLoading] = useState(true);
   const [showOverlay, setShowOverlay] = useState(false);
   const [showComparison, setShowComparison] = useState(false);
-  const [containerDimensions, setContainerDimensions] = useState({
-    width: 0,
-    height: 0,
-  });
   const previewContainerRef = useRef<HTMLDivElement>(null);
   const onLoadedRef = useRef<(() => void) | null>(null);
 

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/no-noninteractive-tabindex, jsx-a11y/no-noninteractive-element-interactions */
 "use client";
 
-import { useEffect, useRef, useState, useCallback, RefObject } from "react";
+import { useEffect, useRef, useState, useCallback, useMemo, RefObject } from "react";
 import { EditRecipe, TextOverlay } from "@/lib/types";
 import { getPresetById } from "@/lib/presets";
 import { cn } from "@/lib/utils";
@@ -124,23 +124,40 @@ export default function VideoPreview({
     videoRef.current.playbackRate = recipe.speed;
   }, [recipe, videoRef]);
 
+  const aspectStyle = useMemo(() => {
+    if (!recipe) return undefined;
+    const preset = recipe.preset === "custom"
+      ? { width: recipe.customWidth, height: recipe.customHeight }
+      : getPresetById(recipe.preset);
+    if (!preset) return undefined;
+    return { aspectRatio: `${preset.width} / ${preset.height}` };
+  }, [recipe]);
+
   /**
-   * Track preview container dimensions for text overlay positioning.
+   * Track preview container dimensions for text overlay positioning using ResizeObserver.
    */
   useEffect(() => {
+    const container = previewContainerRef.current;
+    if (!container) return;
+
     const updateDimensions = () => {
-      if (previewContainerRef.current) {
-        const rect = previewContainerRef.current.getBoundingClientRect();
-        setContainerDimensions({
-          width: rect.width,
-          height: rect.height,
-        });
-      }
+      const rect = container.getBoundingClientRect();
+      setContainerDimensions({
+        width: rect.width,
+        height: rect.height,
+      });
     };
 
     updateDimensions();
-    window.addEventListener("resize", updateDimensions);
-    return () => window.removeEventListener("resize", updateDimensions);
+
+    const observer = new ResizeObserver(() => {
+      updateDimensions();
+    });
+
+    observer.observe(container);
+    return () => {
+      observer.disconnect();
+    };
   }, []);
 
   const overlay = (() => {
@@ -217,7 +234,8 @@ export default function VideoPreview({
       <div
         ref={previewContainerRef}
         role="group"
-        className="relative w-full rounded-lg overflow-hidden bg-[var(--bg)] aspect-video focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+        className="relative w-full rounded-lg overflow-hidden bg-[var(--bg)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] mx-auto max-h-[60vh] object-contain"
+        style={aspectStyle || { aspectRatio: "16 / 9" }}
         tabIndex={0}
         onKeyDown={handleKeyDown}
         aria-label="Video preview (press Space to play/pause)"

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -7,6 +7,7 @@ import { getPresetById } from "@/lib/presets";
 import { loadFFmpeg, exportVideo, terminateFFmpeg, FFmpegLoadError } from "@/lib/ffmpeg";
 import { suggestPreset } from "@/lib/presetSuggestion";
 import { validateDimensions, getDownscaledDimensions } from "@/utils/video-validation";
+import { SubtitleItem, parseSRT } from "@/lib/subtitles";
 
 const DEFAULT_TITLE = "Reframe — Resize, trim, and export videos in your browser";
   const STORAGE_KEY = "reframe:recipe";
@@ -174,6 +175,28 @@ export function useVideoEditor() {
   const [overlaySize, setOverlaySize] = useState(150);
   const [overlayOpacity, setOverlayOpacity] = useState(100);
   const [currentTime, setCurrentTime] = useState(0);
+
+  const [subtitleFile, setSubtitleFile] = useState<File | null>(null);
+  const [parsedSubtitles, setParsedSubtitles] = useState<SubtitleItem[] | null>(null);
+
+  const handleSubtitleSelect = useCallback(async (selectedFile: File) => {
+    if (!selectedFile) return;
+    setSubtitleFile(selectedFile);
+    try {
+      const text = await selectedFile.text();
+      const subs = parseSRT(text);
+      setParsedSubtitles(subs);
+    } catch (err) {
+      console.error("Failed to parse subtitle file:", err);
+      setParsedSubtitles([]);
+    }
+  }, []);
+
+  const clearSubtitles = useCallback(() => {
+    setSubtitleFile(null);
+    setParsedSubtitles(null);
+  }, []);
+
  const updateRecipe = useCallback((patch: Partial<EditRecipe>) => {
   setRecipe((prev) => {
     const next = { ...prev, ...patch };
@@ -212,6 +235,16 @@ export function useVideoEditor() {
         return typeof val === "number" && !isNaN(val) && val >= 0 && val <= 2;
       case "saturation":
         return typeof val === "number" && !isNaN(val) && val >= 0 && val <= 3;
+      case "subtitleFont":
+        return typeof val === "string";
+      case "subtitleColor":
+        return typeof val === "string";
+      case "subtitleSize":
+        return typeof val === "number" && !isNaN(val) && val >= 10 && val <= 120;
+      case "subtitleBgType":
+        return ["none", "box", "shadow", "outline"].includes(val);
+      case "subtitleBgColor":
+        return typeof val === "string";
       default:
         return true;
     }
@@ -483,7 +516,8 @@ export function useVideoEditor() {
           position: overlayPosition,
           size: overlaySize,
           opacity: overlayOpacity,
-        }
+        },
+        parsedSubtitles ?? undefined
       );
       if (exportCancelledRef.current) return;
 
@@ -527,6 +561,7 @@ export function useVideoEditor() {
     recipe,
     result,
     status,
+    parsedSubtitles,
   ]);
 
 
@@ -633,6 +668,7 @@ export function useVideoEditor() {
     overlayPosition,
     overlaySize,
     overlayOpacity,
+    subtitleFile,
   ]);
 
   useEffect(() => {
@@ -673,6 +709,8 @@ export function useVideoEditor() {
     setResult(null);
     setError(null);
     setExportStartedAt(null);
+    setSubtitleFile(null);
+    setParsedSubtitles(null);
     try {
       localStorage.removeItem(STORAGE_KEY);
     } catch {
@@ -738,5 +776,9 @@ export function useVideoEditor() {
     recommendedPreset,
     currentTime,
     toggleSound,
+    subtitleFile,
+    parsedSubtitles,
+    handleSubtitleSelect,
+    clearSubtitles,
   };
 }

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -353,12 +353,13 @@ export function useVideoEditor() {
 
   const handleFileSelect = useCallback(async (selectedFile: File) => {
     setResult(null);
-    setStatus("idle");
+    setStatus("loading");
     setError(null);
     setFile(null);
     setVideoMetadata(null);
     if (!selectedFile.type.startsWith("video/")) {
       setFileError("Please upload a video file only.");
+      setStatus("idle");
       return;
     }
 
@@ -411,6 +412,7 @@ export function useVideoEditor() {
       setDuration(dur);
       setVideoMetadata({ width, height, duration: dur });
       setFile(selectedFile);
+      setStatus("idle");
 
       if (dimensionCheck === "warning") {
         console.warn(`[Reframe] High resolution video detected (${width}×${height}). Export may be slow.`);
@@ -612,6 +614,26 @@ export function useVideoEditor() {
       }
     }
    },[result?.blobUrl])
+
+  // Reset export status/result/error when recipe or options change after an export/error
+  useEffect(() => {
+    if (status === "done" || status === "error") {
+      setStatus("idle");
+      setResult(null);
+      setError(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    recipe,
+    musicFile,
+    musicVolume,
+    originalAudioVolume,
+    loopMusic,
+    overlayFile,
+    overlayPosition,
+    overlaySize,
+    overlayOpacity,
+  ]);
 
   useEffect(() => {
     return () => {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -23,5 +23,10 @@ export const DEFAULT_RECIPE: EditRecipe = {
   soundOnCompletion: false,
   normalizeAudio: false,
   textOverlays: [],
+  subtitleFont: "Inter",
+  subtitleColor: "#ffffff",
+  subtitleSize: 36,
+  subtitleBgType: "outline",
+  subtitleBgColor: "#000000",
   version: RECIPE_VERSION,
 };

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -4,6 +4,7 @@ import { EditRecipe, ExportResult, BackgroundMusicOptions, ImageOverlayOptions }
 import { getPresetById } from "./presets";
 import { buildTextFilter } from "./text-overlay";
 import { simd } from "wasm-feature-detect";
+import { SubtitleItem } from "./subtitles";
 
 const CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd";
 
@@ -98,7 +99,42 @@ function buildSessionId(): string {
   return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
-export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number): string {
+function buildSubtitleFilter(
+  sub: SubtitleItem,
+  recipe: EditRecipe,
+  targetW: number,
+  targetH: number
+): string {
+  const escapedText = sub.text
+    .replace(/\\/g, "\\\\")
+    .replace(/'/g, "'\\\\''")
+    .replace(/:/g, "\\:")
+    .replace(/\n/g, "\n");
+
+  const xExpr = "(w-text_w)/2";
+  const yExpr = "h-th-h*0.12";
+
+  let styleParams = "";
+  if (recipe.subtitleBgType === "box") {
+    const boxCol = recipe.subtitleBgColor.replace("#", "0x") + "@0.6";
+    styleParams = `:box=1:boxcolor=${boxCol}:boxborderw=8`;
+  } else if (recipe.subtitleBgType === "outline") {
+    const borderCol = recipe.subtitleBgColor;
+    styleParams = `:borderw=2:bordercolor=${borderCol}`;
+  } else if (recipe.subtitleBgType === "shadow") {
+    const shadowCol = recipe.subtitleBgColor.replace("#", "0x") + "@0.6";
+    styleParams = `:shadowcolor=${shadowCol}:shadowx=2:shadowy=2`;
+  }
+
+  return `drawtext=text='${escapedText}':x=${xExpr}:y=${yExpr}:fontsize=${recipe.subtitleSize}:fontcolor=${recipe.subtitleColor}${styleParams}:enable='between(t,${sub.startTime},${sub.endTime})'`;
+}
+
+export function buildVideoFilter(
+  recipe: EditRecipe,
+  targetW: number,
+  targetH: number,
+  subtitles?: SubtitleItem[]
+): string {
   const filters: string[] = [];
 
   if (recipe.trimStart > 0 || recipe.trimEnd !== null) {
@@ -162,6 +198,13 @@ export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: n
     filters.push(buildTextFilter(overlay, targetW, targetH));
   });
 
+  // Add subtitles if present
+  if (subtitles && subtitles.length > 0) {
+    subtitles.forEach((sub) => {
+      filters.push(buildSubtitleFilter(sub, recipe, targetW, targetH));
+    });
+  }
+
   return filters.join(",");
 }
 
@@ -209,9 +252,10 @@ function buildArguments(
   overlayInputName: string,
   overlayOptions: ImageOverlayOptions | undefined,
   hasOriginalAudio: boolean,
-  videoDuration: number
+  videoDuration: number,
+  subtitles?: SubtitleItem[]
 ): string[] {
-  const vf = buildVideoFilter(recipe, targetW, targetH);
+  const vf = buildVideoFilter(recipe, targetW, targetH, subtitles);
   const audioTrim = hasOriginalAudio ? buildAudioTrimFilter(recipe) : "";
   const audioSpeed = hasOriginalAudio ? buildAudioFilter(recipe.speed, recipe.normalizeAudio ?? false) : "";
   const afParts = [audioTrim, audioSpeed].filter(Boolean);
@@ -337,7 +381,8 @@ export async function exportVideo(
   onProgress: (percent: number) => void,
   signal?: AbortSignal,
   musicOptions?: BackgroundMusicOptions,
-  overlayOptions?: ImageOverlayOptions
+  overlayOptions?: ImageOverlayOptions,
+  subtitles?: SubtitleItem[]
 ): Promise<ExportResult> {
   const sessionId = buildSessionId();
   let targetW: number, targetH: number;
@@ -418,7 +463,7 @@ export async function exportVideo(
 
     // ── Two-pass GIF export ──────────────────────────────────────────────────
     if (recipe.format === "gif") {
-      const vf = buildVideoFilter(recipe, targetW, targetH);
+      const vf = buildVideoFilter(recipe, targetW, targetH, subtitles);
       const vfWithPalette = vf ? `${vf},palettegen` : "palettegen";
       const vfWithPaletteUse = vf
         ? `[0:v]${vf}[x];[x][1:v]paletteuse`
@@ -486,7 +531,8 @@ export async function exportVideo(
     let args = buildArguments(
       recipe, recipe.format, outputName, inputName, targetW, targetH,
       hasMusicTrack, musicInputName, musicOptions,
-      hasOverlay, overlayInputName, overlayOptions, true, videoDuration
+      hasOverlay, overlayInputName, overlayOptions, true, videoDuration,
+      subtitles
     );
 
     let exitCode = await ffmpeg.exec(args, undefined, { signal });
@@ -497,7 +543,8 @@ export async function exportVideo(
       args = buildArguments(
         recipe, recipe.format, outputName, inputName, targetW, targetH,
         hasMusicTrack, musicInputName, musicOptions,
-        hasOverlay, overlayInputName, overlayOptions, false, videoDuration
+        hasOverlay, overlayInputName, overlayOptions, false, videoDuration,
+        subtitles
       );
       exitCode = await ffmpeg.exec(args, undefined, { signal });
     }
@@ -507,7 +554,8 @@ export async function exportVideo(
       args = buildArguments(
         recipe, "webm", fallbackOutputName, inputName, targetW, targetH,
         hasMusicTrack, musicInputName, musicOptions,
-        hasOverlay, overlayInputName, overlayOptions, !missingAudioDetected, videoDuration
+        hasOverlay, overlayInputName, overlayOptions, !missingAudioDetected, videoDuration,
+        subtitles
       );
 
       const fallbackCode = await ffmpeg.exec(args, undefined, { signal });

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -1,6 +1,7 @@
 import { EditRecipe, ExportResult, BackgroundMusicOptions, ImageOverlayOptions } from "./types";
 import { getPresetById } from "./presets";
 import { buildTextFilter } from "./text-overlay";
+import { SubtitleItem } from "./subtitles";
 
 export class FFmpegLoadError extends Error {}
 
@@ -25,6 +26,7 @@ type WorkerExportRequest = {
   musicOptions?: BackgroundMusicOptions;
   overlayFile?: SerializedFile;
   overlayOptions?: ImageOverlayOptions;
+  subtitles?: SubtitleItem[];
 };
 
 type WorkerLoadResponse = { type: "ready" };
@@ -211,7 +213,8 @@ export async function exportVideo(
   onProgress: (percent: number) => void,
   signal?: AbortSignal,
   musicOptions?: BackgroundMusicOptions,
-  overlayOptions?: ImageOverlayOptions
+  overlayOptions?: ImageOverlayOptions,
+  subtitles?: SubtitleItem[]
 ): Promise<ExportResult> {
   await loadFFmpeg(signal, onProgress);
 
@@ -283,6 +286,7 @@ export async function exportVideo(
       musicOptions: sanitizedMusicOptions,
       overlayFile: overlayFilePayload,
       overlayOptions: sanitizedOverlayOptions,
+      subtitles,
     } as WorkerExportRequest,
     transfers
   );

--- a/src/lib/ffmpeg.worker.ts
+++ b/src/lib/ffmpeg.worker.ts
@@ -3,6 +3,7 @@ import { toBlobURL } from "@ffmpeg/util";
 import { EditRecipe, BackgroundMusicOptions, ImageOverlayOptions } from "./types";
 import { getPresetById } from "./presets";
 import { buildTextFilter } from "./text-overlay";
+import { SubtitleItem } from "./subtitles";
 
 const CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd";
 const MT_CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core-mt@0.12.6/dist/esm";
@@ -27,6 +28,7 @@ type ExportRequest = {
   musicOptions?: BackgroundMusicOptions;
   overlayFile?: SerializedFile;
   overlayOptions?: ImageOverlayOptions;
+  subtitles?: SubtitleItem[];
 };
 
 type LoadRequest = { type: "load" };
@@ -76,7 +78,42 @@ async function fetchWithIntegrity(url: string, mimeType: string): Promise<string
   return URL.createObjectURL(blob);
 }
 
-function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number): string {
+function buildSubtitleFilter(
+  sub: SubtitleItem,
+  recipe: EditRecipe,
+  targetW: number,
+  targetH: number
+): string {
+  const escapedText = sub.text
+    .replace(/\\/g, "\\\\")
+    .replace(/'/g, "'\\\\''")
+    .replace(/:/g, "\\:")
+    .replace(/\n/g, "\n");
+
+  const xExpr = "(w-text_w)/2";
+  const yExpr = "h-th-h*0.12";
+
+  let styleParams = "";
+  if (recipe.subtitleBgType === "box") {
+    const boxCol = recipe.subtitleBgColor.replace("#", "0x") + "@0.6";
+    styleParams = `:box=1:boxcolor=${boxCol}:boxborderw=8`;
+  } else if (recipe.subtitleBgType === "outline") {
+    const borderCol = recipe.subtitleBgColor;
+    styleParams = `:borderw=2:bordercolor=${borderCol}`;
+  } else if (recipe.subtitleBgType === "shadow") {
+    const shadowCol = recipe.subtitleBgColor.replace("#", "0x") + "@0.6";
+    styleParams = `:shadowcolor=${shadowCol}:shadowx=2:shadowy=2`;
+  }
+
+  return `drawtext=text='${escapedText}':x=${xExpr}:y=${yExpr}:fontsize=${recipe.subtitleSize}:fontcolor=${recipe.subtitleColor}${styleParams}:enable='between(t,${sub.startTime},${sub.endTime})'`;
+}
+
+function buildVideoFilter(
+  recipe: EditRecipe,
+  targetW: number,
+  targetH: number,
+  subtitles?: SubtitleItem[]
+): string {
   const filters: string[] = [];
 
   if (recipe.trimStart > 0 || recipe.trimEnd !== null) {
@@ -137,6 +174,13 @@ function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number):
     filters.push(buildTextFilter(overlay, targetW, targetH));
   });
 
+  // Add subtitles if present
+  if (subtitles && subtitles.length > 0) {
+    subtitles.forEach((sub) => {
+      filters.push(buildSubtitleFilter(sub, recipe, targetW, targetH));
+    });
+  }
+
   return filters.join(",");
 }
 
@@ -184,9 +228,10 @@ function buildArguments(
   overlayInputName: string,
   overlayOptions: ImageOverlayOptions | undefined,
   hasOriginalAudio: boolean,
-  videoDuration: number
+  videoDuration: number,
+  subtitles?: SubtitleItem[]
 ): string[] {
-  const vf = buildVideoFilter(recipe, targetW, targetH);
+  const vf = buildVideoFilter(recipe, targetW, targetH, subtitles);
   const audioTrim = hasOriginalAudio ? buildAudioTrimFilter(recipe) : "";
   const audioSpeed = hasOriginalAudio ? buildAudioFilter(recipe.speed, recipe.normalizeAudio ?? false) : "";
   const afParts = [audioTrim, audioSpeed].filter(Boolean);
@@ -427,7 +472,7 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
 
   try {
     if (recipe.format === "gif") {
-      const vf = buildVideoFilter(recipe, targetW, targetH);
+      const vf = buildVideoFilter(recipe, targetW, targetH, request.subtitles);
       const vfWithPalette = vf ? `${vf},palettegen` : "palettegen";
       const vfWithPaletteUse = vf
         ? `[0:v]${vf}[x];[x][1:v]paletteuse`
@@ -498,7 +543,8 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
       overlayInputName,
       request.overlayOptions,
       true,
-      videoDuration
+      videoDuration,
+      request.subtitles
     );
 
     let exitCode = await ffmpeg.exec(args, undefined, {
@@ -521,7 +567,8 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
         overlayInputName,
         request.overlayOptions,
         false,
-        videoDuration
+        videoDuration,
+        request.subtitles
       );
       exitCode = await ffmpeg.exec(args, undefined, {
         signal: activeExportAbortController?.signal,
@@ -543,7 +590,8 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
         overlayInputName,
         request.overlayOptions,
         !missingAudioDetected,
-        videoDuration
+        videoDuration,
+        request.subtitles
       );
 
       const fallbackCode = await ffmpeg.exec(args, undefined, {

--- a/src/lib/subtitles.ts
+++ b/src/lib/subtitles.ts
@@ -28,7 +28,8 @@ export function parseSRT(content: string): SubtitleItem[] {
     // 00:00:01,000 --> 00:00:04,000
     // Subtitle text here...
     let timestampLineIndex = 0;
-    if (/^\d+$/.test(lines[0].trim())) {
+    const firstLine = lines[0];
+    if (firstLine && /^\d+$/.test(firstLine.trim())) {
       timestampLineIndex = 1;
     }
 
@@ -38,8 +39,12 @@ export function parseSRT(content: string): SubtitleItem[] {
     const parts = timestampLine.split("-->");
     if (parts.length !== 2) continue;
 
-    const startTime = parseSRTTimestamp(parts[0].trim());
-    const endTime = parseSRTTimestamp(parts[1].trim());
+    const part0 = parts[0];
+    const part1 = parts[1];
+    if (!part0 || !part1) continue;
+
+    const startTime = parseSRTTimestamp(part0.trim());
+    const endTime = parseSRTTimestamp(part1.trim());
 
     if (startTime === null || endTime === null) continue;
 
@@ -68,10 +73,16 @@ function parseSRTTimestamp(timestamp: string): number | null {
   const match = timestamp.match(regex);
   if (!match) return null;
 
-  const hours = parseInt(match[1], 10);
-  const minutes = parseInt(match[2], 10);
-  const seconds = parseInt(match[3], 10);
-  const milliseconds = parseInt(match[4], 10);
+  const h = match[1];
+  const m = match[2];
+  const s = match[3];
+  const ms = match[4];
+  if (!h || !m || !s || !ms) return null;
+
+  const hours = parseInt(h, 10);
+  const minutes = parseInt(m, 10);
+  const seconds = parseInt(s, 10);
+  const milliseconds = parseInt(ms, 10);
 
   return hours * 3600 + minutes * 60 + seconds + milliseconds / 1000;
 }

--- a/src/lib/subtitles.ts
+++ b/src/lib/subtitles.ts
@@ -1,0 +1,77 @@
+export interface SubtitleItem {
+  id: string;
+  startTime: number; // in seconds
+  endTime: number; // in seconds
+  text: string;
+}
+
+/**
+ * Parses an SRT subtitle file content string into an array of SubtitleItem objects.
+ */
+export function parseSRT(content: string): SubtitleItem[] {
+  if (!content) return [];
+
+  // Normalize line endings to LF
+  const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+
+  // Split by blank lines (double newlines or more)
+  const blocks = normalized.trim().split(/\n\s*\n+/);
+
+  const items: SubtitleItem[] = [];
+
+  for (const block of blocks) {
+    const lines = block.trim().split("\n");
+    if (lines.length < 2) continue;
+
+    // A block usually looks like:
+    // 1
+    // 00:00:01,000 --> 00:00:04,000
+    // Subtitle text here...
+    let timestampLineIndex = 0;
+    if (/^\d+$/.test(lines[0].trim())) {
+      timestampLineIndex = 1;
+    }
+
+    const timestampLine = lines[timestampLineIndex];
+    if (!timestampLine || !timestampLine.includes("-->")) continue;
+
+    const parts = timestampLine.split("-->");
+    if (parts.length !== 2) continue;
+
+    const startTime = parseSRTTimestamp(parts[0].trim());
+    const endTime = parseSRTTimestamp(parts[1].trim());
+
+    if (startTime === null || endTime === null) continue;
+
+    // Subtitle text is the remaining lines
+    const textLines = lines.slice(timestampLineIndex + 1);
+    const text = textLines.join("\n").trim();
+    if (!text) continue;
+
+    items.push({
+      id: `sub-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+      startTime,
+      endTime,
+      text,
+    });
+  }
+
+  // Sort by startTime to ensure chronological order
+  return items.sort((a, b) => a.startTime - b.startTime);
+}
+
+/**
+ * Parses a single SRT timestamp (HH:MM:SS,mmm or HH:MM:SS.mmm) into seconds.
+ */
+function parseSRTTimestamp(timestamp: string): number | null {
+  const regex = /(\d{2}):(\d{2}):(\d{2})[,.](\d{3})/;
+  const match = timestamp.match(regex);
+  if (!match) return null;
+
+  const hours = parseInt(match[1], 10);
+  const minutes = parseInt(match[2], 10);
+  const seconds = parseInt(match[3], 10);
+  const milliseconds = parseInt(match[4], 10);
+
+  return hours * 3600 + minutes * 60 + seconds + milliseconds / 1000;
+}

--- a/src/lib/tests/subtitles.test.ts
+++ b/src/lib/tests/subtitles.test.ts
@@ -13,9 +13,9 @@ describe("parseSRT", () => {
 Hello World!`;
     const result = parseSRT(srt);
     expect(result.length).toBe(1);
-    expect(result[0].startTime).toBe(1.0);
-    expect(result[0].endTime).toBe(4.5);
-    expect(result[0].text).toBe("Hello World!");
+    expect(result[0]!.startTime).toBe(1.0);
+    expect(result[0]!.endTime).toBe(4.5);
+    expect(result[0]!.text).toBe("Hello World!");
   });
 
   it("correctly parses multiple subtitle blocks", () => {
@@ -28,13 +28,13 @@ Hello World!
 This is a second caption.`;
     const result = parseSRT(srt);
     expect(result.length).toBe(2);
-    expect(result[0].startTime).toBe(1.0);
-    expect(result[0].endTime).toBe(3.0);
-    expect(result[0].text).toBe("Hello World!");
+    expect(result[0]!.startTime).toBe(1.0);
+    expect(result[0]!.endTime).toBe(3.0);
+    expect(result[0]!.text).toBe("Hello World!");
 
-    expect(result[1].startTime).toBe(4.25);
-    expect(result[1].endTime).toBe(7.1);
-    expect(result[1].text).toBe("This is a second caption.");
+    expect(result[1]!.startTime).toBe(4.25);
+    expect(result[1]!.endTime).toBe(7.1);
+    expect(result[1]!.text).toBe("This is a second caption.");
   });
 
   it("handles multi-line subtitles", () => {
@@ -45,9 +45,9 @@ subtitle text.
 Enjoy it!`;
     const result = parseSRT(srt);
     expect(result.length).toBe(1);
-    expect(result[0].startTime).toBe(75.123);
-    expect(result[0].endTime).toBe(80.5);
-    expect(result[0].text).toBe("This is a multi-line\nsubtitle text.\nEnjoy it!");
+    expect(result[0]!.startTime).toBe(75.123);
+    expect(result[0]!.endTime).toBe(80.5);
+    expect(result[0]!.text).toBe("This is a multi-line\nsubtitle text.\nEnjoy it!");
   });
 
   it("handles alternative timestamp separators (dot instead of comma)", () => {
@@ -56,17 +56,17 @@ Enjoy it!`;
 Test dot timestamps.`;
     const result = parseSRT(srt);
     expect(result.length).toBe(1);
-    expect(result[0].startTime).toBe(5.5);
-    expect(result[0].endTime).toBe(8.2);
-    expect(result[0].text).toBe("Test dot timestamps.");
+    expect(result[0]!.startTime).toBe(5.5);
+    expect(result[0]!.endTime).toBe(8.2);
+    expect(result[0]!.text).toBe("Test dot timestamps.");
   });
 
   it("handles Windows CRLF and trailing spaces", () => {
     const srt = "1\r\n00:00:02,000 --> 00:00:05,000\r\nWindows CRLF Test\r\n\r\n2\r\n00:00:06,000 --> 00:00:08,000\r\nSecond Line\r\n";
     const result = parseSRT(srt);
     expect(result.length).toBe(2);
-    expect(result[0].text).toBe("Windows CRLF Test");
-    expect(result[1].text).toBe("Second Line");
+    expect(result[0]!.text).toBe("Windows CRLF Test");
+    expect(result[1]!.text).toBe("Second Line");
   });
 
   it("ignores blocks with invalid timestamps", () => {
@@ -79,6 +79,6 @@ Some text
 Valid Subtitle`;
     const result = parseSRT(srt);
     expect(result.length).toBe(1);
-    expect(result[0].text).toBe("Valid Subtitle");
+    expect(result[0]!.text).toBe("Valid Subtitle");
   });
 });

--- a/src/lib/tests/subtitles.test.ts
+++ b/src/lib/tests/subtitles.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { parseSRT } from "../subtitles";
+
+describe("parseSRT", () => {
+  it("returns empty array for empty content", () => {
+    expect(parseSRT("")).toEqual([]);
+    expect(parseSRT("   ")).toEqual([]);
+  });
+
+  it("correctly parses a single basic subtitle block", () => {
+    const srt = `1
+00:00:01,000 --> 00:00:04,500
+Hello World!`;
+    const result = parseSRT(srt);
+    expect(result.length).toBe(1);
+    expect(result[0].startTime).toBe(1.0);
+    expect(result[0].endTime).toBe(4.5);
+    expect(result[0].text).toBe("Hello World!");
+  });
+
+  it("correctly parses multiple subtitle blocks", () => {
+    const srt = `1
+00:00:01,000 --> 00:00:03,000
+Hello World!
+
+2
+00:00:04,250 --> 00:00:07,100
+This is a second caption.`;
+    const result = parseSRT(srt);
+    expect(result.length).toBe(2);
+    expect(result[0].startTime).toBe(1.0);
+    expect(result[0].endTime).toBe(3.0);
+    expect(result[0].text).toBe("Hello World!");
+
+    expect(result[1].startTime).toBe(4.25);
+    expect(result[1].endTime).toBe(7.1);
+    expect(result[1].text).toBe("This is a second caption.");
+  });
+
+  it("handles multi-line subtitles", () => {
+    const srt = `1
+00:01:15,123 --> 00:01:20,500
+This is a multi-line
+subtitle text.
+Enjoy it!`;
+    const result = parseSRT(srt);
+    expect(result.length).toBe(1);
+    expect(result[0].startTime).toBe(75.123);
+    expect(result[0].endTime).toBe(80.5);
+    expect(result[0].text).toBe("This is a multi-line\nsubtitle text.\nEnjoy it!");
+  });
+
+  it("handles alternative timestamp separators (dot instead of comma)", () => {
+    const srt = `1
+00:00:05.500 --> 00:00:08.200
+Test dot timestamps.`;
+    const result = parseSRT(srt);
+    expect(result.length).toBe(1);
+    expect(result[0].startTime).toBe(5.5);
+    expect(result[0].endTime).toBe(8.2);
+    expect(result[0].text).toBe("Test dot timestamps.");
+  });
+
+  it("handles Windows CRLF and trailing spaces", () => {
+    const srt = "1\r\n00:00:02,000 --> 00:00:05,000\r\nWindows CRLF Test\r\n\r\n2\r\n00:00:06,000 --> 00:00:08,000\r\nSecond Line\r\n";
+    const result = parseSRT(srt);
+    expect(result.length).toBe(2);
+    expect(result[0].text).toBe("Windows CRLF Test");
+    expect(result[1].text).toBe("Second Line");
+  });
+
+  it("ignores blocks with invalid timestamps", () => {
+    const srt = `1
+invalid timestamp line
+Some text
+
+2
+00:00:01,000 --> 00:00:03,000
+Valid Subtitle`;
+    const result = parseSRT(srt);
+    expect(result.length).toBe(1);
+    expect(result[0].text).toBe("Valid Subtitle");
+  });
+});

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -33,6 +33,11 @@ export interface EditRecipe {
   saturation: number;
   soundOnCompletion: boolean;
   textOverlays: TextOverlay[];
+  subtitleFont: string;
+  subtitleColor: string;
+  subtitleSize: number;
+  subtitleBgType: "none" | "box" | "shadow" | "outline";
+  subtitleBgColor: string;
   version: number;
 }
 
@@ -103,6 +108,11 @@ export function isValidRecipe(value: unknown): value is EditRecipe {
   if (typeof v.saturation !== "number" || !isFinite(v.saturation)) return false;
   if (typeof v.soundOnCompletion !== "boolean") return false;
   if (!Array.isArray(v.textOverlays)) return false;
+  if (typeof v.subtitleFont !== "string") return false;
+  if (typeof v.subtitleColor !== "string") return false;
+  if (typeof v.subtitleSize !== "number" || !isFinite(v.subtitleSize)) return false;
+  if (!["none", "box", "shadow", "outline"].includes(v.subtitleBgType)) return false;
+  if (typeof v.subtitleBgColor !== "string") return false;
 
   return true;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -68,6 +68,7 @@ export interface ExportResult {
 
 export type ExportStatus =
   | "idle"
+  | "loading"
   | "loading-engine"
   | "exporting"
   | "done"


### PR DESCRIPTION
## Description
This PR adds complete support for uploading, previewing, and burning in captions/subtitles from `.srt` files directly within Reframe. 

- **SRT Parsing Module**: Implements a robust `.srt` parser (`src/lib/subtitles.ts`) supporting time range parsing, multi-line blocks, and alternative punctuation.
- **Typography & Styling Controls**: Added sidebar controls in `SubtitleControls.tsx` for Font Family, text color, scale size, and background style presets.
- **Readability Styles**: Support for **Plain Text**, **Black Outline** (utilizing professional `paintOrder` styling to avoid fill bleed), **Translucent Background Box**, and **Drop Shadow**.
- **Synchronized Playback Preview**: Overlays real-time, responsive subtitles on the video canvas scaled proportionally to the current preview container size.
- **Word-Search Segment Navigation**: A scrollable segment list in the sidebar that allows users to search captions and click a segment to seek the player directly to that time.
- **FFmpeg Web Worker Burn-in**: Integrates dynamic `drawtext` filters with `enable='between(t, start, end)'` inside the background `ffmpeg.worker.ts` Web Worker during export. This avoids WebAssembly `-vf subtitles` core crashes and guarantees offline burn-in reliability.

## Related Issue
Closes #991

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution