### PR TITLE
fix: enable scroll restoration for route navigation (#1180)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "export",
+  experimental: {
+    scrollRestoration: true,
+  },
   // Required for ffmpeg.wasm to load WASM files correctly
   // Without this, Next.js might try to process .wasm files and break them
   webpack: (config) => {


### PR DESCRIPTION
## Summary
Fixes #1180

When navigating between pages/routes, the scroll position was not being 
preserved or consistently reset. This was caused by missing scroll 
restoration configuration in Next.js.

## Root Cause
Next.js does not enable scroll restoration by default. Without it, the 
browser's native scroll restoration behavior is inconsistent across 
route changes.

## Fix
Enabled the `scrollRestoration` experimental flag in `next.config.ts`:

```ts
experimental: {
  scrollRestoration: true,
},
```

This tells Next.js to manage scroll position during client-side 
navigation — restoring position on back/forward navigation and 
resetting to top on fresh route loads.

## Changes Made
- `next.config.ts` — added `experimental.scrollRestoration: true`

## Build
✓ Build passes with no errors or warnings related to this change.

---
Contributing under GSSoC'26