### PR TITLE
fix: remove duplicate React imports and redeclared state in ThemeToggle #1234

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import { useTheme } from "./ThemeProvider";
-import { useEffect, useState } from "react";
 
 export function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
@@ -27,7 +26,6 @@ export function ThemeToggle() {
   }
 
   const isDark = theme === "dark";
-  const [mounted, setMounted] = useState(false);
 
   return (
     <button


### PR DESCRIPTION
## Purpose & Rationale
ThemeToggle.tsx had duplicate React imports and a redeclared state variable that blocked the build. TypeScript and Webpack both errored on the duplicate identifier, preventing bun run build from completing.

## Technical Resolution Details
Removed the duplicate import { useEffect, useState } from "react" on line 5 and the redeclared const [mounted, setMounted] = useState(false) on line 30 in src/components/ThemeToggle.tsx. The import already existed on line 3, and the state variable was already declared on line 9. Closes #1234.

## Local Testing Execution
1. bunx tsc --noEmit -- zero type errors
2. bun run build -- compiled and exported all pages successfully
3. bun run test -- 47 tests passed, ThemeToggle.test.tsx passed

## Desired Review Feedback Type
Verify no other component depends on the removed duplicate declaration and confirm the early-return hydration guard still works as intended.

## Integrity & AI Usage Disclosure
In compliance with the GSSoC 2026 AI Conduct rules, I disclose that AI tools were used solely as learning and boilerplate aids. The final logic was fully reviewed, tested, and manually adapted to match human styling and clean-code design.