### PR TITLE
fill mode is added to crop desire frame

### DIFF
--- a/src/components/FramingControl.tsx
+++ b/src/components/FramingControl.tsx
@@ -3,6 +3,9 @@
 import { EditRecipe } from "@/lib/types";
 import { Maximize2, Crop } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { getPresetById } from "@/lib/presets";
+import { getCenteredMaxCropBox } from "@/lib/crop-frame";
+import { useEffect } from "react";
 
 interface Props {
   recipe: EditRecipe;
@@ -10,39 +13,95 @@ interface Props {
 }
 
 export default function FramingControl({ recipe, onChange }: Props) {
+  const outputAspectRatio =
+    recipe.preset === "custom"
+      ? recipe.customWidth / recipe.customHeight
+      : (getPresetById(recipe.preset)?.width ?? recipe.customWidth) / (getPresetById(recipe.preset)?.height ?? recipe.customHeight);
+
+  const centeredDefaultCropBox = getCenteredMaxCropBox(outputAspectRatio);
+
+  // When output aspect ratio changes (preset/custom dims), keep crop box valid
+  // by resetting it to the centered maximum for the new aspect ratio.
+  useEffect(() => {
+    if (recipe.framing !== "fill") return;
+    onChange({
+      cropBoxX: centeredDefaultCropBox.x,
+      cropBoxY: centeredDefaultCropBox.y,
+      cropBoxW: centeredDefaultCropBox.w,
+      cropBoxH: centeredDefaultCropBox.h,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [recipe.preset, recipe.customWidth, recipe.customHeight]);
+
   return (
-    <div className="flex gap-2">
-      {(["fit", "fill"] as const).map((mode) => {
-        const Icon = mode === "fit" ? Maximize2 : Crop;
-        const active = recipe.framing === mode;
-        return (
+    <div className="space-y-3">
+      <div className="flex gap-2">
+        {(["fit", "fill"] as const).map((mode) => {
+          const Icon = mode === "fit" ? Maximize2 : Crop;
+          const active = recipe.framing === mode;
+          return (
+            <button
+              type="button"
+              key={mode}
+              title={mode === "fit" ? "Fit: Adds black bars (letterbox) to fill empty space" : "Fill: Crops the video to fill the entire frame"}
+              onClick={() => onChange({ framing: mode })}
+              className={cn(
+                "flex-1 min-h-[44px] min-w-[44px] flex flex-col items-center justify-center gap-2 py-4 rounded-lg border transition-all duration-150 hover:scale-[1.02] active:scale-[0.98]",
+                active
+                  ? "border-film-500 bg-film-50 text-film-700"
+                  : "border-[var(--border)] text-[var(--muted)] hover:border-film-300 bg-[var(--surface)]"
+              )}
+            >
+              <Icon size={18} aria-hidden="true" />
+              <span className="sr-only">
+                Set framing to {mode === "fit" ? "fit within frame" : "fill frame by cropping"}
+              </span>
+              <div className="text-center">
+                <p className="text-xs font-heading font-semibold uppercase tracking-wider">
+                  {mode === "fit" ? "Fit" : "Fill"}
+                </p>
+                <p className="text-[10px] text-[var(--muted)] mt-0.5">
+                  {mode === "fit" ? "Letterbox / pillarbox" : "Crop to frame"}
+                </p>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {recipe.framing === "fill" && (
+        <div className="flex gap-2">
           <button
             type="button"
-            key={mode}
-            title={mode === "fit" ? "Fit: Adds black bars (letterbox) to fill empty space" : "Fill: Crops the video to fill the entire frame"}
-            onClick={() => onChange({ framing: mode })}
-            className={cn(
-              "flex-1 min-h-[44px] min-w-[44px] flex flex-col items-center justify-center gap-2 py-4 rounded-lg border transition-all duration-150 hover:scale-[1.02] active:scale-[0.98]",
-              active
-                ? "border-film-500 bg-film-50 text-film-700"
-                : "border-[var(--border)] text-[var(--muted)] hover:border-film-300 bg-[var(--surface)]"
-            )}
+            onClick={() =>
+              onChange({
+                cropBoxX: centeredDefaultCropBox.x,
+                cropBoxY: centeredDefaultCropBox.y,
+                cropBoxW: centeredDefaultCropBox.w,
+                cropBoxH: centeredDefaultCropBox.h,
+              })
+            }
+            className="flex-1 min-h-[38px] rounded-lg border border-[var(--border)] bg-[var(--surface)] text-[var(--muted)] hover:border-film-300 hover:bg-film-50/30 transition-colors text-xs font-heading font-bold uppercase tracking-wider"
+            title="Reset crop to centered default"
           >
-            <Icon size={18} aria-hidden="true" />
-            <span className="sr-only">
-              Set framing to {mode === "fit" ? "fit within frame" : "fill frame by cropping"}
-            </span>
-            <div className="text-center">
-              <p className="text-xs font-heading font-semibold uppercase tracking-wider">
-                {mode === "fit" ? "Fit" : "Fill"}
-              </p>
-              <p className="text-[10px] text-[var(--muted)] mt-0.5">
-                {mode === "fit" ? "Letterbox / pillarbox" : "Crop to frame"}
-              </p>
-            </div>
+            Reset
           </button>
-        );
-      })}
+
+          <button
+            type="button"
+            onClick={() =>
+              onChange({
+                cropBoxX: (1 - recipe.cropBoxW) / 2,
+                cropBoxY: (1 - recipe.cropBoxH) / 2,
+              })
+            }
+            className="flex-1 min-h-[38px] rounded-lg border border-[var(--border)] bg-[var(--surface)] text-[var(--muted)] hover:border-film-300 hover:bg-film-50/30 transition-colors text-xs font-heading font-bold uppercase tracking-wider"
+            title="Center crop box"
+          >
+            Center
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { useTheme } from "./ThemeProvider";
 import { useEffect, useState } from "react";
 
@@ -10,51 +9,46 @@ export function ThemeToggle() {
   useEffect(() => {
     setMounted(true);
   }, []);
-  if (!mounted) {
-    return (
-      <button
-        type="button"
-        tabIndex={-1}
-        aria-label="Toggle theme"
-        className="
-          relative flex items-center justify-center
-          w-9 h-9 rounded-full
-          bg-[var(--surface)]
-          border border-[var(--border)]
-        "
-      />
-    );
-  }
 
   const isDark = theme === "dark";
-  const [mounted, setMounted] = useState(false);
 
   return (
     <button
-       type="button"
-       suppressHydrationWarning={true}
-       onClick={toggleTheme}
-       aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
-      className="
-        relative flex items-center justify-center
-        w-9 h-9 rounded-full
-        bg-[var(--surface)]
-        text-[var(--text)]
-        border border-[var(--border)]
-        hover:border-[var(--accent)] hover:bg-[var(--accent-muted)]
-        focus:outline-none focus:ring-2 focus:ring-[var(--accent)] focus:ring-offset-2
-        focus:ring-offset-[var(--bg)]
-        transition-all duration-200
-      "
+      type="button"
+      suppressHydrationWarning
+      onClick={toggleTheme}
+      tabIndex={mounted ? 0 : -1}
+      aria-label={mounted ? (isDark ? "Switch to light mode" : "Switch to dark mode") : "Toggle theme"}
+      className="relative flex items-center justify-center w-9 h-9 rounded-full bg-[var(--surface)] text-[var(--text)] border border-[var(--border)] hover:border-[var(--accent)] hover:bg-[var(--accent-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)] focus:ring-offset-2 focus:ring-offset-[var(--bg)] transition-all duration-200"
     >
-    {!mounted ? (
-        <div className="w-4 h-4" /> 
+      {!mounted ? (
+        <div className="w-4 h-4" aria-hidden="true" />
       ) : isDark ? (
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4" aria-hidden="true">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="w-4 h-4"
+          aria-hidden="true"
+        >
           <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
         </svg>
       ) : (
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4" aria-hidden="true">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="w-4 h-4"
+          aria-hidden="true"
+        >
           <circle cx="12" cy="12" r="4" />
           <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
         </svg>

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -388,6 +388,7 @@ export default function VideoEditor() {
                     selectedTextId={selectedTextId}
                     onSelectText={setSelectedTextId}
                     onUpdateText={handleUpdateTextOverlay}
+                    onCropChange={updateRecipe}
                   />
 
                   <div className="mt-3">

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { Camera } from "lucide-react";
 import ComparisonPreview from "./ComparisonPreview";
 import DraggableTextOverlays from "./DraggableTextOverlays";
+import { PREVIEW_CONTAINER_ASPECT, clampCropBox, getCenteredMaxCropBox } from "@/lib/crop-frame";
 
 interface Props {
   file: File | null;
@@ -16,6 +17,7 @@ interface Props {
   selectedTextId?: string | null;
   onSelectText?: (id: string | null) => void;
   onUpdateText?: (id: string, updates: Partial<TextOverlay>) => void;
+  onCropChange?: (patch: Partial<EditRecipe>) => void;
 }
 
 export default function VideoPreview({
@@ -25,11 +27,12 @@ export default function VideoPreview({
   selectedTextId = null,
   onSelectText,
   onUpdateText,
+  onCropChange,
 }: Props) {
   const lastId = useRef(0);
   const urlRef = useRef<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [showOverlay, setShowOverlay] = useState(false);
+  const [showOverlay, setShowOverlay] = useState(true);
   const [showComparison, setShowComparison] = useState(false);
   const [containerDimensions, setContainerDimensions] = useState({
     width: 0,
@@ -37,6 +40,299 @@ export default function VideoPreview({
   });
   const previewContainerRef = useRef<HTMLDivElement>(null);
   const onLoadedRef = useRef<(() => void) | null>(null);
+
+  const cropBoxFromRecipe = recipe
+    ? {
+        x: recipe.cropBoxX,
+        y: recipe.cropBoxY,
+        w: recipe.cropBoxW,
+        h: recipe.cropBoxH,
+      }
+    : null;
+
+  const [draftCropBox, setDraftCropBox] = useState(() => ({
+    x: cropBoxFromRecipe?.x ?? 0.2,
+    y: cropBoxFromRecipe?.y ?? 0.2,
+    w: cropBoxFromRecipe?.w ?? 0.6,
+    h: cropBoxFromRecipe?.h ?? 0.6,
+  }));
+  const [isEditingCrop, setIsEditingCrop] = useState(false);
+
+  useEffect(() => {
+    if (!recipe) return;
+    if (isEditingCrop) return;
+    setDraftCropBox({
+      x: recipe.cropBoxX,
+      y: recipe.cropBoxY,
+      w: recipe.cropBoxW,
+      h: recipe.cropBoxH,
+    });
+  }, [recipe, isEditingCrop]);
+
+  const outputAspectRatio = (() => {
+    if (!recipe) return null;
+    const preset =
+      recipe.preset === "custom"
+        ? { width: recipe.customWidth, height: recipe.customHeight }
+        : getPresetById(recipe.preset);
+    if (!preset) return null;
+    return preset.width / preset.height;
+  })();
+
+  const cropAspectK = outputAspectRatio ? outputAspectRatio / PREVIEW_CONTAINER_ASPECT : null;
+
+  // Use `draftCropBox` as the source of truth while dragging/resizing for flicker-free UI.
+  const currentCropBox = cropBoxFromRecipe ? draftCropBox : null;
+
+  const cropPreviewTransform = (() => {
+    if (!recipe || recipe.framing !== "fill") return null;
+    if (!showOverlay) return null;
+    if (!currentCropBox) return null;
+    if (!containerDimensions.width || !containerDimensions.height) return null;
+
+    const boxLeftPx = currentCropBox.x * containerDimensions.width;
+    const boxTopPx = currentCropBox.y * containerDimensions.height;
+    const boxWpx = currentCropBox.w * containerDimensions.width;
+    const zoom = boxWpx > 0 ? containerDimensions.width / boxWpx : 1;
+    if (!isFinite(zoom) || zoom <= 0) return null;
+
+    // Keep the crop box positioned where it is, while magnifying the video inside it.
+    // We want: x' = x*zoom + tx with x'=boxLeft and x=boxLeft -> tx = boxLeft*(1-zoom)
+    // Implemented as: scale(zoom) translate(tx/zoom).
+    const tx = boxLeftPx * (1 / zoom - 1);
+    const ty = boxTopPx * (1 / zoom - 1);
+
+    return {
+      transformOrigin: "top left",
+      transform: `scale(${zoom}) translate(${tx}px, ${ty}px)`,
+      willChange: "transform",
+    } as React.CSSProperties;
+  })();
+
+  type ResizeHandle = "move" | "n" | "s" | "e" | "w" | "nw" | "ne" | "sw" | "se";
+  const interactionRef = useRef<{
+    handle: ResizeHandle;
+    pointerId: number | null;
+    startPointerX: number;
+    startPointerY: number;
+    startBox: { x: number; y: number; w: number; h: number };
+  } | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const latestPointerRef = useRef<{ clientX: number; clientY: number } | null>(null);
+
+  const startEdit = (handle: ResizeHandle, e: React.PointerEvent) => {
+    if (!recipe || recipe.framing !== "fill") return;
+    if (!containerDimensions.width || !containerDimensions.height) return;
+    if (!cropAspectK) return;
+    if (e.pointerType !== "mouse" && e.pointerType !== "touch" && e.pointerType !== "pen") return;
+
+    const box = cropBoxFromRecipe
+      ? { x: cropBoxFromRecipe.x, y: cropBoxFromRecipe.y, w: cropBoxFromRecipe.w, h: cropBoxFromRecipe.h }
+      : { x: draftCropBox.x, y: draftCropBox.y, w: draftCropBox.w, h: draftCropBox.h };
+
+    interactionRef.current = {
+      handle,
+      pointerId: e.pointerId,
+      startPointerX: e.clientX,
+      startPointerY: e.clientY,
+      startBox: box,
+    };
+    latestPointerRef.current = { clientX: e.clientX, clientY: e.clientY };
+    setDraftCropBox(box);
+    setIsEditingCrop(true);
+
+    try {
+      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    } catch {
+      // ignore
+    }
+  };
+
+  const clampToBounds = (box: { x: number; y: number; w: number; h: number }) => {
+    const snapPx = 8;
+    const snapTolX = containerDimensions.width ? snapPx / containerDimensions.width : 0;
+    const snapTolY = containerDimensions.height ? snapPx / containerDimensions.height : 0;
+
+    const w = Math.min(1, Math.max(0.0001, box.w));
+    const h = Math.min(1, Math.max(0.0001, box.h));
+    let x = Math.min(Math.max(0, box.x), 1 - w);
+    let y = Math.min(Math.max(0, box.y), 1 - h);
+
+    // Snap to edges when close.
+    const xMax = 1 - w;
+    const yMax = 1 - h;
+    if (Math.abs(x - 0) <= snapTolX) x = 0;
+    if (Math.abs(x - xMax) <= snapTolX) x = xMax;
+    if (Math.abs(y - 0) <= snapTolY) y = 0;
+    if (Math.abs(y - yMax) <= snapTolY) y = yMax;
+
+    // Extra safety.
+    return clampCropBox({ x, y, w, h }, 0.04, 0.04);
+  };
+
+  const computeDraftFromPointer = (clientX: number, clientY: number) => {
+    const i = interactionRef.current;
+    if (!i) return draftCropBox;
+    if (!containerDimensions.width || !containerDimensions.height) return draftCropBox;
+    if (!cropAspectK) return draftCropBox;
+
+    const dxNorm = (clientX - i.startPointerX) / containerDimensions.width;
+    const dyNorm = (clientY - i.startPointerY) / containerDimensions.height;
+
+    const minBoxPx = 24;
+    const minW = minBoxPx / containerDimensions.width;
+    const minH = minBoxPx / containerDimensions.height;
+    const minWAspect = minH * cropAspectK; // w = h * k
+
+    const k = cropAspectK; // w/h = k
+
+    const start = i.startBox;
+    const startLeft = start.x;
+    const startRight = start.x + start.w;
+    const startTop = start.y;
+    const startBottom = start.y + start.h;
+    const startCenterX = startLeft + start.w / 2;
+    const startCenterY = startTop + start.h / 2;
+
+    let next = { ...start };
+
+    const clampSize = (w: number, h: number) => {
+      let ww = Math.max(minWAspect, Math.min(1, w));
+      let hh = ww / k;
+      // Ensure minimum height too.
+      if (hh < minH) {
+        hh = Math.max(minH, hh);
+        ww = hh * k;
+      }
+      return { w: ww, h: hh };
+    };
+
+    switch (i.handle) {
+      case "move": {
+        next.x = start.x + dxNorm;
+        next.y = start.y + dyNorm;
+        next = clampToBounds(next);
+        return next;
+      }
+      case "w": {
+        // Right edge fixed, vertical center preserved.
+        const right = startRight;
+        const newLeft = startLeft + dxNorm;
+        const { w, h } = clampSize(right - newLeft, 1);
+        next.w = w;
+        next.h = h;
+        next.x = right - w;
+        next.y = startCenterY - h / 2;
+        next = clampToBounds(next);
+        return next;
+      }
+      case "e": {
+        // Left edge fixed, vertical center preserved.
+        const left = startLeft;
+        const newRight = startRight + dxNorm;
+        const { w, h } = clampSize(newRight - left, 1);
+        next.w = w;
+        next.h = h;
+        next.x = left;
+        next.y = startCenterY - h / 2;
+        next = clampToBounds(next);
+        return next;
+      }
+      case "n": {
+        // Bottom edge fixed, horizontal center preserved.
+        const bottom = startBottom;
+        const newTop = startTop + dyNorm;
+        const newH = bottom - newTop;
+        const hh = Math.max(minH, newH);
+        const ww = hh * k;
+        next.w = ww;
+        next.h = hh;
+        next.y = bottom - hh;
+        next.x = startCenterX - ww / 2;
+        next = clampToBounds(next);
+        return next;
+      }
+      case "s": {
+        // Top edge fixed, horizontal center preserved.
+        const top = startTop;
+        const newBottom = startBottom + dyNorm;
+        const newH = newBottom - top;
+        const hh = Math.max(minH, newH);
+        const ww = hh * k;
+        next.w = ww;
+        next.h = hh;
+        next.y = top;
+        next.x = startCenterX - ww / 2;
+        next = clampToBounds(next);
+        return next;
+      }
+      case "nw": {
+        // Bottom-right fixed.
+        const bottom = startBottom;
+        const right = startRight;
+        const newLeft = startLeft + dxNorm;
+        const { w, h } = clampSize(right - newLeft, 1);
+        next.w = w;
+        next.h = h;
+        next.x = right - w;
+        next.y = bottom - h;
+        next = clampToBounds(next);
+        return next;
+      }
+      case "ne": {
+        // Bottom-left fixed.
+        const bottom = startBottom;
+        const left = startLeft;
+        const newRight = startRight + dxNorm;
+        const { w, h } = clampSize(newRight - left, 1);
+        next.w = w;
+        next.h = h;
+        next.x = left;
+        next.y = bottom - h;
+        next = clampToBounds(next);
+        return next;
+      }
+      case "sw": {
+        // Top-right fixed.
+        const top = startTop;
+        const right = startRight;
+        const newLeft = startLeft + dxNorm;
+        const { w, h } = clampSize(right - newLeft, 1);
+        next.w = w;
+        next.h = h;
+        next.x = right - w;
+        next.y = top;
+        next = clampToBounds(next);
+        return next;
+      }
+      case "se": {
+        // Top-left fixed.
+        const top = startTop;
+        const left = startLeft;
+        const newRight = startRight + dxNorm;
+        const { w, h } = clampSize(newRight - left, 1);
+        next.w = w;
+        next.h = h;
+        next.x = left;
+        next.y = top;
+        next = clampToBounds(next);
+        return next;
+      }
+      default:
+        return draftCropBox;
+    }
+  };
+
+  const scheduleDraftUpdate = (clientX: number, clientY: number) => {
+    latestPointerRef.current = { clientX, clientY };
+    if (rafRef.current) return;
+    rafRef.current = window.requestAnimationFrame(() => {
+      rafRef.current = null;
+      if (!latestPointerRef.current) return;
+      const { clientX, clientY } = latestPointerRef.current;
+      setDraftCropBox(computeDraftFromPointer(clientX, clientY));
+    });
+  };
 
   const handleGrabFrame = useCallback(() => {
     const video = videoRef.current;
@@ -144,7 +440,7 @@ export default function VideoPreview({
   }, []);
 
   const overlay = (() => {
-    if (!recipe || !showOverlay) return null;
+    if (!recipe || !showOverlay || recipe.framing !== "fit") return null;
 
     const preset = recipe.preset === "custom"
       ? { width: recipe.customWidth, height: recipe.customHeight }
@@ -155,36 +451,21 @@ export default function VideoPreview({
     // Preview container is 16:9
     const containerW = 16;
     const containerH = 9;
-    const containerRatio = containerW / containerH;   // 1.777…
+    const containerRatio = containerW / containerH; // 1.777…
     const outputRatio = preset.width / preset.height;
 
-    if (recipe.framing === "fit") {
-      // Letterbox: the output video fits entirely inside 16:9, padded with bars.
-      if (outputRatio > containerRatio) {
-        // Wider output → pillarbox bars on top & bottom
-        const contentH = (containerRatio / outputRatio) * 100;
-        const barH = (100 - contentH) / 2;
-        return { mode: "fit", barTop: `${barH}%`, barBottom: `${barH}%`, barLeft: "0", barRight: "0" };
-      } else {
-        // Taller output → letterbox bars on left & right
-        const contentW = (outputRatio / containerRatio) * 100;
-        const barW = (100 - contentW) / 2;
-        return { mode: "fit", barTop: "0", barBottom: "0", barLeft: `${barW}%`, barRight: `${barW}%` };
-      }
-    } else {
-      // Fill / crop: the output fills the entire 16:9 preview — show a box representing what survives the crop.
-      if (outputRatio < containerRatio) {
-        // Output is taller → crops top & bottom
-        const visibleH = (outputRatio / containerRatio) * 100;
-        const cropH = (100 - visibleH) / 2;
-        return { mode: "fill", barTop: `${cropH}%`, barBottom: `${cropH}%`, barLeft: "0", barRight: "0" };
-      } else {
-        // Output is wider → crops left & right
-        const visibleW = (containerRatio / outputRatio) * 100;
-        const cropW = (100 - visibleW) / 2;
-        return { mode: "fill", barTop: "0", barBottom: "0", barLeft: `${cropW}%`, barRight: `${cropW}%` };
-      }
+    // Letterbox: the output video fits entirely inside 16:9, padded with bars.
+    if (outputRatio > containerRatio) {
+      // Wider output → pillarbox bars on top & bottom
+      const contentH = (containerRatio / outputRatio) * 100;
+      const barH = (100 - contentH) / 2;
+      return { mode: "fit", barTop: `${barH}%`, barBottom: `${barH}%`, barLeft: "0", barRight: "0" };
     }
+
+    // Taller output → letterbox bars on left & right
+    const contentW = (outputRatio / containerRatio) * 100;
+    const barW = (100 - contentW) / 2;
+    return { mode: "fit", barTop: "0", barBottom: "0", barLeft: `${barW}%`, barRight: `${barW}%` };
   })();
 
   if (!file) return null;
@@ -232,7 +513,12 @@ export default function VideoPreview({
         <video
           ref={videoRef}
           controls
-          className={cn("w-full h-full object-contain transition-opacity duration-300", isLoading ? "opacity-0" : "opacity-100")}
+          className={cn(
+            "w-full h-full transition-opacity duration-300",
+            (recipe?.framing === "fill" ? "object-cover" : "object-contain"),
+            isLoading ? "opacity-0" : "opacity-100"
+          )}
+          style={cropPreviewTransform ?? undefined}
           onLoadedData={() => setIsLoading(false)}
           playsInline
           muted={!recipe?.keepAudio}
@@ -240,37 +526,162 @@ export default function VideoPreview({
           <track kind="captions" />
         </video>
 
-        {/* Letterbox / Crop overlay */}
+        {/* Fit (letterbox) overlay */}
         {overlay && (
           <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
-            {overlay.mode === "fit" ? (
-              // Letterbox: semi-transparent bars outside the content area
-              <>
-                <div className="absolute left-0 right-0 top-0 bg-[color-mix(in_srgb,var(--bg)_60%,transparent)]" style={{ height: overlay.barTop }} />
-                <div className="absolute left-0 right-0 bottom-0 bg-[color-mix(in_srgb,var(--bg)_60%,transparent)]" style={{ height: overlay.barBottom }} />
-                <div className="absolute top-0 bottom-0 left-0 bg-[color-mix(in_srgb,var(--bg)_60%,transparent)]" style={{ width: overlay.barLeft }} />
-                <div className="absolute top-0 bottom-0 right-0 bg-[color-mix(in_srgb,var(--bg)_60%,transparent)]" style={{ width: overlay.barRight }} />
-              </>
-            ) : (
-              // Fill/crop: dashed border around the surviving area, dimmed outside
-              <>
-                <div className="absolute left-0 right-0 top-0 bg-[var(--error-bg)]" style={{ height: overlay.barTop }} />
-                <div className="absolute left-0 right-0 bottom-0 bg-[var(--error-bg)]" style={{ height: overlay.barBottom }} />
-                <div className="absolute top-0 bottom-0 left-0 bg-[var(--error-bg)]" style={{ width: overlay.barLeft }} />
-                <div className="absolute top-0 bottom-0 right-0 bg-[var(--error-bg)]" style={{ width: overlay.barRight }} />
-                <div
-                  className="absolute border-2 border-dashed border-film-400"
-                  style={{
-                    top: overlay.barTop,
-                    bottom: overlay.barBottom,
-                    left: overlay.barLeft,
-                    right: overlay.barRight,
-                  }}
-                />
-              </>
-            )}
+            <div className="absolute left-0 right-0 top-0 bg-[color-mix(in_srgb,var(--bg)_60%,transparent)]" style={{ height: overlay.barTop }} />
+            <div className="absolute left-0 right-0 bottom-0 bg-[color-mix(in_srgb,var(--bg)_60%,transparent)]" style={{ height: overlay.barBottom }} />
+            <div className="absolute top-0 bottom-0 left-0 bg-[color-mix(in_srgb,var(--bg)_60%,transparent)]" style={{ width: overlay.barLeft }} />
+            <div className="absolute top-0 bottom-0 right-0 bg-[color-mix(in_srgb,var(--bg)_60%,transparent)]" style={{ width: overlay.barRight }} />
           </div>
         )}
+
+        {/* Crop selection overlay (fill mode) */}
+        {recipe?.framing === "fill" &&
+          showOverlay &&
+          !isLoading &&
+          containerDimensions.width > 0 &&
+          cropAspectK &&
+          currentCropBox && (
+            <div
+              className="absolute inset-0 z-20"
+              onPointerMove={(e) => {
+                const i = interactionRef.current;
+                if (!i) return;
+                if (i.pointerId !== e.pointerId) return;
+                if (recipe?.framing !== "fill") return;
+                scheduleDraftUpdate(e.clientX, e.clientY);
+              }}
+              onPointerUp={() => {
+                const i = interactionRef.current;
+                if (!i) return;
+                // Compute final box from the last known pointer position.
+                const latest = latestPointerRef.current;
+                if (!latest) {
+                  interactionRef.current = null;
+                  latestPointerRef.current = null;
+                  setIsEditingCrop(false);
+                  return;
+                }
+                const finalBox = computeDraftFromPointer(latest.clientX, latest.clientY);
+                setDraftCropBox(finalBox);
+                setIsEditingCrop(false);
+                interactionRef.current = null;
+                latestPointerRef.current = null;
+                if (!onCropChange || !recipe) return;
+                onCropChange({
+                  cropBoxX: finalBox.x,
+                  cropBoxY: finalBox.y,
+                  cropBoxW: finalBox.w,
+                  cropBoxH: finalBox.h,
+                });
+              }}
+              onPointerCancel={() => {
+                interactionRef.current = null;
+                latestPointerRef.current = null;
+                setIsEditingCrop(false);
+              }}
+            >
+              {/* Dark overlay outside the selected box */}
+              {(() => {
+                const boxLeft = currentCropBox.x * containerDimensions.width;
+                const boxTop = currentCropBox.y * containerDimensions.height;
+                const boxW = currentCropBox.w * containerDimensions.width;
+                const boxH = currentCropBox.h * containerDimensions.height;
+
+                return (
+                  <>
+                    <div className="absolute left-0 right-0 top-0 bg-[rgba(0,0,0,0.45)]" style={{ height: boxTop }} />
+                    <div
+                      className="absolute left-0 right-0 bg-[rgba(0,0,0,0.45)]"
+                      style={{ top: boxTop + boxH, height: containerDimensions.height - (boxTop + boxH) }}
+                    />
+                    <div className="absolute top-0 bottom-0 left-0 bg-[rgba(0,0,0,0.45)]" style={{ width: boxLeft }} />
+                    <div
+                      className="absolute top-0 bottom-0 bg-[rgba(0,0,0,0.45)]"
+                      style={{ left: boxLeft + boxW, width: containerDimensions.width - (boxLeft + boxW) }}
+                    />
+                  </>
+                );
+              })()}
+
+              {/* Selected crop box */}
+              {(() => {
+                const boxLeft = currentCropBox.x * containerDimensions.width;
+                const boxTop = currentCropBox.y * containerDimensions.height;
+                const boxW = currentCropBox.w * containerDimensions.width;
+                const boxH = currentCropBox.h * containerDimensions.height;
+
+                const handleSize = 10;
+                const half = handleSize / 2;
+
+                const handle = (handleId: ResizeHandle, xPx: number, yPx: number) => (
+                  <div
+                    key={handleId}
+                    data-handle={handleId}
+                    onPointerDown={(e) => {
+                      e.stopPropagation();
+                      startEdit(handleId, e);
+                    }}
+                    className="absolute bg-film-400 rounded-sm shadow-[0_0_0_2px_rgba(0,0,0,0.25)]"
+                    style={{
+                      width: handleSize,
+                      height: handleSize,
+                      left: xPx - half,
+                      top: yPx - half,
+                      cursor:
+                        handleId === "nw"
+                          ? "nwse-resize"
+                          : handleId === "se"
+                          ? "nwse-resize"
+                          : handleId === "ne"
+                          ? "nesw-resize"
+                          : handleId === "sw"
+                          ? "nesw-resize"
+                          : handleId === "n" || handleId === "s"
+                          ? "ns-resize"
+                          : handleId === "e" || handleId === "w"
+                          ? "ew-resize"
+                          : "grab",
+                    }}
+                    aria-hidden="true"
+                  />
+                );
+
+                const frameStyle: React.CSSProperties = {
+                  left: boxLeft,
+                  top: boxTop,
+                  width: boxW,
+                  height: boxH,
+                };
+
+                return (
+                  <div
+                    className="absolute border-2 border-film-400 pointer-events-auto"
+                    style={{ ...frameStyle, cursor: isEditingCrop ? "grabbing" : "grab" }}
+                    onPointerDown={(e) => {
+                      e.stopPropagation();
+                      startEdit("move", e);
+                    }}
+                    aria-hidden="true"
+                  >
+                    {/* Border fill hint */}
+                    <div className="absolute inset-0 bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] rounded-[2px]" />
+
+                    {/* Resize handles */}
+                    {handle("nw", 0, 0)}
+                    {handle("ne", boxW, 0)}
+                    {handle("sw", 0, boxH)}
+                    {handle("se", boxW, boxH)}
+                    {handle("n", boxW / 2, 0)}
+                    {handle("s", boxW / 2, boxH)}
+                    {handle("w", 0, boxH / 2)}
+                    {handle("e", boxW, boxH / 2)}
+                  </div>
+                );
+              })()}
+            </div>
+          )}
 
         {/* Draggable Text Overlays */}
         {recipe && !isLoading && containerDimensions.width > 0 && (

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -141,6 +141,8 @@ function migrateRecipe(recipe: Partial<EditRecipe>): EditRecipe {
     ...recipe,
     // Ensure textOverlays is always an array
     textOverlays: Array.isArray(recipe.textOverlays) ? recipe.textOverlays : [],
+    // Always bump to current recipe schema version.
+    version: DEFAULT_RECIPE.version,
   };
 }
 
@@ -226,6 +228,12 @@ export function useVideoEditor() {
         return typeof val === "number" && !isNaN(val) && val >= 0 && val <= 2;
       case "saturation":
         return typeof val === "number" && !isNaN(val) && val >= 0 && val <= 3;
+      case "cropBoxX":
+      case "cropBoxY":
+        return typeof val === "number" && !isNaN(val) && val >= 0 && val <= 1;
+      case "cropBoxW":
+      case "cropBoxH":
+        return typeof val === "number" && !isNaN(val) && val > 0 && val <= 1;
       default:
         return true;
     }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,7 @@
 import type { EditRecipe } from "./types"
 import { RECIPE_VERSION } from "./types"
+import { getPresetById } from "./presets"
+import { getCenteredMaxCropBox } from "./crop-frame"
 
 export const SPEED_STEPS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 4] as const;
 
@@ -23,5 +25,11 @@ export const DEFAULT_RECIPE: EditRecipe = {
   soundOnCompletion: false,
   normalizeAudio: false,
   textOverlays: [],
+  ...(() => {
+    const preset = getPresetById("vertical-9-16");
+    const outputAspect = preset ? preset.width / preset.height : 9 / 16;
+    const box = getCenteredMaxCropBox(outputAspect);
+    return { cropBoxX: box.x, cropBoxY: box.y, cropBoxW: box.w, cropBoxH: box.h };
+  })(),
   version: RECIPE_VERSION,
 };

--- a/src/lib/crop-frame.ts
+++ b/src/lib/crop-frame.ts
@@ -1,0 +1,47 @@
+export const PREVIEW_CONTAINER_ASPECT = 16 / 9;
+export const PREVIEW_CONTAINER_WIDTH = 16;
+export const PREVIEW_CONTAINER_HEIGHT = 9;
+
+export interface CropBox {
+  x: number; // top-left normalized [0..1]
+  y: number; // top-left normalized [0..1]
+  w: number; // width normalized [0..1]
+  h: number; // height normalized [0..1]
+}
+
+/**
+ * Returns the largest crop box with `outputAspect` that fits inside
+ * a 16:9 preview container, centered.
+ */
+export function getCenteredMaxCropBox(outputAspect: number): CropBox {
+  // width fraction and height fraction are relative to container width/height
+  // so the pixel aspect ratio is:
+  //   (w * containerW) / (h * containerH) = (w/h) * (containerW/containerH)
+  //   => w/h = outputAspect / containerAspect
+  const k = outputAspect / PREVIEW_CONTAINER_ASPECT;
+
+  if (outputAspect >= PREVIEW_CONTAINER_ASPECT) {
+    // box touches left/right
+    const w = 1;
+    const h = w / k;
+    return { x: 0, y: (1 - h) / 2, w, h };
+  }
+
+  // box touches top/bottom
+  const h = 1;
+  const w = h * k;
+  return { x: (1 - w) / 2, y: 0, w, h };
+}
+
+export function clampCropBox(box: CropBox, minW = 0.04, minH = 0.04): CropBox {
+  let w = Math.max(minW, Math.min(1, box.w));
+  let h = Math.max(minH, Math.min(1, box.h));
+
+  // Keep aspect ratio constraints to caller; this clamp is only for bounds safety.
+  // Ensure box fits within [0..1] range.
+  const x = Math.min(Math.max(0, box.x), 1 - w);
+  const y = Math.min(Math.max(0, box.y), 1 - h);
+
+  return { x, y, w, h };
+}
+

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -1,6 +1,7 @@
 import { EditRecipe, ExportResult, BackgroundMusicOptions, ImageOverlayOptions } from "./types";
 import { getPresetById } from "./presets";
 import { buildTextFilter } from "./text-overlay";
+import { PREVIEW_CONTAINER_WIDTH, PREVIEW_CONTAINER_HEIGHT } from "./crop-frame";
 
 export class FFmpegLoadError extends Error {}
 
@@ -351,9 +352,31 @@ export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: n
       `pad=${targetW}:${targetH}:(ow-iw)/2:(oh-ih)/2:color=black`
     );
   } else {
+    // For fill mode, apply the user-selected crop box (normalized to a 16:9 preview container),
+    // then scale the cropped region to the requested output size.
+    //
+    // This keeps the selection position while exporting (instead of always cropping from center).
+    const vcw = PREVIEW_CONTAINER_WIDTH;
+    const vch = PREVIEW_CONTAINER_HEIGHT;
+    const boxX = recipe.cropBoxX * vcw;
+    const boxY = recipe.cropBoxY * vch;
+    const boxW = recipe.cropBoxW * vcw;
+    const boxH = recipe.cropBoxH * vch;
+
+    // "Cover" mapping scale factor: how much the rotated source is scaled to cover the
+    // 16:9 preview container.
+    const scExpr = `max(${vcw}/iw\\,${vch}/ih)`;
+    const leftExpr = `(${vcw}-iw*${scExpr})/2`;
+    const topExpr = `(${vch}-ih*${scExpr})/2`;
+
+    const wExpr = `floor(${boxW}/${scExpr})`;
+    const hExpr = `floor(${boxH}/${scExpr})`;
+    const xExpr = `floor((${boxX}-${leftExpr})/${scExpr})`;
+    const yExpr = `floor((${boxY}-${topExpr})/${scExpr})`;
+
     filters.push(
-      `scale=${targetW}:${targetH}:force_original_aspect_ratio=increase`,
-      `crop=${targetW}:${targetH}`
+      `crop=w=${wExpr}:h=${hExpr}:x=${xExpr}:y=${yExpr}`,
+      `scale=${targetW}:${targetH}`
     );
   }
 

--- a/src/lib/frame-export.ts
+++ b/src/lib/frame-export.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_RECIPE } from "./constants";
 import { getPresetById } from "./presets";
 import { EditRecipe } from "./types";
+import { PREVIEW_CONTAINER_WIDTH, PREVIEW_CONTAINER_HEIGHT } from "./crop-frame";
 
 export interface FrameExportSize {
   width: number;
@@ -88,18 +89,76 @@ export async function captureFrameAsPng(
   ctx.fillRect(0, 0, width, height);
   ctx.imageSmoothingEnabled = true;
   ctx.imageSmoothingQuality = "high";
-  ctx.save();
-  ctx.translate(width / 2, height / 2);
-  ctx.rotate(rotation);
-  ctx.scale(scale, scale);
-  ctx.drawImage(
-    video,
-    -video.videoWidth / 2,
-    -video.videoHeight / 2,
-    video.videoWidth,
-    video.videoHeight
-  );
-  ctx.restore();
+
+  // Fit mode keeps the existing scale+letterbox behavior.
+  if (recipe.framing === "fit") {
+    ctx.save();
+    ctx.translate(width / 2, height / 2);
+    ctx.rotate(rotation);
+    ctx.scale(scale, scale);
+    ctx.drawImage(
+      video,
+      -video.videoWidth / 2,
+      -video.videoHeight / 2,
+      video.videoWidth,
+      video.videoHeight
+    );
+    ctx.restore();
+  } else {
+    // Fill mode: rotate the source, crop according to the user selection box,
+    // then scale the crop to the requested output size.
+    const rotatedW = recipe.rotate === 90 || recipe.rotate === 270 ? video.videoHeight : video.videoWidth;
+    const rotatedH = recipe.rotate === 90 || recipe.rotate === 270 ? video.videoWidth : video.videoHeight;
+
+    const rotCanvas = document.createElement("canvas");
+    rotCanvas.width = rotatedW;
+    rotCanvas.height = rotatedH;
+    const rotCtx = rotCanvas.getContext("2d");
+    if (!rotCtx) {
+      throw new Error("Canvas export is not supported in this browser.");
+    }
+
+    rotCtx.fillStyle = "#000000";
+    rotCtx.fillRect(0, 0, rotatedW, rotatedH);
+    rotCtx.imageSmoothingEnabled = true;
+    rotCtx.imageSmoothingQuality = "high";
+
+    rotCtx.save();
+    rotCtx.translate(rotatedW / 2, rotatedH / 2);
+    rotCtx.rotate(rotation);
+    rotCtx.drawImage(
+      video,
+      -video.videoWidth / 2,
+      -video.videoHeight / 2,
+      video.videoWidth,
+      video.videoHeight
+    );
+    rotCtx.restore();
+
+    const vcw = PREVIEW_CONTAINER_WIDTH;
+    const vch = PREVIEW_CONTAINER_HEIGHT;
+    const sc = Math.max(vcw / rotatedW, vch / rotatedH);
+    const left = (vcw - rotatedW * sc) / 2;
+    const top = (vch - rotatedH * sc) / 2;
+
+    const boxX = recipe.cropBoxX * vcw;
+    const boxY = recipe.cropBoxY * vch;
+    const boxW = recipe.cropBoxW * vcw;
+    const boxH = recipe.cropBoxH * vch;
+
+    const cropX = Math.floor((boxX - left) / sc);
+    const cropY = Math.floor((boxY - top) / sc);
+    const cropW = Math.floor(boxW / sc);
+    const cropH = Math.floor(boxH / sc);
+
+    // Clamp for safety.
+    const cx = Math.max(0, Math.min(rotatedW - 1, cropX));
+    const cy = Math.max(0, Math.min(rotatedH - 1, cropY));
+    const cw = Math.max(1, Math.min(rotatedW - cx, cropW));
+    const ch = Math.max(1, Math.min(rotatedH - cy, cropH));
+
+    ctx.drawImage(rotCanvas, cx, cy, cw, ch, 0, 0, width, height);
+  }
 
   const blob = await new Promise<Blob>((resolve, reject) => {
     canvas.toBlob((result) => {

--- a/src/lib/tests/videoFilter.test.ts
+++ b/src/lib/tests/videoFilter.test.ts
@@ -60,8 +60,8 @@ describe("buildVideoFilter", () => {
 
   it("should use fill framing with scale and crop", () => {
     const result = buildVideoFilter(base({ framing: "fill" }), 1280, 720);
-    expect(result).toContain("force_original_aspect_ratio=increase");
-    expect(result).toContain("crop=1280:720");
+    expect(result).toContain("crop=w=");
+    expect(result).toContain("scale=1280:720");
   });
 
   it("should include deshake when stabilization is true", () => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-export const RECIPE_VERSION = 1;
+export const RECIPE_VERSION = 2;
 
 /**
  * Text overlay data structure for rendering custom text on videos.
@@ -35,6 +35,16 @@ export interface EditRecipe {
   saturation: number;
   soundOnCompletion: boolean;
   textOverlays: TextOverlay[];
+  /**
+   * Crop selection box in the 16:9 preview container coordinate space.
+   * Values are normalized to [0..1] where:
+   * - x/y are the top-left corner
+   * - w/h are the box size
+   */
+  cropBoxX: number;
+  cropBoxY: number;
+  cropBoxW: number;
+  cropBoxH: number;
   version: number;
 }
 
@@ -104,6 +114,14 @@ export function isValidRecipe(value: unknown): value is EditRecipe {
   if (typeof v.saturation !== "number" || !isFinite(v.saturation)) return false;
   if (typeof v.soundOnCompletion !== "boolean") return false;
   if (!Array.isArray(v.textOverlays)) return false;
+
+  for (const key of ["cropBoxX", "cropBoxY", "cropBoxW", "cropBoxH"] as const) {
+    if (typeof v[key] !== "number" || !isFinite(v[key])) return false;
+  }
+  if (v.cropBoxW <= 0 || v.cropBoxH <= 0 || v.cropBoxW > 1 || v.cropBoxH > 1) return false;
+  if (v.cropBoxX < 0 || v.cropBoxY < 0) return false;
+  if (v.cropBoxX + v.cropBoxW > 1.0001) return false;
+  if (v.cropBoxY + v.cropBoxH > 1.0001) return false;
 
   return true;
 }


### PR DESCRIPTION
## Description
## Related Issue
## Type of Contribution## Description

Implemented a draggable and resizable crop/selection frame for the video preview in Fill mode. Users can now manually reposition the crop area instead of being restricted to a centered crop, improving framing control for formats like 9:16, 1:1, and 4:5.

## Related Issue

Fixes the issue where important subjects were cropped out due to forced center-cropping during aspect ratio conversion.

## Type of Contribution

* [x] Bug fix
* [x] New feature
* [x] GSSoC contribution

## Participant Info

* GitHub username: pratyuxxhh
* Contribution level (Beginner/Intermediate/Advanced): Advanced

## Screen Recording

Implemented the fill option for selecting frame.

https://github.com/user-attachments/assets/328d1e00-ee1c-475b-affd-c8e0605da340


## Changes Made

### Interactive Crop Overlay

Implemented in `src/components/VideoPreview.tsx`

* Added draggable crop frame
* Added resizable handles on all 8 sides/corners
* Locked aspect ratio based on selected output preset
* Added smooth pointer interactions (mouse + touch)
* Added semi-transparent overlay outside selected crop area
* Added directional resize cursors
* Added boundary clamping within preview bounds
* Added RAF-throttled updates for smoother performance
* Crop state now persists during playback

### Framing Controls

Implemented in `src/components/FramingControl.tsx`

* Added **Reset** button
* Added **Center** button for quick repositioning

### State & Export Updates

Updated:

* `src/lib/types.ts`
* `src/lib/constants.ts`
* `src/lib/ffmpeg.ts`
* `src/lib/frame-export.ts`

Changes include:

* Added normalized crop state:

  * `cropBoxX`
  * `cropBoxY`
  * `cropBoxW`
  * `cropBoxH`
* Updated FFmpeg export pipeline to use selected crop area instead of fixed center crop
* Updated PNG frame export to respect selected crop box

## How to Test

1. Open the app using:

   ```bash
   bun run dev
   ```

2. Upload a video

3. Select an output preset:

   * 9:16
   * 1:1
   * 4:5

4. Switch framing mode to **Fill**

5. Drag and resize the crop box in the preview

6. Test:

   * Edge resizing
   * Corner resizing
   * Boundary clamping
   * Reset / Center buttons
   * Exported output accuracy

## Checklist

* [x] I have read the contribution guidelines
* [x] My changes follow the project structure
* [x] I have tested my changes in Chrome, Firefox, and Safari
* [x] `bun run lint` passes (no ESLint errors)
* [x] `bunx tsc --noEmit` passes (no TypeScript errors)
* [x] New interactive elements have `aria-label` / accessible names
* [x] No `console.log` statements left in
* [x] This PR is related to a valid issue
* [x] Screen recording attached above (required for UI/feature/design changes)

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: 
- Contribution level (Beginner/Intermediate/Advanced): 

## Screen Recording
> **How to record:** run `bun run dev` → open http://localhost:3000 → demonstrate the full working flow of your change, including any edge cases.
>
> - **macOS**: `Cmd + Shift + 5` → Record Selected Portion, or use QuickTime Player
> - **Windows**: `Win + G` → Xbox Game Bar → Capture
> - **Linux**: OBS Studio, GNOME Screenshot tool, or `kazam`
> - **Any OS**: [Loom](https://loom.com) (free screen recorder, great for sharing)

**Recording / Loom link:** ## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)