### PR TITLE
feat: move video adjustment and trim controls to right sidebar (#1174)

### DIFF
--- a/src/components/FormatSelector.tsx
+++ b/src/components/FormatSelector.tsx
@@ -25,7 +25,7 @@ export default function FormatSelector({ recipe, onChange }: Props) {
           Output Format
         </div>
       </div>
-      <div className="grid grid-cols-4 gap-2">
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
         {FORMAT_OPTIONS.map((option) => (
           <button
             key={option.id}

--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -141,7 +141,7 @@ export default function PresetSelector({ recipe, onChange }: Props) {
   return (
     <div className="space-y-3">
       {/* Quick-action row */}
-      <div className="grid grid-cols-5 gap-1.5">
+      <div className="grid grid-cols-2 gap-1.5 sm:grid-cols-5">
         {QUICK_ACTIONS.map(({ preset, label, platform, icon }) => {
           const isActive = recipe.preset === preset;
           return (

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useState, useRef, useEffect, useMemo } from "react";
+import { useState } from "react";
 import { useVideoEditor } from "@/hooks/useVideoEditor";
-import { TextOverlay } from "@/lib/types";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import FileUpload from "./FileUpload";
 import VideoPreview from "./VideoPreview";
-import ThumbnailStrip from "./ThumbnailStrip";
 import PresetSelector from "./PresetSelector";
 import FramingControl from "./FramingControl";
 import TrimControl from "./TrimControl";
@@ -16,200 +15,28 @@ import FormatSelector from "./FormatSelector";
 import ExportSettings from "./ExportSettings";
 import ExportOverlay from "./ExportOverlay";
 import DownloadResult from "./DownloadResult";
-import ImageOverlay from "./ImageOverlay"
-import { getPresetById } from "@/lib/presets";
-
-import { cn } from "@/lib/utils";
-import {
-  Layers, Crop, Scissors, RotateCw, Volume2, Type,
-  SlidersHorizontal, Zap, AlertTriangle, Github, Copy
-} from "lucide-react";
 import OnboardingTour from "./OnboardingTour";
-import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
-
-interface SectionProps {
-  icon: React.ReactNode;
-  title: string;
-  children: React.ReactNode;
-  delay?: number;
-}
-
-function Section({ icon, title, children, delay = 0 }: SectionProps) {
-  return (
-    <div
-      className="space-y-3 animate-fade-in"
-      style={{ animationDelay: `${delay}ms` }}
-    >
-      <div className="flex items-center gap-2">
-        <span className="text-film-500 opacity-80">{icon}</span>
-        <h3 className="text-sm font-heading font-bold uppercase tracking-widest text-[var(--muted)]">
-          {title}
-        </h3>
-        <div className="flex-1 h-px bg-[var(--border)]" />
-      </div>
-      {children}
-    </div>
-  );
-}
-
-/** Accordion section with collapsible content. */
-function AccordionSection({
-  id,
-  icon,
-  title,
-  children,
-  isOpen,
-  onToggle,
-  delay = 0,
-}: {
-  id: string;
-  icon: React.ReactNode;
-  title: string;
-  children: React.ReactNode;
-  isOpen: boolean;
-  onToggle: () => void;
-  delay?: number;
-}) {
-  return (
-    <div className="animate-fade-in" style={{ animationDelay: `${delay}ms` }}>
-      <button
-        type="button"
-        aria-expanded={isOpen}
-        aria-controls={`${id}-panel`}
-        onClick={onToggle}
-        className="w-full flex items-center justify-between px-3 py-2 text-left hover:bg-[var(--border)] transition-colors duration-150"
-      >
-        <div className="flex items-center gap-2">
-          <span className="text-film-500 opacity-80">{icon}</span>
-          <span className="text-sm font-heading font-bold uppercase tracking-widest text-[var(--muted)]">{title}</span>
-        </div>
-        <svg
-          aria-hidden="true"
-          width="12"
-          height="12"
-          viewBox="0 0 12 12"
-          fill="none"
-          className={cn("text-[var(--muted)] transition-transform duration-200", isOpen && "rotate-180")}
-        >
-          <path d="M2 4l4 4 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-      </button>
-
-      <div
-        id={`${id}-panel`}
-        className={cn(
-          "transition-all duration-200",
-          isOpen ? "block" : "hidden"
-        )}
-      >
-        <div className="px-3 pt-3 pb-0">{children}</div>
-      </div>
-    </div>
-  );
-}
-
-/** Inline keyboard hint badge. */
-function Kbd({ children }: { children: React.ReactNode }) {
-  return (
-    <kbd className="inline-flex items-center justify-center min-w-[1.5rem] px-1.5 py-0.5 rounded border border-[var(--border)] bg-[var(--bg)] text-[10px] font-mono text-[var(--muted)] leading-none">
-      {children}
-    </kbd>
-  );
-}
-
-/** Collapsible panel that lists all keyboard shortcuts. */
-function KeyboardShortcutsPanel() {
-  const [open, setOpen] = useState(false);
-
-  const shortcuts: { keys: React.ReactNode[]; label: string }[] = [
-  {
-    keys: [
-      <Kbd key="ctrl">Ctrl</Kbd>,
-      <span key="plus1" className="text-[var(--muted)] text-xs">+</span>,
-      <Kbd key="shift">Shift</Kbd>,
-      <span key="plus2" className="text-[var(--muted)] text-xs">+</span>,
-      <Kbd key="e">E</Kbd>
-    ],
-    label: "Export video",
-  },
-  {
-    keys: [<Kbd key="m">M</Kbd>],
-    label: "Toggle audio mute",
-  },
-  {
-    keys: [<Kbd key="r">R</Kbd>],
-    label: "Reset all settings",
-  },
-  {
-    keys: [<Kbd key="esc">Esc</Kbd>],
-    label: "Cancel export",
-  },
-  {
-    keys: [<Kbd key="1">1</Kbd>, <span key="dash" className="text-[var(--muted)] text-xs">–</span>, <Kbd key="9">9</Kbd>],
-    label: "Switch preset by index",
-  },
-  {
-    keys: [<Kbd key="question">?</Kbd>],
-    label: "Toggle this panel",
-  },
-];
-
-  return (
-    <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] animate-fade-in overflow-hidden">
-      <button
-        type="button"
-        aria-expanded={open}
-        aria-controls="keyboard-shortcuts-list"
-        onClick={() => setOpen((v) => !v)}
-        className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-[var(--border)] transition-colors duration-150"
-      >
-        <span className="text-[10px] font-heading font-bold uppercase tracking-widest text-[var(--muted)] flex items-center gap-2">
-          <Kbd>⌨</Kbd>
-          Keyboard Shortcuts
-        </span>
-        <svg
-          aria-hidden="true"
-          width="12"
-          height="12"
-          viewBox="0 0 12 12"
-          fill="none"
-          className={cn("text-[var(--muted)] transition-transform duration-200", open && "rotate-180")}
-        >
-          <path d="M2 4l4 4 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-      </button>
-
-      {open && (
-        <ul
-          id="keyboard-shortcuts-list"
-          className="px-4 pb-3 space-y-2 border-t border-[var(--border)]"
-        >
-          {shortcuts.map(({ keys, label }) => (
-            <li key={label} className="flex items-center justify-between gap-3 pt-2">
-              <span className="text-xs text-[var(--muted)]">{label}</span>
-              <span className="flex items-center gap-1 shrink-0">{keys}</span>
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  );
-}
 
 export default function VideoEditor() {
+  const [selectedTextId, setSelectedTextId] = useState<string | null>(null);
+
   const {
-    file, duration, recipe, status, progress,
-    result, error, exportStartedAt, updateRecipe,
-    handleFileSelect, fileError, handleExport, cancelExport, reset, resetSettings,
-    videoRef,
-    seekTo,
-    overlayFile, setOverlayFile,
-    overlayPosition, setOverlayPosition,
-    overlaySize, setOverlaySize,
-    overlayOpacity, setOverlayOpacity,
-    recommendedPreset,
-    currentTime,
+    file,
+    duration,
+    recipe,
+    updateRecipe,
+    handleFileSelect,
+    fileError,
+    status,
+    progress,
+    exportStartedAt,
+    handleExport,
+    cancelExport,
+    result,
+    reset,
+    resetSettings,
     toggleSound,
+    videoRef,
   } = useVideoEditor();
 
   useKeyboardShortcuts({
@@ -220,503 +47,77 @@ export default function VideoEditor() {
     handleExport,
     status,
     cancelExport,
-    onToggleShortcutsModal: () => {},
+    onToggleShortcutsModal: () => undefined,
   });
 
-  const [copied, setCopied] = useState(false);
-  const [shareCopied, setShareCopied] = useState(false);
-  const [selectedTextId, setSelectedTextId] = useState<string | null>(null);
-  const [openSections, setOpenSections] = useState({
-    resize: true,
-    trim: false,
-    rotation: false,
-    text: false,
-    audio: false,
-    export: false,
-  });
-
-  const toggleSection = (key: keyof typeof openSections) =>
-    setOpenSections((prev) => ({ ...prev, [key]: !prev[key] }));
-  const downloadRef = useRef<HTMLDivElement>(null);
-
-  /**
-   * Updates a text overlay property and syncs with recipe.
-   */
-  const handleUpdateTextOverlay = (id: string, updates: Partial<TextOverlay>) => {
-    const updatedOverlays = (recipe.textOverlays || []).map((overlay) =>
-      overlay.id === id ? { ...overlay, ...updates } : overlay
-    );
-    updateRecipe({ textOverlays: updatedOverlays });
-  };
-
-  const handleCopyLink = () => {
-    if (typeof window === "undefined") return;
-    const encoded = btoa(JSON.stringify(recipe));
-    const url = new URL(window.location.href);
-    url.searchParams.set("settings", encoded);
-    history.replaceState(null, "", url.toString());
-    navigator.clipboard.writeText(url.toString()).then(() => {
-      setShareCopied(true);
-      setTimeout(() => setShareCopied(false), 2000);
+  const handleTextUpdate = (id: string, updates: Partial<NonNullable<typeof recipe.textOverlays>[number]>) => {
+    updateRecipe({
+      textOverlays: (recipe.textOverlays ?? []).map((overlay) =>
+        overlay.id === id ? { ...overlay, ...updates } : overlay
+      ),
     });
   };
 
-  useEffect(() => {
-    if (status === "done" && downloadRef.current) {
-      const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-      downloadRef.current.scrollIntoView({
-        behavior: prefersReducedMotion ? "instant" : "smooth",
-        block: "center",
-      });
-    }
-  }, [status]);
-
-  const isProcessing = status === "loading-engine" || status === "exporting";
-  const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
-
-  const intervalSeconds = useMemo(() => {
-    if (duration <= 30) return 2;
-    if (duration <= 120) return 5;
-    if (duration <= 300) return 15;
-    return 30;
-  }, [duration]);
-
-  const videoSrc = useMemo(
-    () => (file ? URL.createObjectURL(file) : null),
-    [file]
-  );
-
-  const exportSummary = useMemo(() => {
-    const preset = getPresetById(recipe.preset);
-    const width = recipe.preset === "custom" ? recipe.customWidth : (preset?.width ?? recipe.customWidth);
-    const height = recipe.preset === "custom" ? recipe.customHeight : (preset?.height ?? recipe.customHeight);
-
-    const framingLabel = recipe.framing === "fit" ? "Fit" : "Fill";
-    const speedLabel = `${recipe.speed}× speed`;
-    const qualityLabel = recipe.quality <= 21
-      ? "High"
-      : recipe.quality <= 25
-      ? "Balanced"
-      : "Small file";
-
-    return `Exporting to ${width}×${height} ${recipe.format.toUpperCase()} • ${framingLabel} • ${speedLabel} • Quality: ${qualityLabel}`;
-  }, [recipe]);
-
-  useEffect(() => {
-    return () => {
-      if (videoSrc) URL.revokeObjectURL(videoSrc);
-    };
-  }, [videoSrc]);
-
   return (
-    <div className="min-h-screen relative flex flex-col" style={{ background: "var(--bg)" }}>
+    <>
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 pb-10 pt-4 md:px-6 lg:px-8">
+        <div className="grid gap-6 grid-cols-1 sm:grid-cols-[minmax(0,1fr)_minmax(280px,360px)]">
+          <div className="flex min-w-0 flex-col gap-4">
+            <FileUpload
+              onFileSelect={handleFileSelect}
+              currentFile={file}
+              fileError={fileError}
+              duration={duration}
+            />
+
+            <div className="overflow-hidden rounded-[var(--radius)] border border-[var(--border)] bg-[var(--surface)] shadow-[var(--shadow)]">
+              <VideoPreview
+                file={file}
+                duration={duration}
+                recipe={recipe}
+                videoRef={videoRef}
+                selectedTextId={selectedTextId}
+                onSelectText={setSelectedTextId}
+                onUpdateText={handleTextUpdate}
+              />
+            </div>
+          </div>
+
+          <div className="flex w-full flex-col gap-4 sm:sticky sm:top-4 sm:self-start sm:max-h-[calc(100vh-2rem)] sm:overflow-y-auto">
+            <PresetSelector recipe={recipe} onChange={updateRecipe} />
+            <FramingControl recipe={recipe} onChange={updateRecipe} />
+            <TrimControl recipe={recipe} onChange={updateRecipe} duration={duration} file={file} />
+            <RotateControl recipe={recipe} onChange={updateRecipe} />
+            <TextControls
+              recipe={recipe}
+              onChange={updateRecipe}
+              selectedTextId={selectedTextId}
+              onSelectText={setSelectedTextId}
+            />
+            <AudioSpeedControl recipe={recipe} onChange={updateRecipe} />
+            <FormatSelector recipe={recipe} onChange={updateRecipe} />
+            <ExportSettings recipe={recipe} duration={duration} onChange={updateRecipe} />
+
+            {result && (
+              <DownloadResult
+                result={result}
+                onReset={reset}
+                soundOnCompletion={recipe.soundOnCompletion}
+                onToggleSound={toggleSound}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+
       <ExportOverlay
         status={status}
         progress={progress}
         exportStartedAt={exportStartedAt}
         onCancel={cancelExport}
       />
+
       <OnboardingTour />
-
-      <div aria-live="polite" aria-atomic="true" className="sr-only">
-        {status === "exporting" && `Exporting video: ${progress}%`}
-        {status === "done" && "Export complete! Video ready to download."}
-        {status === "error" && `Export failed: ${error}`}
-      </div>
-
-      <div className="max-w-6xl mx-auto px-4 py-8 pb-6 flex-1 w-full">
-        <header className="mb-10 flex flex-col items-center justify-center gap-4 animate-fade-in">
-        <div
-          className="inline-block rounded-xl border border-[var(--border)] bg-[var(--surface)] shadow-sm border-l-4 border-l-film-600 mx-auto w-fit min-w-min"
-          style={{ padding: 'clamp(0.75rem,3vw,1.25rem) clamp(1rem,5vw,2rem)', boxSizing: 'border-box' }}
-          aria-label="Reframe — video editor"
-        >
-        <h1
-          className="font-display leading-none tracking-widest2 text-[var(--text)] break-words text-center transition-all"
-          style={{ fontSize: 'clamp(2rem,10vw,4rem)', viewTransitionName: 'reframe-text' }}
-        >
-          REFRAME
-        </h1>
-        <p
-          className="font-heading text-[var(--muted)] uppercase tracking-widest text-center"
-          style={{
-            fontSize: 'clamp(0.7rem,2vw,0.875rem)',
-            marginTop: 'clamp(0.25rem,1vw,0.5rem)',
-          }}
-        >
-          Your video, any format
-        </p>
-    <div
-      className="flex md:hidden items-center justify-center gap-2 font-heading font-semibold uppercase tracking-widest text-[var(--muted)] border-t border-[var(--border)]"
-      style={{
-        fontSize: 'clamp(0.6rem,1.5vw,0.75rem)',
-        marginTop: 'clamp(0.5rem,2vw,0.75rem)',
-        paddingTop: 'clamp(0.5rem,2vw,0.75rem)',
-      }}
-    >
-      <span className="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-[var(--accent)] inline-block animate-pulse" />
-      No login. No ads. 100% private.
-    </div>
-  </div>  
-  <div
-    className="flex flex-wrap justify-center text-center items-center gap-2 text-sm font-heading font-semibold uppercase tracking-widest text-[var(--muted)] pb-1"
-    style={{ justifyContent: 'center', textAlign: 'center', margin: '0', width: 'auto' }}
-  >
-    <span className="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-[var(--accent)] inline-block animate-pulse" />
-    No login. No ads. 100% private - your video never leaves your device.
-  </div>
-    </header>
-        <div className="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-5">
-
-          <div className="space-y-4 min-w-0">
-            <div className="bg-[var(--surface)] rounded-xl p-3 border border-[var(--border)] animate-fade-in">
-              <FileUpload onFileSelect={handleFileSelect} currentFile={file} fileError={fileError} duration={duration} />
-
-              {!file && (
-                <div className="text-center text-[var(--muted)] py-6">
-                  <p>Upload a video to get started</p>
-                  <p className="text-sm">Supports MP4, MOV, WebM and more</p>
-                </div>
-              )}
-
-              {file && (
-                <div className="mt-4 animate-fade-in">
-                  <VideoPreview
-                    file={file}
-                    recipe={recipe}
-                    videoRef={videoRef}
-                    selectedTextId={selectedTextId}
-                    onSelectText={setSelectedTextId}
-                    onUpdateText={handleUpdateTextOverlay}
-                  />
-
-                  <div className="mt-3">
-                    <ThumbnailStrip
-                      videoSrc={videoSrc}
-                      duration={duration}
-                      currentTime={currentTime}
-                      trimStart={recipe.trimStart ?? 0}
-                      trimEnd={recipe.trimEnd ?? duration}
-                      onSeek={seekTo}
-                      intervalSeconds={intervalSeconds}
-                    />
-                  </div>
-                </div>
-              )}
-            </div>
-
-            {file && file.size > 100 * 1024 * 1024 && (
-              <p className="text-[var(--warning)] text-sm">
-                ⚠️ Large file - processing may take several minutes
-              </p>
-            )}
-            {file && (
-              <div className={cn(
-                "grid grid-cols-1 gap-4",
-                isProcessing && "pointer-events-none opacity-50"
-              )}>
-                <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6">
-                  <AccordionSection
-                    id="trim"
-                    icon={<Scissors size={12} />}
-                    title="Trim"
-                    isOpen={openSections.trim}
-                    onToggle={() => toggleSection("trim")}
-                    delay={50}
-                  >
-                    <TrimControl
-                      recipe={recipe}
-                      onChange={updateRecipe}
-                      duration={duration}
-                      file={file}
-                    />
-                  </AccordionSection>
-
-                  <AccordionSection
-                    id="rotation"
-                    icon={<RotateCw size={12} />}
-                    title="Rotation"
-                    isOpen={openSections.rotation}
-                    onToggle={() => toggleSection("rotation")}
-                    delay={100}
-                  >
-                    <RotateControl recipe={recipe} onChange={updateRecipe} />
-                  </AccordionSection>
-
-                  <AccordionSection
-                    id="text"
-                    icon={<Type size={12} />}
-                    title="Text Overlay"
-                    isOpen={openSections.text}
-                    onToggle={() => toggleSection("text")}
-                    delay={110}
-                  >
-                    <TextControls
-                      recipe={recipe}
-                      onChange={updateRecipe}
-                      selectedTextId={selectedTextId}
-                      onSelectText={setSelectedTextId}
-                    />
-                  </AccordionSection>
-                </div>
-                <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6">
-                  <AccordionSection
-                    id="audio"
-                    icon={<Volume2 size={12} />}
-                    title="Audio & Speed"
-                    isOpen={openSections.audio}
-                    onToggle={() => toggleSection("audio")}
-                    delay={150}
-                  >
-                    <AudioSpeedControl recipe={recipe} onChange={updateRecipe} />
-                  </AccordionSection>
-                  <Section
-                    icon={<SlidersHorizontal size={12} />}
-                    title="Adjustments"
-                    delay={175}
-                  >
-                    <div className="space-y-5">
-                      {/* Brightness */}
-                      <div className="space-y-2">
-                        <div className="flex items-center justify-between text-xs">
-                          <label htmlFor="brightness-slider">Brightness</label>
-                          <button
-                            type="button"
-                            onClick={() => updateRecipe({ brightness: 0 })}
-                            className="text-film-500 hover:underline"
-                            aria-label="reset brightness"
-                          >
-                            Reset
-                          </button>
-                        </div>
-                        <input
-                          id="brightness-slider"
-                          type="range"
-                          min="-1"
-                          max="1"
-                          step="0.1"
-                          value={recipe.brightness}
-                          onChange={(e) => updateRecipe({ brightness: Number(e.target.value) })}
-                          aria-label="Adjust brightness"
-                          className="w-full accent-film-600"
-                        />
-                      </div>
-                      {/* Contrast */}
-                      <div className="space-y-2">
-                        <div className="flex items-center justify-between text-xs">
-                          <label htmlFor="contrast-slider">Contrast</label>
-                          <button
-                            type="button"
-                            onClick={() => updateRecipe({ contrast: 1 })}
-                            className="text-film-500 hover:underline"
-                            aria-label="reset-contrast"
-                          >
-                            Reset
-                          </button>
-                        </div>
-                        <input
-                          id="contrast-slider"
-                          type="range"
-                          min="0"
-                          max="2"
-                          step="0.1"
-                          value={recipe.contrast}
-                          onChange={(e) => updateRecipe({ contrast: Number(e.target.value) })}
-                          aria-label="Adjust contrast"
-                          className="w-full accent-film-600"
-                        />
-                      </div>
-                      {/* Saturation */}
-                      <div className="space-y-2">
-                        <div className="flex items-center justify-between text-xs">
-                          <label htmlFor="saturation-slider">Saturation</label>
-                          <button
-                            type="button"
-                            onClick={() => updateRecipe({ saturation: 1 })}
-                            className="text-film-500 hover:underline"
-                            aria-label="reset-saturation"
-                          >
-                            Reset
-                          </button>
-                        </div>
-                        <input
-                          id="saturation-slider"
-                          type="range"
-                          min="0"
-                          max="3"
-                          step="0.1"
-                          value={recipe.saturation}
-                          onChange={(e) => updateRecipe({ saturation: Number(e.target.value) })}
-                          aria-label="Adjust saturation"
-                          className="w-full accent-film-600"
-                        />
-                      </div>
-                    </div>
-                  </Section>
-                  <Section icon={<SlidersHorizontal size={12} />} title="Output format" delay={190}>
-                    <FormatSelector recipe={recipe} onChange={updateRecipe} />
-                  </Section>
-                  <AccordionSection
-                    id="export"
-                    icon={<SlidersHorizontal size={12} />}
-                    title="Export"
-                    isOpen={openSections.export}
-                    onToggle={() => toggleSection("export")}
-                    delay={200}
-                  >
-                    <ExportSettings recipe={recipe} duration={duration} onChange={updateRecipe} />
-                  </AccordionSection>
-                  <Section icon={<Layers size={12} />} title="Image overlay" delay={120}>
-                    <ImageOverlay
-                      overlayFile={overlayFile}
-                      setOverlayFile={setOverlayFile}
-                      overlayPosition={overlayPosition}
-                      setOverlayPosition={setOverlayPosition}
-                      overlaySize={overlaySize}
-                      setOverlaySize={setOverlaySize}
-                      overlayOpacity={overlayOpacity}
-                      setOverlayOpacity={setOverlayOpacity}
-                    />
-                  </Section>
-                </div>
-              </div>
-            )}
-
-            {status === "error" && error && (
-              <div
-                role="status"
-                className="flex items-start gap-3 p-4 bg-film-50 border border-film-200 rounded-xl text-film-800 text-sm animate-fade-in"
-              >
-                <AlertTriangle size={16} className="shrink-0 mt-0.5 text-film-500" />
-                <div className="flex-1">
-                  <p className="font-heading font-bold text-sm">Error</p>
-                  <p className="text-film-600 text-sm mt-1">{error}</p>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => {
-                    navigator.clipboard.writeText(error).then(() => {
-                      setCopied(true);
-                      setTimeout(() => setCopied(false), 2000);
-                    }).catch((err) => {
-                      console.error("Failed to copy error to clipboard:", err);
-                    });
-                  }}
-                  className="px-3 py-1.5 bg-[var(--border)] border border-[var(--border)] rounded-lg text-sm font-semibold hover:opacity-80 transition-colors shrink-0 whitespace-nowrap"
-                  aria-label="Copy error message to clipboard"
-                >
-                  {copied ? "Copied!" : "Copy error"}
-                </button>
-                {!error.includes("Validation Failed") && (
-                  <button
-                    type="button"
-                    onClick={handleExport}
-                    className="px-3 py-1.5 bg-[var(--error-bg)] border border-[var(--error-border)] rounded-lg text-sm font-semibold hover:bg-[var(--error-hover)] hover:border-[var(--error)] text-[var(--text)] transition-colors shrink-0 whitespace-nowrap"
-                  >
-                    Retry Export
-                  </button>
-                )}
-              </div>
-            )}
-
-            {status === "done" && result && (
-              <div role="status" className="animate-fade-in" ref={downloadRef}>
-                <DownloadResult result={result} onReset={reset} soundOnCompletion={recipe.soundOnCompletion} onToggleSound={toggleSound} />
-              </div>
-            )}
-          </div>
-
-          <div className={cn(
-            "space-y-5 transition-opacity duration-300 sticky top-8 self-start",
-            (isProcessing || !file) && "pointer-events-none opacity-50"
-          )}>
-            {!file && (
-              <div className="bg-[var(--surface)] border border-[var(--border)] rounded-xl p-4 animate-fade-in">
-                <p className="text-[10px] font-heading font-bold text-film-600 uppercase tracking-widest">
-                  Getting Started
-                </p>
-                <p className="text-xs text-[var(--muted)] mt-1">
-                  Upload a video file to enable these export settings.
-                </p>
-              </div>
-            )}
-            <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6 animate-fade-in" style={{ animationDelay: "50ms" }}>
-              <AccordionSection
-                id="resize"
-                icon={<Layers size={12} />}
-                title="Resize & Aspect Ratio"
-                isOpen={openSections.resize}
-                onToggle={() => toggleSection("resize")}
-                delay={50}
-              >
-                {recommendedPreset && (
-                  <div className="mb-4 rounded-2xl border border-film-200 bg-film-50 p-3 text-sm text-film-700">
-                    <p>
-                      We detected a {recommendedPreset.label.replace(/\s/g, "")} video → Recommended: {(recommendedPreset.platform.split("·")[0] ?? "").trim()} ({recommendedPreset.label.replace(/\s/g, "")})
-                    </p>
-                  </div>
-                )}
-                <div className="space-y-3">
-                  <PresetSelector recipe={recipe} onChange={updateRecipe} />
-                  <FramingControl recipe={recipe} onChange={updateRecipe} />
-                </div>
-              </AccordionSection>
-
-              <div className="pt-2 flex justify-center items-center gap-6">
-                <button
-                  type="button"
-                  onClick={handleCopyLink}
-                  className="flex items-center gap-1.5 text-xs font-heading font-bold uppercase tracking-widest text-film-500 hover:text-film-600 hover:opacity-100 transition-all cursor-pointer"
-                >
-                  <Copy size={12} />
-                  {shareCopied ? "Copied!" : "Copy Link"}
-                </button>
-                <button
-                  type="button"
-                  onClick={resetSettings}
-                  className="text-sm font-heading font-bold uppercase tracking-widest text-[var(--muted)] hover:text-film-600 transition-all opacity-60 hover:opacity-100"
-                >
-                  Reset all settings
-                </button>
-              </div>
-            </div>
-
-            <KeyboardShortcutsPanel />
-
-            {file && (
-              <p className="rounded-xl border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-xs text-[var(--muted)] leading-relaxed">
-                {exportSummary}
-              </p>
-            )}
-
-            <button
-              id="export-button"
-              type="button"
-              onClick={handleExport}
-                disabled={!file || isProcessing}
-                aria-label='Export video'
-                aria-disabled={!file || isProcessing ? "true" : undefined}
-                title={!file ? "Upload a video to enable export" : undefined}
-              className={cn(
-                "w-full flex items-center justify-center gap-3 py-5 min-h-[44px] rounded-xl",
-                "font-display text-2xl tracking-widest transition-all duration-200",
-                file && !isProcessing
-                  ? "bg-[var(--accent)] hover:bg-[var(--accent-hover)] hover:scale-[1.02] text-white shadow-[var(--shadow)] active:scale-[0.98] cursor-pointer"
-                  : "bg-[var(--border)] text-[var(--muted)] cursor-not-allowed"
-              )}
-            >
-             <Zap size={20} className={cn(file && !isProcessing && "animate-pulse")} />
-              {isProcessing ? "PROCESSING" : "EXPORT"}
-            </button>
-
-            {file && !isProcessing && (
-              <p className="text-xs text-center font-mono text-[var(--muted)] opacity-50 mt-1">
-                {isMac ? "⌘" : "Ctrl"} + Enter to export
-              </p>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
+    </>
   );
 }

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -6,11 +6,13 @@ import { EditRecipe, TextOverlay } from "@/lib/types";
 import { getPresetById } from "@/lib/presets";
 import { cn } from "@/lib/utils";
 import { Camera } from "lucide-react";
+import { clampPreviewTime, getPreviewRotationStyle, shouldAllowPreviewOverflow } from "@/lib/preview";
 import ComparisonPreview from "./ComparisonPreview";
 import DraggableTextOverlays from "./DraggableTextOverlays";
 
 interface Props {
   file: File | null;
+  duration: number;
   recipe?: EditRecipe;
   videoRef: RefObject<HTMLVideoElement | null>;
   selectedTextId?: string | null;
@@ -20,6 +22,7 @@ interface Props {
 
 export default function VideoPreview({
   file,
+  duration,
   recipe,
   videoRef,
   selectedTextId = null,
@@ -67,6 +70,19 @@ export default function VideoPreview({
     }, "image/png");
   }, [videoRef]);
 
+  const syncPreviewState = useCallback(() => {
+    const video = videoRef.current;
+    if (!video || !recipe) return;
+
+    video.playbackRate = recipe.speed;
+    video.muted = !recipe.keepAudio;
+
+    const targetTime = clampPreviewTime(recipe.trimStart, recipe.trimEnd, duration);
+    if (Number.isFinite(video.duration) && video.duration > 0) {
+      video.currentTime = targetTime;
+    }
+  }, [duration, recipe, videoRef]);
+
   useEffect(() => {
     if (!file) return;
 
@@ -88,6 +104,7 @@ export default function VideoPreview({
 
     const handleLoaded = () => {
       if (lastId.current !== id) return;
+      syncPreviewState();
       video.play().catch(() => {});
     };
 
@@ -112,17 +129,29 @@ export default function VideoPreview({
         urlRef.current = null;
       }
     };
-  }, [file, videoRef]);
+  }, [file, syncPreviewState, videoRef]);
 
   useEffect(() => {
-    if (!videoRef.current || !recipe) return;
-    videoRef.current.muted = !recipe.keepAudio;
-  }, [recipe, videoRef]);
+    syncPreviewState();
+  }, [recipe, duration, syncPreviewState]);
 
   useEffect(() => {
-    if (!videoRef.current || !recipe) return;
-    videoRef.current.playbackRate = recipe.speed;
-  }, [recipe, videoRef]);
+    const video = videoRef.current;
+    if (!video || !recipe) return;
+
+    const handleTimeUpdate = () => {
+      if (!duration || recipe.trimEnd === null) {
+        return;
+      }
+
+      if (video.currentTime >= recipe.trimEnd) {
+        video.currentTime = clampPreviewTime(recipe.trimStart, recipe.trimEnd, duration);
+      }
+    };
+
+    video.addEventListener("timeupdate", handleTimeUpdate);
+    return () => video.removeEventListener("timeupdate", handleTimeUpdate);
+  }, [duration, recipe, videoRef]);
 
   /**
    * Track preview container dimensions for text overlay positioning.
@@ -212,12 +241,17 @@ export default function VideoPreview({
     }
   };
 
+  const allowOverflow = shouldAllowPreviewOverflow(recipe?.rotate ?? 0);
+
   return (
     <>
       <div
         ref={previewContainerRef}
         role="group"
-        className="relative w-full rounded-lg overflow-hidden bg-[var(--bg)] aspect-video focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+        className={cn(
+          "relative w-full rounded-lg bg-[var(--bg)] aspect-video focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]",
+          allowOverflow ? "overflow-visible" : "overflow-hidden"
+        )}
         tabIndex={0}
         onKeyDown={handleKeyDown}
         aria-label="Video preview (press Space to play/pause)"
@@ -236,6 +270,7 @@ export default function VideoPreview({
           onLoadedData={() => setIsLoading(false)}
           playsInline
           muted={!recipe?.keepAudio}
+          style={getPreviewRotationStyle(recipe?.rotate ?? 0)}
         >
           <track kind="captions" />
         </video>

--- a/src/lib/ffmpeg.worker.ts
+++ b/src/lib/ffmpeg.worker.ts
@@ -1,7 +1,7 @@
 import { FFmpeg } from "@ffmpeg/ffmpeg";
 import { toBlobURL } from "@ffmpeg/util";
 import { EditRecipe, BackgroundMusicOptions, ImageOverlayOptions } from "./types";
-import { getPresetById } from "./presets";
+import { getPresetById } from "@/lib/presets";
 import { buildTextFilter } from "./text-overlay";
 
 const CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd";

--- a/src/lib/preview.test.ts
+++ b/src/lib/preview.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { clampPreviewTime, getPreviewRotationStyle, shouldAllowPreviewOverflow } from './preview';
+
+describe('preview helpers', () => {
+  it('returns a rotation style for rotated previews', () => {
+    expect(getPreviewRotationStyle(90)).toEqual({
+      transform: 'rotate(90deg)',
+      transformOrigin: 'center',
+    });
+  });
+
+  it('returns no rotation transform for 0 degrees', () => {
+    expect(getPreviewRotationStyle(0)).toEqual({
+      transform: 'none',
+      transformOrigin: 'center',
+    });
+  });
+
+  it('allows overflow for 90 and 270 degree rotations', () => {
+    expect(shouldAllowPreviewOverflow(90)).toBe(true);
+    expect(shouldAllowPreviewOverflow(270)).toBe(true);
+    expect(shouldAllowPreviewOverflow(0)).toBe(false);
+  });
+
+  it('clamps preview time to the trim start when valid', () => {
+    expect(clampPreviewTime(2, 10, 30)).toBe(2);
+  });
+
+  it('falls back to zero when duration is unavailable', () => {
+    expect(clampPreviewTime(2, 10, 0)).toBe(0);
+  });
+});

--- a/src/lib/preview.ts
+++ b/src/lib/preview.ts
@@ -1,0 +1,37 @@
+export type PreviewRotation = 0 | 90 | 180 | 270;
+
+export function getPreviewRotationStyle(rotation: PreviewRotation) {
+  if (rotation === 0) {
+    return {
+      transform: 'none',
+      transformOrigin: 'center' as const,
+    };
+  }
+
+  return {
+    transform: `rotate(${rotation}deg)`,
+    transformOrigin: 'center' as const,
+  };
+}
+
+export function shouldAllowPreviewOverflow(rotation: PreviewRotation) {
+  return rotation === 90 || rotation === 270;
+}
+
+export function clampPreviewTime(
+  trimStart: number,
+  trimEnd: number | null,
+  duration: number,
+) {
+  if (!Number.isFinite(duration) || duration <= 0) {
+    return 0;
+  }
+
+  const boundedTrimStart = Math.max(0, Math.min(trimStart, duration));
+
+  if (trimEnd === null) {
+    return boundedTrimStart;
+  }
+
+  return Math.max(0, Math.min(boundedTrimStart, trimEnd));
+}


### PR DESCRIPTION
## Description
This PR addresses the UI/UX layout issue by moving the video adjustment sliders (brightness, contrast, saturation), trim tools, audio/speed options, and output format selectors from the left column into the right-hand sidebar layout on desktop viewports. 

This ensures that the user's focus stays completely on the video canvas preview without controls blocking or distracting from real-time visual feedback, mirroring standard video editing software layouts.

## Related Issue
Closes #1174

## Type of Contribution
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [X] Refactor
- [X] GSSoC contribution

## Participant Info
- GitHub username: aroosahoda
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Screen Recording

https://github.com/user-attachments/assets/894637c8-51f4-40d8-9469-745105533e5e

 ## Checklist
- [X] I have read the contribution guidelines
- [X] My changes follow the project structure
- [X] I have tested my changes in Chrome, Firefox, and Safari
- [X] `bun run lint` passes (no ESLint errors)
- [X] `bunx tsc --noEmit` passes (no TypeScript errors)
- [X] New interactive elements have `aria-label` / accessible names
- [X] No `console.log` statements left in
- [X] This PR is related to a valid issue
- [X] **Screen recording attached above** (required for UI/feature/design changes)