### PR TITLE
fix: resolve theme toggle hydration mismatch during SSR

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,9 +1,30 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useTheme } from "./ThemeProvider";
 
 export function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+  if (!mounted) {
+    return (
+      <button
+        type="button"
+        tabIndex={-1}
+        aria-label="Toggle theme"
+        className="
+          relative flex items-center justify-center
+          w-9 h-9 rounded-full
+          bg-[var(--surface)]
+          border border-[var(--border)]
+        "
+      />
+    );
+  }
+
   const isDark = theme === "dark";
 
   return (


### PR DESCRIPTION
## Description
Closes #1020 
Fixes the hydration mismatch caused by theme-dependent rendering in ThemeToggle.tsx.
Previously, the server and client could render different theme states during hydration:

- SSR rendered the light mode icon
- Client hydration rendered the dark mode icon

This caused React hydration errors because the rendered HTML differed between server-side rendering and client-side hydration.

Changes made

- Added a mounted state using useEffect
- Delayed theme-dependent rendering until after client mount
- Added a placeholder button during initial hydration to preserve layout stability

## Related Issue
Fixes hydration mismatch error in theme toggle caused by SSR/client theme divergence.

## Type of Contribution
- [X] Bug fix
- [X] GSSoC contribution

## Participant Info
- GitHub username: @janmejay1438
- Contribution level: Intermediate

## Screen Recording


**Recording / Loom link:** ## Checklist
- [X] I have read the contribution guidelines
- [X] My changes follow the project structure
- [X] I have tested my changes in Chrome, Firefox, and Safari
- [X] `bun run lint` passes (no ESLint errors)
- [X] `bunx tsc --noEmit` passes (no TypeScript errors)
- [X] New interactive elements have `aria-label` / accessible names
- [X] No `console.log` statements left in
- [X] This PR is related to a valid issue
- [X] **Screen recording attached above** (required for UI/feature/design changes)