### PR TITLE
fix: remove duplicate imports and variable declarations in ThemeToggle.tsx

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import { useTheme } from "./ThemeProvider";
-import { useEffect, useState } from "react";
 
 export function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
@@ -27,7 +26,6 @@ export function ThemeToggle() {
   }
 
   const isDark = theme === "dark";
-  const [mounted, setMounted] = useState(false);
 
   return (
     <button


### PR DESCRIPTION
## Description

`ThemeToggle.tsx` had a duplicate `import` block for `useEffect` / `useState` , and a duplicate 
`const [mounted, setMounted] = useState(false)` variable declaration. 
This caused 8 TypeScript errors and 2 ESLint errors that failed `bunx tsc --noEmit` and `bun run lint` repo-wide.

The fix removes:
- The duplicate `import { useEffect, useState } from "react"` block
- The duplicate `const [mounted, setMounted] = useState(false)` declaration

Both commands now pass with no errors.

## Related Issue

Closes #1230 

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] GSSoC contribution

## Participant Info
- GitHub username: @yashsh13
- Contribution level (Beginner/Intermediate/Advanced): Beginner

## Screen Recording

Not applicable — this PR only removes duplicate code. No UI changes were made.

**Recording / Loom link:** N/A

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [ ] I have tested my changes in Chrome, Firefox, and Safari (not applicable — no UI changes)
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [ ] New interactive elements have `aria-label` / accessible names (not applicable)
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [ ] Screen recording attached above (not applicable — no UI changes)