### PR TITLE
feat: wrap Rotation and Export into collapsible Advanced Settings panel

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -144,3 +144,10 @@ textarea:focus {
   box-shadow: 0 0 0 3px var(--accent-muted);
   border-radius: var(--radius);
 }
+
+detail > summary {
+  list-style: none;
+}
+details > summary::-webkit-details-marker {
+  display: none;
+}

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -458,6 +458,36 @@ export default function VideoEditor() {
                       onSelectText={setSelectedTextId}
                     />
                   </AccordionSection>
+                  <details className="group">
+                  <summary className="flex items-center gap-2 cursor-pointer select-none list-none
+                      text-[10px] font-heading font-bold uppercase tracking-widest text-[var(--muted)] py-1">
+                      <span className="text-film-500 opacity-80 transition-transform duration-200 group-open:rotate-90">›</span>
+                      Advanced settings
+                      <div className="flex-1 h-px bg-[var(--border)]" />
+                    </summary>
+
+                    <div className="mt-4 space-y-4">
+                      <AccordionSection
+                        id="rotation"
+                        icon={<RotateCw size={12} />}
+                        title="Rotation"
+                        isOpen={openSections.rotation}
+                        onToggle={() => toggleSection("rotation")}
+                      >
+                        <RotateControl recipe={recipe} onChange={updateRecipe} />
+                      </AccordionSection>
+
+                      <AccordionSection
+                        id="export"
+                        icon={<SlidersHorizontal size={12} />}
+                        title="Export"
+                        isOpen={openSections.export}
+                        onToggle={() => toggleSection("export")}
+                      >
+                        <ExportSettings recipe={recipe} duration={duration} onChange={updateRecipe} />
+                      </AccordionSection>
+                    </div>
+                  </details>
                 </div>
                 <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6">
                   <AccordionSection
@@ -578,6 +608,36 @@ export default function VideoEditor() {
                       setOverlayOpacity={setOverlayOpacity}
                     />
                   </Section>
+                  <details className="group">
+                  <summary className="flex items-center gap-2 cursor-pointer select-none list-none
+                    text-[10px] font-heading font-bold uppercase tracking-widest text-[var(--muted)] py-1">
+                    <span className="text-film-500 opacity-80 transition-transform duration-200 group-open:rotate-90">›</span>
+                    Advanced settings
+                    <div className="flex-1 h-px bg-[var(--border)]" />
+                  </summary>
+
+                  <div className="mt-4 space-y-4">
+                    <AccordionSection
+                      id="rotation"
+                      icon={<RotateCw size={12} />}
+                      title="Rotation"
+                      isOpen={openSections.rotation}
+                      onToggle={() => toggleSection("rotation")}
+                    >
+                      <RotateControl recipe={recipe} onChange={updateRecipe} />
+                    </AccordionSection>
+
+                    <AccordionSection
+                      id="export"
+                      icon={<SlidersHorizontal size={12} />}
+                      title="Export"
+                      isOpen={openSections.export}
+                      onToggle={() => toggleSection("export")}
+                    >
+                      <ExportSettings recipe={recipe} duration={duration} onChange={updateRecipe} />
+                    </AccordionSection>
+                  </div>
+                </details>
                 </div>
               </div>
             )}


### PR DESCRIPTION
Closes #229

## 📋 Overview
This PR improves the default UI of the Video Editor by moving the less frequently used controls (`RotateControl` and `ExportSettings`) into a collapsible "Advanced settings" section. This reduces visual clutter and simplifies the default view for users.

## 🛠️ Changes Made
- **`src/components/VideoEditor.tsx`**: 
  - Restructured the left/right column layout.
  - Wrapped `RotateControl` and `ExportSettings` inside a native HTML `<details>` and `<summary>` element in the left column.
  - Maintained `TrimControl` and `AudioSpeedControl` as always-visible primary options.
- **`src/app/globals.css`**: 
  - Added a CSS snippet to hide the browser's default `::-webkit-details-marker` disclosure triangle so only the custom `›` chevron is displayed.

## ♿ Accessibility & UX
- Utilizes native HTML `<details>`/`<summary>`, meaning keyboard navigation (Tab, Space/Enter) and screen reader support (native `aria-expanded`) work out of the box without additional JavaScript.
- Section is collapsed by default and expands on click.

## 📸 Visual Proof
<img width="876" height="456" alt="Screenshot 2026-05-14 162933" src="https://github.com/user-attachments/assets/f2b5db68-f35c-46a8-98f6-30ec7c98cd87" />
<img width="886" height="560" alt="Screenshot 2026-05-14 162940" src="https://github.com/user-attachments/assets/97e78840-78a7-47a2-9ac9-b2a3432b713c" />

## ✅ Checklist
- [x] Tested locally
- [x] Verified native expanding/collapsing behavior
- [x] Verified keyboard navigation works
- [x] Code passes the linter