### PR TITLE
[Feature][Video] Add "Blurred Background" padding option for Fit framing

### DIFF
--- a/src/components/FramingControl.tsx
+++ b/src/components/FramingControl.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { EditRecipe } from "@/lib/types";
-import { Maximize2, Crop } from "lucide-react";
+import { Maximize2, Crop, Image as ImageIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -12,14 +12,14 @@ interface Props {
 export default function FramingControl({ recipe, onChange }: Props) {
   return (
     <div className="flex gap-2">
-      {(["fit", "fill"] as const).map((mode) => {
-        const Icon = mode === "fit" ? Maximize2 : Crop;
+      {(["fit", "fit-blur", "fill"] as const).map((mode) => {
+        const Icon = mode === "fit" ? Maximize2 : mode === "fit-blur" ? ImageIcon : Crop;
         const active = recipe.framing === mode;
         return (
           <button
             type="button"
             key={mode}
-            title={mode === "fit" ? "Fit: Adds black bars (letterbox) to fill empty space" : "Fill: Crops the video to fill the entire frame"}
+            title={mode === "fit" ? "Fit: Adds black bars (letterbox) to fill empty space" : mode === "fit-blur" ? "Fit (Blur): Fills empty space with a blurred background" : "Fill: Crops the video to fill the entire frame"}
             onClick={() => onChange({ framing: mode })}
             className={cn(
               "flex-1 min-h-[44px] min-w-[44px] flex flex-col items-center justify-center gap-2 py-4 rounded-lg border transition-all duration-150 hover:scale-[1.02] active:scale-[0.98]",
@@ -30,14 +30,14 @@ export default function FramingControl({ recipe, onChange }: Props) {
           >
             <Icon size={18} aria-hidden="true" />
             <span className="sr-only">
-              Set framing to {mode === "fit" ? "fit within frame" : "fill frame by cropping"}
+              Set framing to {mode === "fit" ? "fit within frame" : mode === "fit-blur" ? "fit within frame with blurred background" : "fill frame by cropping"}
             </span>
             <div className="text-center">
               <p className="text-xs font-heading font-semibold uppercase tracking-wider">
-                {mode === "fit" ? "Fit" : "Fill"}
+                {mode === "fit" ? "Fit" : mode === "fit-blur" ? "Fit (Blur)" : "Fill"}
               </p>
               <p className="text-[10px] text-[var(--muted)] mt-0.5">
-                {mode === "fit" ? "Letterbox / pillarbox" : "Crop to frame"}
+                {mode === "fit" ? "Letterbox / pillarbox" : mode === "fit-blur" ? "Blurred padding" : "Crop to frame"}
               </p>
             </div>
           </button>

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -345,7 +345,11 @@ export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: n
     filters.push("transpose=2");
   }
 
-  if (recipe.framing === "fit") {
+  if (recipe.framing === "fit-blur") {
+    filters.push(
+      `split=2[bg][fg];[bg]scale=${targetW}:${targetH}:force_original_aspect_ratio=increase,crop=${targetW}:${targetH},boxblur=20:20[bg_out];[fg]scale=${targetW}:${targetH}:force_original_aspect_ratio=decrease[fg_out];[bg_out][fg_out]overlay=(main_w-overlay_w)/2:(main_h-overlay_h)/2`
+    );
+  } else if (recipe.framing === "fit") {
     filters.push(
       `scale=${targetW}:${targetH}:force_original_aspect_ratio=decrease`,
       `pad=${targetW}:${targetH}:(ow-iw)/2:(oh-ih)/2:color=black`

--- a/src/lib/tests/videoFilter.test.ts
+++ b/src/lib/tests/videoFilter.test.ts
@@ -64,6 +64,13 @@ describe("buildVideoFilter", () => {
     expect(result).toContain("crop=1280:720");
   });
 
+  it("should use fit-blur framing with split, boxblur, and overlay", () => {
+    const result = buildVideoFilter(base({ framing: "fit-blur" }), 1280, 720);
+    expect(result).toContain("split=2[bg][fg]");
+    expect(result).toContain("boxblur=20:20");
+    expect(result).toContain("overlay=(main_w-overlay_w)/2:(main_h-overlay_h)/2");
+  });
+
   it("should include deshake when stabilization is true", () => {
     const result = buildVideoFilter(base({ stabilization: true }), 1280, 720);
     expect(result).toContain("deshake");

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,7 +19,7 @@ export interface EditRecipe {
   preset: string;
   customWidth: number;
   customHeight: number;
-  framing: "fit" | "fill";
+  framing: "fit" | "fill" | "fit-blur";
   trimStart: number;
   trimEnd: number | null;
   rotate: 0 | 90 | 180 | 270;
@@ -89,7 +89,7 @@ export function isValidRecipe(value: unknown): value is EditRecipe {
   if (typeof v.preset !== "string") return false;
   if (typeof v.customWidth !== "number" || !isFinite(v.customWidth)) return false;
   if (typeof v.customHeight !== "number" || !isFinite(v.customHeight)) return false;
-  if (v.framing !== "fit" && v.framing !== "fill") return false;
+  if (v.framing !== "fit" && v.framing !== "fill" && v.framing !== "fit-blur") return false;
   if (typeof v.trimStart !== "number" || !isFinite(v.trimStart)) return false;
   if (!(v.trimEnd === null || (typeof v.trimEnd === "number" && isFinite(v.trimEnd)))) return false;
   if (![0, 90, 180, 270].includes(v.rotate)) return false;


### PR DESCRIPTION
## Description

This PR introduces a highly requested framing mode: **Fit (Blur)**. When resizing videos (e.g. converting a 16:9 landscape to a 9:16 vertical), the standard "Fit" mode leaves solid black bars. This new mode fills the empty space with a scaled-up, heavily blurred version of the original video.

---

## Related Issue

Closes #1237

---

## Type of Contribution

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [ ] Refactor
* [x] GSSoC contribution

---

## Participant Info

* GitHub username: javaprogswing
* Contribution level (Beginner/Intermediate/Advanced): Intermediate

---

## Screen Recording

**Recording / Loom link:** N/A (UI enhancement changes only)

---

## Checklist

* [x] I have read the contribution guidelines
* [x] My changes follow the project structure
* [ ] I have tested my changes in Chrome, Firefox, and Safari
* [ ] `bun run lint` passes (no ESLint errors)
* [ ] `bunx tsc --noEmit` passes (no TypeScript errors)
* [x] New interactive elements have `aria-label` / accessible names
* [x] No `console.log` statements left in
* [x] This PR is related to a valid issue
* [ ] **Screen recording attached above** (required for UI/feature/design changes)
