### PR TITLE
fix: prevent tooltip overflow on left viewport

### DIFF
--- a/src/components/OnboardingTour.tsx
+++ b/src/components/OnboardingTour.tsx
@@ -78,8 +78,11 @@ function getTooltipStyle(
       };
     case "left":
       return {
-        top: sr.top + sr.height / 2 - th / 2,
-        left: sr.left - tw - TOOLTIP_OFFSET,
+       top: sr.top + sr.height / 2 - th / 2,
+       left: Math.max(               //Prevent Tooltip from going out of left viewport
+         PADDING,
+         sr.left - tw - TOOLTIP_OFFSET
+    ),
       };
     case "right":
       return {


### PR DESCRIPTION
## Issue
Fixes #1086

Tooltip in onboardingTour overflowed outside viewport when positioned on the left side.

## Fix
Added viewport boundary protection to prevent tooltip from rendering beyond left edge.

## Testing
- Verified onboarding steps
- Tested left tooltip positioning
- Confirmed no regression on other positions  
