### PR TITLE
feat: add clear video button to reset workspace

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -381,6 +381,20 @@ export default function VideoEditor() {
 
               {file && (
                 <div className="mt-4 animate-fade-in">
+
+                  {/* NEW CLEAR VIDEO BUTTON */}
+                  <div className="flex justify-end mb-3">
+                    <button
+                      onClick={reset}
+                      type="button"
+                      className="flex items-center gap-2 px-3 py-1.5 text-[10px] font-heading font-bold uppercase tracking-widest text-red-500 hover:text-white bg-red-500/10 hover:bg-red-500 rounded-lg transition-all border border-red-500/20 hover:border-red-500"
+                      aria-label="Clear current video"
+                    >
+                      ✕ Clear Video
+                    </button>
+                  </div>
+                  {/* END NEW CLEAR VIDEO BUTTON */}
+
                   <VideoPreview
                     file={file}
                     recipe={recipe}


### PR DESCRIPTION
## Description
This PR adds a **"Clear Video"** button to the main `VideoEditor` component. Currently, users have to manually refresh the entire browser page if they want to clear the workspace or process a different video. This addition allows users to instantly clear the current video state (`reset()`) and return to the initial `FileUpload` dropzone without a hard page refresh, significantly improving the user experience and workflow.

## Related Issue
Fixes #1195

## Type of Contribution
- [  ] Bug fix
- [x] New feature
- [  ] Documentation update
- [  ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: @nandannikam
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Screen Recording
> **How to record:** run `bun run dev` → open http://localhost:3000 → demonstrate the full working flow of your change, including any edge cases.
>
> - **macOS**: `Cmd + Shift + 5` → Record Selected Portion, or use QuickTime Player
> - **Windows**: `Win + G` → Xbox Game Bar → Capture
> - **Linux**: OBS Studio, GNOME Screenshot tool, or `kazam`
> - **Any OS**: [Loom](https://loom.com) (free screen recorder, great for sharing)

**Recording / Loom link:** 

https://github.com/user-attachments/assets/b7607070-de56-4ed5-a62c-db419a347076



## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)


### Note for the Maintainers: >
I am contributing to this issue as part of GSSoC 2026. If everything looks good, could you please add the gssoc:approved and appropriate level labels to this PR so it tracks for my leaderboard? Thank you so much for your time and for maintaining this awesome project! 🚀