### PR TITLE
Fix duplicate React import in ThemeToggle

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import { useTheme } from "./ThemeProvider";
-import { useEffect, useState } from "react";
 
 export function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
@@ -27,7 +26,6 @@ export function ThemeToggle() {
   }
 
   const isDark = theme === "dark";
-  const [mounted, setMounted] = useState(false);
 
   return (
     <button


### PR DESCRIPTION
## Description

Resolved a duplicate React import in `ThemeToggle.tsx` that was causing the Next.js application to fail during compilation. The redundant import was removed to restore successful builds and normal application startup.

## Related Issue

N/A

## Type of Contribution

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor
* [x] GSSoC contribution

## Participant Info

* GitHub username: 1221smolkiddo
* Contribution level (Beginner/Intermediate/Advanced): Intermediate
