### PR TITLE
feat: add multi-segment trimming (#1221)

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import { useTheme } from "./ThemeProvider";
-import { useEffect, useState } from "react";
 
 export function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
@@ -27,7 +26,6 @@ export function ThemeToggle() {
   }
 
   const isDark = theme === "dark";
-  const [mounted, setMounted] = useState(false);
 
   return (
     <button

--- a/src/components/ThumbnailStrip.tsx
+++ b/src/components/ThumbnailStrip.tsx
@@ -2,6 +2,8 @@
 
 import Image from "next/image";
 import { useEffect, useRef, useState, useCallback } from "react";
+import { TrimSegment } from "@/lib/types";
+import { hasMultiSegments } from "@/lib/trim-segments";
 
 interface Thumbnail {
   time: number;
@@ -14,6 +16,7 @@ interface ThumbnailStripProps {
   currentTime: number;
   trimStart?: number;
   trimEnd?: number;
+  trimSegments?: TrimSegment[];
   onSeek: (time: number) => void;
   intervalSeconds?: number;
 }
@@ -24,6 +27,7 @@ export default function ThumbnailStrip({
   currentTime,
   trimStart = 0,
   trimEnd,
+  trimSegments = [],
   onSeek,
   intervalSeconds = 5,
 }: ThumbnailStripProps) {
@@ -207,8 +211,14 @@ export default function ThumbnailStrip({
           <div className="strip-inner">
             {thumbnails.map((thumb, i) => {
               const isActive = i === activeIndex;
-              const inTrimRange =
-                thumb.time >= trimStart && thumb.time <= effectiveTrimEnd;
+              
+              let inTrimRange = false;
+              if (hasMultiSegments(trimSegments)) {
+                inTrimRange = trimSegments.some(seg => thumb.time >= seg.start && thumb.time <= seg.end);
+              } else {
+                inTrimRange = thumb.time >= trimStart && thumb.time <= effectiveTrimEnd;
+              }
+
               const isHovered = hoveredIndex === i;
 
               return (

--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -1,53 +1,76 @@
 "use client";
 
-import { EditRecipe } from "@/lib/types";
-import { useState, useEffect, useRef, useCallback } from "react";
-import { AlertCircle } from "lucide-react";
+import { EditRecipe, TrimSegment } from "@/lib/types";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { AlertCircle, Scissors, Plus, Trash2 } from "lucide-react";
 import { formatDuration } from "@/lib/utils";
-import { useAudioWaveform } from "@/hooks/useAudioWaveform";
-import WaveformCanvas from "@/components/WaveformCanvas";
+import {
+  generateSegmentId,
+  getCutRegions,
+  addSplitPoint,
+  removeSegment,
+  updateSegmentBound,
+  totalSegmentsDuration,
+  validateSegments,
+  mergeWithNextSegment,
+} from "@/lib/trim-segments";
 
 const MIN_CLIP_DURATION = 0.1;
 
 interface Props {
-  recipe: EditRecipe;
-  onChange: (patch: Partial<EditRecipe>) => void;
-  duration: number;
-  file: File | null;
+  readonly recipe: EditRecipe;
+  readonly onChange: (patch: Partial<EditRecipe>) => void;
+  readonly duration: number;
+  readonly file: File | null;
+  readonly currentTime?: number;
 }
 
-export default function TrimControl({ recipe, onChange, duration, file }: Props) {
-  const [invalidStart, setStart] = useState(false);
-  const [invalidEnd, setEnd] = useState(false);
+export default function TrimControl({ recipe, onChange, duration, file, currentTime }: Props) {
+  const [invalidStart, setInvalidStart] = useState(false);
+  const [invalidEnd, setInvalidEnd] = useState(false);
   const [startErrorMsg, setStartErrorMsg] = useState("");
   const [endErrorMsg, setEndErrorMsg] = useState("");
   const [startInput, setStartInput] = useState(
     recipe.trimStart.toString()
   );
 
-  const { waveform, isLoading: waveformLoading } = useAudioWaveform(file);
-  const hasAudio = waveform.length > 0;
-
   useEffect(() => {
     setStartInput(recipe.trimStart.toString());
   }, [recipe.trimStart]);
 
-  const clipLength =
-    (recipe.trimEnd ?? duration) - recipe.trimStart;
+  const segments = useMemo(() => recipe.trimSegments ?? [], [recipe.trimSegments]);
+  const isMultiSeg = segments.length > 0;
+
+  const clipLength = isMultiSeg
+    ? totalSegmentsDuration(segments)
+    : (recipe.trimEnd ?? duration) - recipe.trimStart;
 
   const trackRef = useRef<HTMLDivElement>(null);
   const dragging = useRef<"start" | "end" | null>(null);
+  const draggingSegBound = useRef<{ segId: string; field: "start" | "end" } | null>(null);
+  // Prevents the timeline click from firing a split after a drag release
+  const wasDragging = useRef(false);
 
   const xToSeconds = useCallback((clientX: number) => {
     const track = trackRef.current;
     if (!track || duration <= 0) return 0;
     const { left, width } = track.getBoundingClientRect();
     const ratio = Math.max(0, Math.min(1, (clientX - left) / width));
-    return parseFloat((ratio * duration).toFixed(1));
+    return Number.parseFloat((ratio * duration).toFixed(1));
   }, [duration]);
 
   const applyDrag = useCallback((clientX: number) => {
     const seconds = xToSeconds(clientX);
+
+    // Multi-segment drag
+    if (draggingSegBound.current) {
+      const { segId, field } = draggingSegBound.current;
+      const updated = updateSegmentBound(segments, segId, field, seconds, duration);
+      onChange({ trimSegments: updated });
+      return;
+    }
+
+    // Single-trim drag
     if (dragging.current === "start") {
       const clamped = Math.min(seconds, (recipe.trimEnd ?? duration) - 0.1);
       onChange({ trimStart: Math.max(0, clamped) });
@@ -55,7 +78,7 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
       const clamped = Math.max(seconds, recipe.trimStart + 0.1);
       onChange({ trimEnd: Math.min(duration, clamped) });
     }
-  }, [xToSeconds, duration, recipe.trimStart, recipe.trimEnd, onChange]);
+  }, [xToSeconds, duration, recipe.trimStart, recipe.trimEnd, segments, onChange]);
 
  useEffect(() => {
   const onMove = (e: MouseEvent | TouchEvent) => {
@@ -75,7 +98,12 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
   };
 
   const onUp = () => {
+    // Mark that we just finished a drag so onClick doesn't create a split
+    if (dragging.current || draggingSegBound.current) {
+      wasDragging.current = true;
+    }
     dragging.current = null;
+    draggingSegBound.current = null;
   };
 
   document.addEventListener("mousemove", onMove);
@@ -90,31 +118,79 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
     document.removeEventListener("touchend", onUp);
   };
 }, [applyDrag]);
+
+  // ── Multi-segment operations ──
+
+  const handleEnableMultiSegment = useCallback(() => {
+    if (duration <= 0) return;
+    // Initialize with a single full-range segment
+    const fullSegment: TrimSegment = {
+      id: generateSegmentId(),
+      start: recipe.trimStart,
+      end: recipe.trimEnd ?? duration,
+    };
+    onChange({ trimSegments: [fullSegment] });
+  }, [duration, recipe.trimStart, recipe.trimEnd, onChange]);
+
+  const handleAddSplit = useCallback(() => {
+    if (segments.length === 0) return;
+    
+    // First try splitting at the current video playhead
+    if (typeof currentTime === "number") {
+      const updated = addSplitPoint(segments, currentTime);
+      // If it successfully split (length changed), we're done
+      if (updated.length > segments.length) {
+        onChange({ trimSegments: updated });
+        return;
+      }
+    }
+    
+    // Fallback: Find the largest segment and split it at its midpoint
+    const sorted = [...segments].sort((a, b) => (b.end - b.start) - (a.end - a.start));
+    const largest = sorted[0];
+    if (!largest) return;
+    const midPoint = (largest.start + largest.end) / 2;
+    const updated = addSplitPoint(segments, midPoint);
+    onChange({ trimSegments: updated });
+  }, [segments, currentTime, onChange]);
+
+  const handleRemoveSegment = useCallback((segId: string) => {
+    const updated = removeSegment(segments, segId);
+    onChange({ trimSegments: updated });
+  }, [segments, onChange]);
+
+  const handleDisableMultiSegment = useCallback(() => {
+    onChange({ trimSegments: [], trimStart: 0, trimEnd: null });
+  }, [onChange]);
+
+  const segmentError = isMultiSeg ? validateSegments(segments, duration) : null;
+
+  // ── Handlers for the legacy single-trim inputs ──
   const handleStart = (val: string) => {
     setStartInput(val);
 
     if (val === "") {
-      setStart(false);
+      setInvalidStart(false);
       setStartErrorMsg("");
       return;
     }
 
-    const n = parseFloat(val);
+    const n = Number.parseFloat(val);
 
-    if (isNaN(n)) {
-      setStart(true);
+    if (Number.isNaN(n)) {
+      setInvalidStart(true);
       setStartErrorMsg("Enter a valid number.");
       return;
     }
 
     if (n < 0) {
-      setStart(true);
+      setInvalidStart(true);
       setStartErrorMsg("Start time must be 0 or greater.");
       return;
     }
 
     if (duration > 0 && n >= duration) {
-      setStart(true);
+      setInvalidStart(true);
       setStartErrorMsg(
         `Start time must be less than duration (${duration.toFixed(1)}s).`
       );
@@ -122,12 +198,12 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
     }
 
     if (recipe.trimEnd !== null && n >= recipe.trimEnd - MIN_CLIP_DURATION) {
-      setStart(true);
+      setInvalidStart(true);
       setStartErrorMsg("Start time must be less than the end time.");
       return;
     }
 
-    setStart(false);
+    setInvalidStart(false);
     setStartErrorMsg("");
     onChange({ trimStart: n });
   };
@@ -135,39 +211,39 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
   const handleEnd = (val: string) => {
     if (val === "") {
       onChange({ trimEnd: null });
-      setEnd(false);
+      setInvalidEnd(false);
       return;
     }
 
-    const n = parseFloat(val);
+    const n = Number.parseFloat(val);
 
-    if (isNaN(n)) {
-      setEnd(true);
+    if (Number.isNaN(n)) {
+      setInvalidEnd(true);
       setEndErrorMsg("Enter a valid number.");
       return;
     }
 
     if (n <= 0) {
-      setEnd(true);
+      setInvalidEnd(true);
       setEndErrorMsg("End time must be greater than 0.");
       return;
     }
 
     if (n <= recipe.trimStart + MIN_CLIP_DURATION) {
-      setEnd(true);
+      setInvalidEnd(true);
       setEndErrorMsg("End time must be greater than start time.");
       return;
     }
 
     if (duration > 0 && n > duration + 0.01) {
-      setEnd(true);
+      setInvalidEnd(true);
       setEndErrorMsg(
         `End time cannot exceed duration (${duration.toFixed(1)}s).`,
       );
       return;
     }
 
-    setEnd(false);
+    setInvalidEnd(false);
     setEndErrorMsg("");
     onChange({ trimEnd: n });
   };
@@ -177,7 +253,188 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
 
   return (
     <div id="trim-control" className="space-y-3">
-      {duration > 0 && (
+      {/* Multi-segment toggle */}
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          onClick={isMultiSeg ? handleDisableMultiSegment : handleEnableMultiSegment}
+          disabled={duration <= 0}
+          className={`flex items-center gap-1.5 text-xs font-heading font-bold uppercase tracking-widest transition-all ${
+            isMultiSeg
+              ? "text-film-600 hover:text-film-700"
+              : "text-[var(--muted)] hover:text-film-500"
+          }`}
+        >
+          <Scissors size={12} />
+          {isMultiSeg ? "Multi-Cut: ON" : "Enable Multi-Cut"}
+        </button>
+        {isMultiSeg && (
+          <button
+            type="button"
+            onClick={handleAddSplit}
+            className="flex items-center gap-1 text-xs font-heading font-bold uppercase tracking-widest text-film-500 hover:text-film-600 transition-all"
+          >
+            <Plus size={12} />
+            Add Split
+          </button>
+        )}
+      </div>
+
+      {/* ── Multi-segment timeline ── */}
+      {isMultiSeg && duration > 0 && (
+        <div className="space-y-2">
+          {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
+          <div
+            ref={trackRef}
+            className="relative h-8 rounded-md overflow-hidden cursor-pointer select-none bg-[var(--border)]"
+            onClick={(e) => {
+              // Suppress accidental splits caused by mouseup after a drag
+              if (wasDragging.current) {
+                wasDragging.current = false;
+                return;
+              }
+              if (draggingSegBound.current) return;
+              const t = xToSeconds(e.clientX);
+              const updated = addSplitPoint(segments, t);
+              onChange({ trimSegments: updated });
+            }}
+          >
+            {/* Full track background */}
+            <div className="absolute inset-0 bg-[var(--border)]" />
+
+            {/* Cut regions (dimmed) */}
+            {getCutRegions(segments, duration).map((cut) => (
+              <div
+                key={`cut-${cut.start}-${cut.end}`}
+                className="absolute top-0 bottom-0"
+                style={{
+                  left: `${(cut.start / duration) * 100}%`,
+                  width: `${((cut.end - cut.start) / duration) * 100}%`,
+                  background: "repeating-linear-gradient(45deg, transparent, transparent 3px, rgba(239,68,68,0.15) 3px, rgba(239,68,68,0.15) 6px)",
+                }}
+              />
+            ))}
+
+            {/* Keep segments (accent colored) */}
+            {[...segments].sort((a, b) => a.start - b.start).map((seg) => (
+              <div
+                key={seg.id}
+                className="absolute top-0 bottom-0 bg-film-400/40 border-y border-film-400/60 group flex items-center justify-center"
+                style={{
+                  left: `${(seg.start / duration) * 100}%`,
+                  width: `${((seg.end - seg.start) / duration) * 100}%`,
+                }}
+              >
+                {/* Delete button (shows on hover) */}
+                <button
+                  type="button"
+                  className="opacity-0 group-hover:opacity-100 p-1 bg-red-500/80 text-white rounded hover:bg-red-500 transition-all z-10 scale-75 hover:scale-100"
+                  onClick={(e) => {
+                    e.stopPropagation(); // prevent adding a split point
+                    handleRemoveSegment(seg.id);
+                  }}
+                  title="Remove segment"
+                >
+                  <Trash2 size={12} />
+                </button>
+                {/* Start handle — double-click to merge with previous segment */}
+                <div
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Split point at ${seg.start.toFixed(1)}s`}
+                  title="Double-click to remove this split"
+                  className="absolute left-0 top-0 bottom-0 w-2 cursor-ew-resize bg-film-500 hover:bg-film-600 transition-colors z-20"
+                  onDoubleClick={(e) => {
+                    e.stopPropagation();
+                    const sorted = [...segments].sort((a, b) => a.start - b.start);
+                    const idx = sorted.findIndex(s => s.id === seg.id);
+                    if (idx > 0) {
+                      const prev = sorted[idx - 1];
+                      if (prev) {
+                        const updated = mergeWithNextSegment(segments, prev.id);
+                        onChange({ trimSegments: updated });
+                      }
+                    }
+                  }}
+                  onMouseDown={(e) => {
+                    e.stopPropagation();
+                    draggingSegBound.current = { segId: seg.id, field: "start" };
+                  }}
+                  onTouchStart={(e) => {
+                    e.stopPropagation();
+                    draggingSegBound.current = { segId: seg.id, field: "start" };
+                  }}
+                />
+                {/* End handle — double-click to merge with next segment */}
+                <div
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Split point at ${seg.end.toFixed(1)}s`}
+                  title="Double-click to remove this split"
+                  className="absolute right-0 top-0 bottom-0 w-2 cursor-ew-resize bg-film-500 hover:bg-film-600 transition-colors z-20"
+                  onDoubleClick={(e) => {
+                    e.stopPropagation();
+                    const updated = mergeWithNextSegment(segments, seg.id);
+                    if (updated !== segments) {
+                      onChange({ trimSegments: updated });
+                    }
+                  }}
+                  onMouseDown={(e) => {
+                    e.stopPropagation();
+                    draggingSegBound.current = { segId: seg.id, field: "end" };
+                  }}
+                  onTouchStart={(e) => {
+                    e.stopPropagation();
+                    draggingSegBound.current = { segId: seg.id, field: "end" };
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+
+          {/* Segment list */}
+          <div className="space-y-1.5">
+            {[...segments].sort((a, b) => a.start - b.start).map((seg, i) => (
+              <div
+                key={seg.id}
+                className="flex items-center gap-2 px-2 py-1.5 rounded-md bg-[var(--bg)] border border-[var(--border)] text-xs"
+              >
+                <span className="font-heading font-bold text-film-500 w-4">{i + 1}</span>
+                <span className="text-[var(--muted)] font-mono flex-1">
+                  {formatDuration(seg.start)} → {formatDuration(seg.end)}
+                </span>
+                <span className="text-[var(--muted)] font-mono">
+                  ({formatDuration(seg.end - seg.start)})
+                </span>
+                {segments.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveSegment(seg.id)}
+                    className="text-red-400 hover:text-red-500 transition-colors p-0.5"
+                    aria-label={`Remove segment ${i + 1}`}
+                  >
+                    <Trash2 size={12} />
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {segmentError && (
+            <p className="font-heading animate-fade-in mt-1.5 flex items-center gap-1 text-[10px] text-red-500">
+              <AlertCircle size={10} className="shrink-0" />
+              {segmentError}
+            </p>
+          )}
+
+          <p className="text-xs text-[var(--muted)]">
+            Tip: Click the timeline to add a split point. Drag the edges to adjust.
+          </p>
+        </div>
+      )}
+
+      {/* ── Legacy single-trim timeline ── */}
+      {!isMultiSeg && duration > 0 && (
         <div
           role="toolbar"
           aria-label="Trim timeline"
@@ -235,89 +492,103 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
           />
         </div>
       )}
-      <div className="flex gap-3">
-        <div className="flex-1">
-          <label
-            htmlFor="trim-start"
-            className="font-heading mb-1.5 block text-[10px] font-semibold uppercase tracking-wider text-[var(--muted)]"
-          >
-            Start (sec)
-          </label>
 
-          <input
-            id="trim-start"
-            type="number"
-            autoComplete="off"
-            min={0}
-            max={duration > 0 ? duration : undefined}
-            step={0.1}
-            value={startInput}
-            spellCheck={false}
-            onChange={(e) => handleStart(e.target.value)}
-            aria-label="Trim start time in seconds"
-            aria-invalid={invalidStart}
-            aria-describedby={invalidStart ? "trim-start-error" : undefined}
-            className={`${inputClass} ${
-              invalidStart ? "border-[var(--error)]" : "border-[var(--border)]"
-            }`}
-            placeholder="0"
-          />
-          {invalidStart && (
-            <p
-              id="trim-start-error"
-              className="font-heading animate-fade-in mt-1.5 flex items-center gap-1 text-[10px] text-red-500"
+      {/* Legacy single-trim inputs */}
+      {!isMultiSeg && (
+        <div className="flex gap-3">
+          <div className="flex-1">
+            <label
+              htmlFor="trim-start"
+              className="font-heading mb-1.5 block text-[10px] font-semibold uppercase tracking-wider text-[var(--muted)]"
             >
-              <AlertCircle size={10} className="shrink-0" />
-              {startErrorMsg}
-            </p>
-          )}
-        </div>
+              Start (sec)
+            </label>
 
-        <div className="flex-1">
-          <label
-            htmlFor="trim-end"
-            className="font-heading mb-1.5 block text-[10px] font-semibold uppercase tracking-wider text-[var(--muted)]"
-          >
-            End (sec)
-          </label>
+            <input
+              id="trim-start"
+              type="number"
+              autoComplete="off"
+              min={0}
+              max={duration > 0 ? duration : undefined}
+              step={0.1}
+              value={startInput}
+              spellCheck={false}
+              onChange={(e) => handleStart(e.target.value)}
+              aria-label="Trim start time in seconds"
+              aria-invalid={invalidStart}
+              aria-describedby={invalidStart ? "trim-start-error" : undefined}
+              className={`${inputClass} ${
+                invalidStart ? "border-[var(--error)]" : "border-[var(--border)]"
+              }`}
+              placeholder="0"
+            />
+            {invalidStart && (
+              <p
+                id="trim-start-error"
+                className="font-heading animate-fade-in mt-1.5 flex items-center gap-1 text-[10px] text-red-500"
+              >
+                <AlertCircle size={10} className="shrink-0" />
+                {startErrorMsg}
+              </p>
+            )}
+          </div>
 
-          <input
-            id="trim-end"
-            type="number"
-            autoComplete="off"
-            min={0}
-            max={duration > 0 ? duration : undefined}
-            step={0.1}
-            value={recipe.trimEnd ?? ""}
-            spellCheck={false}
-            onChange={(e) => handleEnd(e.target.value)}
-            aria-label="Trim end time in seconds"
-            aria-invalid={invalidEnd}
-            aria-describedby={invalidEnd ? "trim-end-error" : undefined}
-            className={`${inputClass} ${
-              invalidEnd ? "border-[var(--error)]" : "border-[var(--border)]"
-            }`}
-            placeholder={duration > 0 ? `${duration.toFixed(1)}` : "full length"}
-          />
-          {invalidEnd && (
-            <p
-              id="trim-end-error"
-              className="font-heading animate-fade-in mt-1.5 flex items-center gap-1 text-[10px] text-red-500"
+          <div className="flex-1">
+            <label
+              htmlFor="trim-end"
+              className="font-heading mb-1.5 block text-[10px] font-semibold uppercase tracking-wider text-[var(--muted)]"
             >
-              <AlertCircle size={10} className="shrink-0" />
-              {endErrorMsg}
-            </p>
-          )}
+              End (sec)
+            </label>
+
+            <input
+              id="trim-end"
+              type="number"
+              autoComplete="off"
+              min={0}
+              max={duration > 0 ? duration : undefined}
+              step={0.1}
+              value={recipe.trimEnd ?? ""}
+              spellCheck={false}
+              onChange={(e) => handleEnd(e.target.value)}
+              aria-label="Trim end time in seconds"
+              aria-invalid={invalidEnd}
+              aria-describedby={invalidEnd ? "trim-end-error" : undefined}
+              className={`${inputClass} ${
+                invalidEnd ? "border-[var(--error)]" : "border-[var(--border)]"
+              }`}
+              placeholder={duration > 0 ? `${duration.toFixed(1)}` : "full length"}
+            />
+            {invalidEnd && (
+              <p
+                id="trim-end-error"
+                className="font-heading animate-fade-in mt-1.5 flex items-center gap-1 text-[10px] text-red-500"
+              >
+                <AlertCircle size={10} className="shrink-0" />
+                {endErrorMsg}
+              </p>
+            )}
+          </div>
         </div>
-      </div>
+      )}
 
       {duration > 0 && (
         <p className="text-sm text-[var(--muted)] font-heading mt-1">
-          Clip: {formatDuration(clipLength)} of{" "}
-          {formatDuration(duration)}
+          {isMultiSeg ? (
+            <>
+              Output: {formatDuration(clipLength)} from{" "}
+              {segments.length} segment{segments.length > 1 ? "s" : ""} of{" "}
+              {formatDuration(duration)}
+            </>
+          ) : (
+            <>
+              Clip: {formatDuration(clipLength)} of{" "}
+              {formatDuration(duration)}
+            </>
+          )}
         </p>
       )}
-      {recipe.trimEnd !== null &&
+      {!isMultiSeg && recipe.trimEnd !== null &&
         recipe.trimEnd - recipe.trimStart < MIN_CLIP_DURATION && (
           <p className="text-[10px] text-[var(--error)] font-heading">
             Clip must be at least 0.1 seconds long.
@@ -326,5 +597,3 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
     </div>
   );
 }
-
-

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -397,6 +397,7 @@ export default function VideoEditor() {
                       currentTime={currentTime}
                       trimStart={recipe.trimStart ?? 0}
                       trimEnd={recipe.trimEnd ?? duration}
+                      trimSegments={recipe.trimSegments}
                       onSeek={seekTo}
                       intervalSeconds={intervalSeconds}
                     />
@@ -429,6 +430,7 @@ export default function VideoEditor() {
                       onChange={updateRecipe}
                       duration={duration}
                       file={file}
+                      currentTime={currentTime}
                     />
                   </AccordionSection>
 

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -1,12 +1,13 @@
 "use client";
 
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
-import { EditRecipe, ExportResult, ExportStatus, MAX_FILE_SIZE, OverlayPosition, isValidRecipe } from "@/lib/types";
+import { EditRecipe, ExportResult, ExportStatus, MAX_FILE_SIZE, OverlayPosition, isValidRecipe, RECIPE_VERSION } from "@/lib/types";
 import { DEFAULT_RECIPE, SPEED_STEPS } from "@/lib/constants";
 import { getPresetById } from "@/lib/presets";
 import { loadFFmpeg, exportVideo, terminateFFmpeg, FFmpegLoadError } from "@/lib/ffmpeg";
 import { suggestPreset } from "@/lib/presetSuggestion";
 import { validateDimensions, getDownscaledDimensions } from "@/utils/video-validation";
+import { validateSegments, hasMultiSegments } from "@/lib/trim-segments";
 
 const DEFAULT_TITLE = "Reframe — Resize, trim, and export videos in your browser";
   const STORAGE_KEY = "reframe:recipe";
@@ -112,10 +113,16 @@ function validateRecipe(recipe: EditRecipe, duration: number ): string | null {
     ],
   ];
 
-  return (
-    validations.find(([condition]) => condition)?.[1] ??
-    null
-  );
+  const basicError = validations.find(([condition]) => condition)?.[1] ?? null;
+  if (basicError) return basicError;
+
+  // Multi-segment validation
+  if (hasMultiSegments(recipe.trimSegments ?? [])) {
+    const segError = validateSegments(recipe.trimSegments!, duration);
+    if (segError) return segError;
+  }
+
+  return null;
 }
 
 function encodeRecipe(recipe: EditRecipe): string {
@@ -141,6 +148,10 @@ function migrateRecipe(recipe: Partial<EditRecipe>): EditRecipe {
     ...recipe,
     // Ensure textOverlays is always an array
     textOverlays: Array.isArray(recipe.textOverlays) ? recipe.textOverlays : [],
+    // Ensure trimSegments is always an array (v1 recipes don't have it)
+    trimSegments: Array.isArray(recipe.trimSegments) ? recipe.trimSegments : [],
+    // Bump version to current
+    version: RECIPE_VERSION,
   };
 }
 
@@ -250,6 +261,12 @@ export function useVideoEditor() {
               parsedVal = parseFloat(paramVal);
             } else if (defaultType === "boolean") {
               parsedVal = paramVal === "true";
+            } else if (defaultType === "object" && paramVal !== "null") {
+              try {
+                parsedVal = JSON.parse(paramVal);
+              } catch {
+                parsedVal = DEFAULT_RECIPE[key];
+              }
             } else {
               parsedVal = paramVal === "null" ? null : paramVal;
             }
@@ -315,7 +332,11 @@ export function useVideoEditor() {
         const defaultVal = DEFAULT_RECIPE[key];
 
         if (currentVal !== defaultVal) {
-          params.set(key, currentVal === null ? "null" : String(currentVal));
+          if (typeof currentVal === "object" && currentVal !== null) {
+            params.set(key, JSON.stringify(currentVal));
+          } else {
+            params.set(key, currentVal === null ? "null" : String(currentVal));
+          }
         }
       });
 
@@ -437,6 +458,7 @@ export function useVideoEditor() {
           ...prev,
           trimStart: 0,
           trimEnd: null,
+          trimSegments: [],
           ...(shouldApplySuggestion ? { preset: suggestedPreset } : {}),
         };
       });

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -10,6 +10,7 @@ export const DEFAULT_RECIPE: EditRecipe = {
   framing: "fit",
   trimStart: 0,
   trimEnd: null,
+  trimSegments: [],
   rotate: 0,
   keepAudio: true,
   speed: 1,

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -1,6 +1,7 @@
-import { EditRecipe, ExportResult, BackgroundMusicOptions, ImageOverlayOptions } from "./types";
+import { EditRecipe, ExportResult, BackgroundMusicOptions, ImageOverlayOptions, TrimSegment } from "./types";
 import { getPresetById } from "./presets";
 import { buildTextFilter } from "./text-overlay";
+import { hasMultiSegments } from "./trim-segments";
 
 export class FFmpegLoadError extends Error {}
 
@@ -325,10 +326,16 @@ function buildSessionId(): string {
   return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
+/**
+ * Builds video filters for single-trim or no-trim mode.
+ * When multi-segment mode is active, trim is handled by buildMultiSegmentFilterComplex instead.
+ */
 export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number): string {
   const filters: string[] = [];
+  const isMultiSeg = hasMultiSegments(recipe.trimSegments ?? []);
 
-  if (recipe.trimStart > 0 || recipe.trimEnd !== null) {
+  // Skip trim in multi-segment mode — it's handled by the concat pipeline
+  if (!isMultiSeg && (recipe.trimStart > 0 || recipe.trimEnd !== null)) {
     const end = recipe.trimEnd !== null ? recipe.trimEnd : 999999;
     filters.push(`trim=start=${recipe.trimStart}:end=${end}`);
   }
@@ -359,7 +366,7 @@ export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: n
 
   // Normalize timestamps only when needed — trim or speed change both
   // require a clean 0-based timeline to produce correct output duration.
-  if (recipe.trimStart > 0 || recipe.trimEnd !== null || recipe.speed !== 1) {
+  if (!isMultiSeg && (recipe.trimStart > 0 || recipe.trimEnd !== null || recipe.speed !== 1)) {
     filters.push("setpts=PTS-STARTPTS");
   }
 
@@ -417,9 +424,133 @@ export function buildAudioFilter(speed: number, normalizeAudio: boolean): string
 }
 
 function buildAudioTrimFilter(recipe: EditRecipe): string {
+  // Skip in multi-segment mode
+  if (hasMultiSegments(recipe.trimSegments ?? [])) return "";
   if (recipe.trimStart === 0 && recipe.trimEnd === null) return "";
   const end = recipe.trimEnd !== null ? recipe.trimEnd : 999999;
   return `atrim=start=${recipe.trimStart}:end=${end},asetpts=PTS-STARTPTS`;
+}
+
+/**
+ * Builds the post-concat video filter chain.
+ * These filters are applied to the concatenated output stream.
+ */
+function buildPostConcatVideoFilter(recipe: EditRecipe, targetW: number, targetH: number): string {
+  const filters: string[] = [];
+
+  if (recipe.stabilization) filters.push("deshake");
+
+  if (recipe.rotate === 90) filters.push("transpose=1");
+  else if (recipe.rotate === 180) filters.push("transpose=1,transpose=1");
+  else if (recipe.rotate === 270) filters.push("transpose=2");
+
+  if (recipe.framing === "fit") {
+    filters.push(
+      `scale=${targetW}:${targetH}:force_original_aspect_ratio=decrease`,
+      `pad=${targetW}:${targetH}:(ow-iw)/2:(oh-ih)/2:color=black`
+    );
+  } else {
+    filters.push(
+      `scale=${targetW}:${targetH}:force_original_aspect_ratio=increase`,
+      `crop=${targetW}:${targetH}`
+    );
+  }
+
+  if (recipe.speed !== 1) {
+    filters.push("setpts=PTS-STARTPTS");
+    const pts = (1 / recipe.speed).toFixed(4);
+    filters.push(`setpts=${pts}*PTS`);
+  }
+
+  if (recipe.denoise) filters.push("hqdn3d=1.5:1.5:6:6");
+
+  const needsEq = recipe.brightness !== 0 || recipe.contrast !== 1 || recipe.saturation !== 1;
+  if (needsEq) {
+    filters.push(`eq=brightness=${recipe.brightness}:contrast=${recipe.contrast}:saturation=${recipe.saturation}`);
+  }
+
+  const textOverlays = recipe.textOverlays || [];
+  textOverlays.forEach((overlay) => {
+    filters.push(buildTextFilter(overlay, targetW, targetH));
+  });
+
+  return filters.join(",");
+}
+
+/**
+ * Builds a filter_complex string for multi-segment concatenation.
+ *
+ * Strategy:
+ * 1. For each segment, create a trim+setpts chain (video) and atrim+asetpts chain (audio)
+ * 2. Concat all segments together
+ * 3. Apply post-processing (scale, rotate, eq, speed, text) on the concat output
+ *
+ * Example for 2 segments:
+ *   [0:v]trim=0:15,setpts=PTS-STARTPTS[v0];
+ *   [0:v]trim=20:60,setpts=PTS-STARTPTS[v1];
+ *   [0:a]atrim=0:15,asetpts=PTS-STARTPTS[a0];
+ *   [0:a]atrim=20:60,asetpts=PTS-STARTPTS[a1];
+ *   [v0][a0][v1][a1]concat=n=2:v=1:a=1[vcombined][acombined];
+ *   [vcombined]scale=...,setpts=...[vout]
+ */
+export function buildMultiSegmentFilterComplex(
+  recipe: EditRecipe,
+  segments: TrimSegment[],
+  targetW: number,
+  targetH: number,
+  includeAudio: boolean
+): { filterComplex: string; videoOut: string; audioOut: string } {
+  const sorted = [...segments].sort((a, b) => a.start - b.start);
+  const n = sorted.length;
+  const parts: string[] = [];
+
+  // Step 1: Per-segment trim chains
+  for (let i = 0; i < sorted.length; i++) {
+    const seg = sorted[i];
+    if (!seg) continue;
+    parts.push(`[0:v]trim=start=${seg.start}:end=${seg.end},setpts=PTS-STARTPTS[v${i}]`);
+    if (includeAudio) {
+      parts.push(`[0:a]atrim=start=${seg.start}:end=${seg.end},asetpts=PTS-STARTPTS[a${i}]`);
+    }
+  }
+
+  // Step 2: Concat
+  let concatInputs = "";
+  for (let i = 0; i < n; i++) {
+    concatInputs += `[v${i}]`;
+    if (includeAudio) concatInputs += `[a${i}]`;
+  }
+
+  const audioStreams = includeAudio ? 1 : 0;
+  if (includeAudio) {
+    parts.push(`${concatInputs}concat=n=${n}:v=1:a=${audioStreams}[vcombined][acombined]`);
+  } else {
+    parts.push(`${concatInputs}concat=n=${n}:v=1:a=0[vcombined]`);
+  }
+
+  // Step 3: Post-processing on the concat output
+  const postFilters = buildPostConcatVideoFilter(recipe, targetW, targetH);
+  let videoOut = "[vcombined]";
+  if (postFilters) {
+    parts.push(`[vcombined]${postFilters}[vout]`);
+    videoOut = "[vout]";
+  }
+
+  // Audio post-processing (speed)
+  let audioOut = includeAudio ? "[acombined]" : "";
+  if (includeAudio) {
+    const audioSpeed = buildAudioFilter(recipe.speed, recipe.normalizeAudio ?? false);
+    if (audioSpeed) {
+      parts.push(`[acombined]${audioSpeed}[aout]`);
+      audioOut = "[aout]";
+    }
+  }
+
+  return {
+    filterComplex: parts.join(";"),
+    videoOut,
+    audioOut,
+  };
 }
 
 function buildArguments(
@@ -438,14 +569,7 @@ function buildArguments(
   hasOriginalAudio: boolean,
   videoDuration: number
 ): string[] {
-  const vf = buildVideoFilter(recipe, targetW, targetH);
-  const audioTrim = hasOriginalAudio ? buildAudioTrimFilter(recipe) : "";
-  const audioSpeed = hasOriginalAudio ? buildAudioFilter(recipe.speed, recipe.normalizeAudio ?? false) : "";
-  const afParts = [audioTrim, audioSpeed].filter(Boolean);
-  const af = afParts.join(",");
-
-  const musicIdx = 1;
-  const overlayIdx = hasMusicTrack ? 2 : 1;
+  const isMultiSeg = hasMultiSegments(recipe.trimSegments ?? []);
 
   const args: string[] = [];
   args.push("-i", inputName);
@@ -457,17 +581,47 @@ function buildArguments(
     args.push("-i", overlayInputName);
   }
 
-  const needsFilterComplex = hasOverlay || hasMusicTrack;
   const shouldKeepAudio = recipe.keepAudio && (hasOriginalAudio || hasMusicTrack);
 
-  if (needsFilterComplex) {
-    const filterParts: string[] = [];
-    let videoOut = "[0:v]";
+  // ── Multi-segment concat path ──
+  if (isMultiSeg) {
+    const segments = recipe.trimSegments!;
+    const multiSeg = buildMultiSegmentFilterComplex(
+      recipe,
+      segments,
+      targetW,
+      targetH,
+      shouldKeepAudio && hasOriginalAudio
+    );
 
-    if (vf) {
-      filterParts.push(`[0:v]${vf}[vbase]`);
-      videoOut = "[vbase]";
+    args.push("-filter_complex", multiSeg.filterComplex);
+    args.push("-map", multiSeg.videoOut);
+
+    if (!shouldKeepAudio) {
+      args.push("-an");
+    } else if (multiSeg.audioOut) {
+      args.push("-map", multiSeg.audioOut);
     }
+  } else {
+    // ── Original single-trim path (unchanged) ──
+    const vf = buildVideoFilter(recipe, targetW, targetH);
+    const audioTrim = hasOriginalAudio ? buildAudioTrimFilter(recipe) : "";
+    const audioSpeed = hasOriginalAudio ? buildAudioFilter(recipe.speed, recipe.normalizeAudio ?? false) : "";
+    const afParts = [audioTrim, audioSpeed].filter(Boolean);
+    const af = afParts.join(",");
+
+    const musicIdx = 1;
+    const overlayIdx = hasMusicTrack ? 2 : 1;
+    const needsFilterComplex = hasOverlay || hasMusicTrack;
+
+    if (needsFilterComplex) {
+      const filterParts: string[] = [];
+      let videoOut = "[0:v]";
+
+      if (vf) {
+        filterParts.push(`[0:v]${vf}[vbase]`);
+        videoOut = "[vbase]";
+      }
 
 if (hasOverlay) {
   const scaledW = overlayOptions!.size;
@@ -495,47 +649,48 @@ interface PositionCoords {
   videoOut = "[vout]";
 }
 
-    let audioOut = "";
-    if (shouldKeepAudio) {
-      if (hasMusicTrack) {
-        const musicVol = (musicOptions!.musicVolume / 100).toFixed(2);
-        if (hasOriginalAudio) {
-          const origVol  = (musicOptions!.originalAudioVolume / 100).toFixed(2);
-          const origChain = afParts.length > 0
-            ? `[0:a]${afParts.join(",")},volume=${origVol}[orig]`
-            : `[0:a]volume=${origVol}[orig]`;
-          filterParts.push(origChain);
-          filterParts.push(`[${musicIdx}:a]volume=${musicVol}[music]`);
-          filterParts.push(`[orig][music]amix=inputs=2:duration=first:dropout_transition=0[aout]`);
-          audioOut = "[aout]";
-        } else {
-          filterParts.push(`[${musicIdx}:a]volume=${musicVol}[aout]`);
+      let audioOut = "";
+      if (shouldKeepAudio) {
+        if (hasMusicTrack) {
+          const musicVol = (musicOptions!.musicVolume / 100).toFixed(2);
+          if (hasOriginalAudio) {
+            const origVol  = (musicOptions!.originalAudioVolume / 100).toFixed(2);
+            const origChain = afParts.length > 0
+              ? `[0:a]${afParts.join(",")},volume=${origVol}[orig]`
+              : `[0:a]volume=${origVol}[orig]`;
+            filterParts.push(origChain);
+            filterParts.push(`[${musicIdx}:a]volume=${musicVol}[music]`);
+            filterParts.push(`[orig][music]amix=inputs=2:duration=first:dropout_transition=0[aout]`);
+            audioOut = "[aout]";
+          } else {
+            filterParts.push(`[${musicIdx}:a]volume=${musicVol}[aout]`);
+            audioOut = "[aout]";
+          }
+        } else if (hasOriginalAudio && af) {
+          filterParts.push(`[0:a]${af}[aout]`);
           audioOut = "[aout]";
         }
-      } else if (hasOriginalAudio && af) {
-        filterParts.push(`[0:a]${af}[aout]`);
-        audioOut = "[aout]";
       }
-    }
 
-    if (filterParts.length > 0) {
-      args.push("-filter_complex", filterParts.join(";"));
-    }
-    args.push("-map", videoOut === "[0:v]" ? "0:v" : videoOut);
+      if (filterParts.length > 0) {
+        args.push("-filter_complex", filterParts.join(";"));
+      }
+      args.push("-map", videoOut === "[0:v]" ? "0:v" : videoOut);
 
-    if (!shouldKeepAudio) {
-      args.push("-an");
-    } else if (audioOut) {
-      args.push("-map", audioOut);
-    } else if (hasOriginalAudio) {
-      args.push("-map", "0:a");
-    }
-  } else {
-    if (vf) args.push("-vf", vf);
-    if (!shouldKeepAudio) {
-      args.push("-an");
-    } else if (af && hasOriginalAudio) {
-      args.push("-af", af);
+      if (!shouldKeepAudio) {
+        args.push("-an");
+      } else if (audioOut) {
+        args.push("-map", audioOut);
+      } else if (hasOriginalAudio) {
+        args.push("-map", "0:a");
+      }
+    } else {
+      if (vf) args.push("-vf", vf);
+      if (!shouldKeepAudio) {
+        args.push("-an");
+      } else if (af && hasOriginalAudio) {
+        args.push("-af", af);
+      }
     }
   }
 
@@ -559,7 +714,12 @@ interface PositionCoords {
   // Add explicit output duration when speed != 1 to prevent slight duration
   // overshoot caused by encoder/filter pipeline frame flush at stream end.
   if (recipe.speed !== 1) {
-    const sourceDuration = (recipe.trimEnd ?? videoDuration) - recipe.trimStart;
+    let sourceDuration: number;
+    if (isMultiSeg) {
+      sourceDuration = recipe.trimSegments!.reduce((sum, seg) => sum + (seg.end - seg.start), 0);
+    } else {
+      sourceDuration = (recipe.trimEnd ?? videoDuration) - recipe.trimStart;
+    }
     const outputDuration = sourceDuration / recipe.speed;
     args.push("-t", outputDuration.toFixed(6));
   }

--- a/src/lib/ffmpeg.worker.ts
+++ b/src/lib/ffmpeg.worker.ts
@@ -1,8 +1,7 @@
-import { FFmpeg } from "@ffmpeg/ffmpeg";
-import { toBlobURL } from "@ffmpeg/util";
-import { EditRecipe, BackgroundMusicOptions, ImageOverlayOptions } from "./types";
+import { EditRecipe, BackgroundMusicOptions, ImageOverlayOptions, TrimSegment } from "./types";
 import { getPresetById } from "./presets";
 import { buildTextFilter } from "./text-overlay";
+import { hasMultiSegments } from "./trim-segments";
 
 const CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd";
 const MT_CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core-mt@0.12.6/dist/esm";
@@ -79,10 +78,14 @@ async function fetchWithIntegrity(url: string, mimeType: string): Promise<string
   return URL.createObjectURL(blob);
 }
 
+import { FFmpeg } from "@ffmpeg/ffmpeg";
+import { toBlobURL } from "@ffmpeg/util";
+
 function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number): string {
   const filters: string[] = [];
+  const isMultiSeg = hasMultiSegments(recipe.trimSegments ?? []);
 
-  if (recipe.trimStart > 0 || recipe.trimEnd !== null) {
+  if (!isMultiSeg && (recipe.trimStart > 0 || recipe.trimEnd !== null)) {
     const end = recipe.trimEnd !== null ? recipe.trimEnd : 999999;
     filters.push(`trim=start=${recipe.trimStart}:end=${end}`);
   }
@@ -111,7 +114,7 @@ function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number):
     );
   }
 
-  if (recipe.trimStart > 0 || recipe.trimEnd !== null || recipe.speed !== 1) {
+  if (!isMultiSeg && (recipe.trimStart > 0 || recipe.trimEnd !== null || recipe.speed !== 1)) {
     filters.push("setpts=PTS-STARTPTS");
   }
 
@@ -168,9 +171,103 @@ function buildAudioFilter(speed: number, normalizeAudio: boolean): string {
 }
 
 function buildAudioTrimFilter(recipe: EditRecipe): string {
+  if (hasMultiSegments(recipe.trimSegments ?? [])) return "";
   if (recipe.trimStart === 0 && recipe.trimEnd === null) return "";
   const end = recipe.trimEnd !== null ? recipe.trimEnd : 999999;
   return `atrim=start=${recipe.trimStart}:end=${end},asetpts=PTS-STARTPTS`;
+}
+
+function buildPostConcatVideoFilter(recipe: EditRecipe, targetW: number, targetH: number): string {
+  const filters: string[] = [];
+
+  if (recipe.stabilization) filters.push("deshake");
+  if (recipe.rotate === 90) filters.push("transpose=1");
+  else if (recipe.rotate === 180) filters.push("transpose=1,transpose=1");
+  else if (recipe.rotate === 270) filters.push("transpose=2");
+
+  if (recipe.framing === "fit") {
+    filters.push(
+      `scale=${targetW}:${targetH}:force_original_aspect_ratio=decrease`,
+      `pad=${targetW}:${targetH}:(ow-iw)/2:(oh-ih)/2:color=black`
+    );
+  } else {
+    filters.push(
+      `scale=${targetW}:${targetH}:force_original_aspect_ratio=increase`,
+      `crop=${targetW}:${targetH}`
+    );
+  }
+
+  if (recipe.speed !== 1) {
+    filters.push("setpts=PTS-STARTPTS");
+    const pts = (1 / recipe.speed).toFixed(4);
+    filters.push(`setpts=${pts}*PTS`);
+  }
+
+  if (recipe.denoise) filters.push("hqdn3d=1.5:1.5:6:6");
+
+  const needsEq = recipe.brightness !== 0 || recipe.contrast !== 1 || recipe.saturation !== 1;
+  if (needsEq) {
+    filters.push(`eq=brightness=${recipe.brightness}:contrast=${recipe.contrast}:saturation=${recipe.saturation}`);
+  }
+
+  const textOverlays = recipe.textOverlays || [];
+  textOverlays.forEach((overlay) => {
+    filters.push(buildTextFilter(overlay, targetW, targetH));
+  });
+
+  return filters.join(",");
+}
+
+function buildMultiSegmentFilterComplex(
+  recipe: EditRecipe,
+  segments: TrimSegment[],
+  targetW: number,
+  targetH: number,
+  includeAudio: boolean
+): { filterComplex: string; videoOut: string; audioOut: string } {
+  const sorted = [...segments].sort((a, b) => a.start - b.start);
+  const n = sorted.length;
+  const parts: string[] = [];
+
+  for (let i = 0; i < sorted.length; i++) {
+    const seg = sorted[i];
+    if (!seg) continue;
+    parts.push(`[0:v]trim=start=${seg.start}:end=${seg.end},setpts=PTS-STARTPTS[v${i}]`);
+    if (includeAudio) {
+      parts.push(`[0:a]atrim=start=${seg.start}:end=${seg.end},asetpts=PTS-STARTPTS[a${i}]`);
+    }
+  }
+
+  let concatInputs = "";
+  for (let i = 0; i < n; i++) {
+    concatInputs += `[v${i}]`;
+    if (includeAudio) concatInputs += `[a${i}]`;
+  }
+
+  const audioStreams = includeAudio ? 1 : 0;
+  if (includeAudio) {
+    parts.push(`${concatInputs}concat=n=${n}:v=1:a=${audioStreams}[vcombined][acombined]`);
+  } else {
+    parts.push(`${concatInputs}concat=n=${n}:v=1:a=0[vcombined]`);
+  }
+
+  const postFilters = buildPostConcatVideoFilter(recipe, targetW, targetH);
+  let videoOut = "[vcombined]";
+  if (postFilters) {
+    parts.push(`[vcombined]${postFilters}[vout]`);
+    videoOut = "[vout]";
+  }
+
+  let audioOut = includeAudio ? "[acombined]" : "";
+  if (includeAudio) {
+    const audioSpeed = buildAudioFilter(recipe.speed, recipe.normalizeAudio ?? false);
+    if (audioSpeed) {
+      parts.push(`[acombined]${audioSpeed}[aout]`);
+      audioOut = "[aout]";
+    }
+  }
+
+  return { filterComplex: parts.join(";"), videoOut, audioOut };
 }
 
 function buildArguments(
@@ -189,14 +286,7 @@ function buildArguments(
   hasOriginalAudio: boolean,
   videoDuration: number
 ): string[] {
-  const vf = buildVideoFilter(recipe, targetW, targetH);
-  const audioTrim = hasOriginalAudio ? buildAudioTrimFilter(recipe) : "";
-  const audioSpeed = hasOriginalAudio ? buildAudioFilter(recipe.speed, recipe.normalizeAudio ?? false) : "";
-  const afParts = [audioTrim, audioSpeed].filter(Boolean);
-  const af = afParts.join(",");
-
-  const musicIdx = 1;
-  const overlayIdx = hasMusicTrack ? 2 : 1;
+  const isMultiSeg = hasMultiSegments(recipe.trimSegments ?? []);
 
   const args: string[] = [];
   args.push("-i", inputName);
@@ -208,17 +298,45 @@ function buildArguments(
     args.push("-i", overlayInputName);
   }
 
-  const needsFilterComplex = hasOverlay || hasMusicTrack;
   const shouldKeepAudio = recipe.keepAudio && (hasOriginalAudio || hasMusicTrack);
 
-  if (needsFilterComplex) {
-    const filterParts: string[] = [];
-    let videoOut = "[0:v]";
+  if (isMultiSeg) {
+    const segments = recipe.trimSegments!;
+    const multiSeg = buildMultiSegmentFilterComplex(
+      recipe,
+      segments,
+      targetW,
+      targetH,
+      shouldKeepAudio && hasOriginalAudio
+    );
 
-    if (vf) {
-      filterParts.push(`[0:v]${vf}[vbase]`);
-      videoOut = "[vbase]";
+    args.push("-filter_complex", multiSeg.filterComplex);
+    args.push("-map", multiSeg.videoOut);
+
+    if (!shouldKeepAudio) {
+      args.push("-an");
+    } else if (multiSeg.audioOut) {
+      args.push("-map", multiSeg.audioOut);
     }
+  } else {
+    const vf = buildVideoFilter(recipe, targetW, targetH);
+    const audioTrim = hasOriginalAudio ? buildAudioTrimFilter(recipe) : "";
+    const audioSpeed = hasOriginalAudio ? buildAudioFilter(recipe.speed, recipe.normalizeAudio ?? false) : "";
+    const afParts = [audioTrim, audioSpeed].filter(Boolean);
+    const af = afParts.join(",");
+
+    const musicIdx = 1;
+    const overlayIdx = hasMusicTrack ? 2 : 1;
+    const needsFilterComplex = hasOverlay || hasMusicTrack;
+
+    if (needsFilterComplex) {
+      const filterParts: string[] = [];
+      let videoOut = "[0:v]";
+
+      if (vf) {
+        filterParts.push(`[0:v]${vf}[vbase]`);
+        videoOut = "[vbase]";
+      }
 
 if (hasOverlay) {
   const scaledW = overlayOptions!.size;
@@ -246,47 +364,48 @@ interface PositionCoords {
   videoOut = "[vout]";
 }
 
-    let audioOut = "";
-    if (shouldKeepAudio) {
-      if (hasMusicTrack) {
-        const musicVol = (musicOptions!.musicVolume / 100).toFixed(2);
-        if (hasOriginalAudio) {
-          const origVol = (musicOptions!.originalAudioVolume / 100).toFixed(2);
-          const origChain = afParts.length > 0
-            ? `[0:a]${afParts.join(",")},volume=${origVol}[orig]`
-            : `[0:a]volume=${origVol}[orig]`;
-          filterParts.push(origChain);
-          filterParts.push(`[${musicIdx}:a]volume=${musicVol}[music]`);
-          filterParts.push(`[orig][music]amix=inputs=2:duration=first:dropout_transition=0[aout]`);
-          audioOut = "[aout]";
-        } else {
-          filterParts.push(`[${musicIdx}:a]volume=${musicVol}[aout]`);
+      let audioOut = "";
+      if (shouldKeepAudio) {
+        if (hasMusicTrack) {
+          const musicVol = (musicOptions!.musicVolume / 100).toFixed(2);
+          if (hasOriginalAudio) {
+            const origVol = (musicOptions!.originalAudioVolume / 100).toFixed(2);
+            const origChain = afParts.length > 0
+              ? `[0:a]${afParts.join(",")},volume=${origVol}[orig]`
+              : `[0:a]volume=${origVol}[orig]`;
+            filterParts.push(origChain);
+            filterParts.push(`[${musicIdx}:a]volume=${musicVol}[music]`);
+            filterParts.push(`[orig][music]amix=inputs=2:duration=first:dropout_transition=0[aout]`);
+            audioOut = "[aout]";
+          } else {
+            filterParts.push(`[${musicIdx}:a]volume=${musicVol}[aout]`);
+            audioOut = "[aout]";
+          }
+        } else if (hasOriginalAudio && af) {
+          filterParts.push(`[0:a]${af}[aout]`);
           audioOut = "[aout]";
         }
-      } else if (hasOriginalAudio && af) {
-        filterParts.push(`[0:a]${af}[aout]`);
-        audioOut = "[aout]";
       }
-    }
 
-    if (filterParts.length > 0) {
-      args.push("-filter_complex", filterParts.join(";"));
-    }
-    args.push("-map", videoOut === "[0:v]" ? "0:v" : videoOut);
+      if (filterParts.length > 0) {
+        args.push("-filter_complex", filterParts.join(";"));
+      }
+      args.push("-map", videoOut === "[0:v]" ? "0:v" : videoOut);
 
-    if (!shouldKeepAudio) {
-      args.push("-an");
-    } else if (audioOut) {
-      args.push("-map", audioOut);
-    } else if (hasOriginalAudio) {
-      args.push("-map", "0:a");
-    }
-  } else {
-    if (vf) args.push("-vf", vf);
-    if (!shouldKeepAudio) {
-      args.push("-an");
-    } else if (af && hasOriginalAudio) {
-      args.push("-af", af);
+      if (!shouldKeepAudio) {
+        args.push("-an");
+      } else if (audioOut) {
+        args.push("-map", audioOut);
+      } else if (hasOriginalAudio) {
+        args.push("-map", "0:a");
+      }
+    } else {
+      if (vf) args.push("-vf", vf);
+      if (!shouldKeepAudio) {
+        args.push("-an");
+      } else if (af && hasOriginalAudio) {
+        args.push("-af", af);
+      }
     }
   }
 
@@ -308,7 +427,12 @@ interface PositionCoords {
   }
 
   if (recipe.speed !== 1) {
-    const sourceDuration = (recipe.trimEnd ?? videoDuration) - recipe.trimStart;
+    let sourceDuration: number;
+    if (isMultiSeg) {
+      sourceDuration = recipe.trimSegments!.reduce((sum, seg) => sum + (seg.end - seg.start), 0);
+    } else {
+      sourceDuration = (recipe.trimEnd ?? videoDuration) - recipe.trimStart;
+    }
     const outputDuration = sourceDuration / recipe.speed;
     args.push("-t", outputDuration.toFixed(6));
   }

--- a/src/lib/trim-segments.ts
+++ b/src/lib/trim-segments.ts
@@ -1,0 +1,228 @@
+import type { TrimSegment } from "./types";
+
+let segIdCounter = 0;
+
+/**
+ * Generates a unique ID for a trim segment.
+ */
+export function generateSegmentId(): string {
+  segIdCounter += 1;
+  return `seg_${Date.now()}_${segIdCounter}`;
+}
+
+/**
+ * Determines whether the recipe is using multi-segment trimming.
+ * Returns true when there is at least 1 segment, meaning the advanced UI is active.
+ */
+export function hasMultiSegments(segments: TrimSegment[]): boolean {
+  return segments.length > 0;
+}
+
+/**
+ * Converts a list of "keep" segments into a list of "cut" regions.
+ * Useful for rendering the dimmed/removed zones on the timeline.
+ */
+export function getCutRegions(
+  segments: TrimSegment[],
+  duration: number
+): { start: number; end: number }[] {
+  if (segments.length === 0) return [];
+
+  const sorted = [...segments].sort((a, b) => a.start - b.start);
+  const cuts: { start: number; end: number }[] = [];
+
+  // Gap before first segment
+  const first = sorted[0];
+  if (first && first.start > 0) {
+    cuts.push({ start: 0, end: first.start });
+  }
+
+  // Gaps between segments
+  for (let i = 0; i < sorted.length - 1; i++) {
+    const currentSeg = sorted[i];
+    const nextSeg = sorted[i + 1];
+    if (!currentSeg || !nextSeg) continue;
+    const gapStart = currentSeg.end;
+    const gapEnd = nextSeg.start;
+    if (gapEnd > gapStart) {
+      cuts.push({ start: gapStart, end: gapEnd });
+    }
+  }
+
+  // Gap after last segment
+  const last = sorted.at(-1);
+  if (last && last.end < duration) {
+    cuts.push({ start: last.end, end: duration });
+  }
+
+  return cuts;
+}
+
+/**
+ * Builds the initial segments array from legacy trimStart/trimEnd values.
+ * Called when upgrading a v1 recipe to v2.
+ */
+export function segmentsFromLegacyTrim(
+  trimStart: number,
+  trimEnd: number | null,
+  duration: number
+): TrimSegment[] {
+  const start = Math.max(0, trimStart);
+  const end = trimEnd === null ? duration : Math.min(trimEnd, duration);
+  if (end <= start) return [];
+  return [{ id: generateSegmentId(), start, end }];
+}
+
+/**
+ * Adds a split point at a given time, dividing a segment into two.
+ * Returns a new segments array without mutating the original.
+ */
+export function addSplitPoint(
+  segments: TrimSegment[],
+  splitTime: number
+): TrimSegment[] {
+  const sorted = [...segments].sort((a, b) => a.start - b.start);
+
+  for (let i = 0; i < sorted.length; i++) {
+    const seg = sorted[i];
+    if (!seg) continue;
+    // Reject if either resulting segment would be shorter than the minimum duration
+    const minDuration = 0.1;
+    if (splitTime > seg.start + minDuration && splitTime < seg.end - minDuration) {
+      const left: TrimSegment = {
+        id: seg.id,
+        start: seg.start,
+        end: splitTime,
+      };
+      const right: TrimSegment = {
+        id: generateSegmentId(),
+        start: splitTime,
+        end: seg.end,
+      };
+      const newSegments = [...sorted];
+      newSegments.splice(i, 1, left, right);
+      return newSegments;
+    }
+  }
+
+  return sorted;
+}
+
+/**
+ * Merges a segment with the next adjacent segment, effectively removing the split point.
+ */
+export function mergeWithNextSegment(
+  segments: TrimSegment[],
+  segId: string
+): TrimSegment[] {
+  const sorted = [...segments].sort((a, b) => a.start - b.start);
+  const idx = sorted.findIndex(s => s.id === segId);
+  if (idx === -1 || idx === sorted.length - 1) return segments; // Cannot merge last segment
+
+  const left = sorted[idx];
+  const right = sorted[idx + 1];
+  
+  if (!left || !right) return segments;
+
+  const merged: TrimSegment = {
+    id: left.id,
+    start: left.start,
+    end: right.end
+  };
+
+  const newSegments = [...sorted];
+  newSegments.splice(idx, 2, merged);
+  return newSegments;
+}
+
+/**
+ * Removes a segment by ID and returns the updated array.
+ * The gap left by the removed segment becomes a "cut" zone.
+ */
+export function removeSegment(
+  segments: TrimSegment[],
+  segmentId: string
+): TrimSegment[] {
+  if (segments.length <= 1) return segments; // Must keep at least one segment
+  return segments.filter((s) => s.id !== segmentId);
+}
+
+/**
+ * Updates a segment's start or end time, clamping to valid bounds.
+ * Prevents overlapping with adjacent segments.
+ */
+export function updateSegmentBound(
+  segments: TrimSegment[],
+  segmentId: string,
+  field: "start" | "end",
+  value: number,
+  duration: number
+): TrimSegment[] {
+  const sorted = [...segments].sort((a, b) => a.start - b.start);
+  const idx = sorted.findIndex((s) => s.id === segmentId);
+  if (idx === -1) return sorted;
+
+  const originalSeg = sorted[idx];
+  if (!originalSeg) return sorted;
+
+  const seg: TrimSegment = { ...originalSeg };
+  const minDuration = 0.1;
+
+  if (field === "start") {
+    const prevSeg = sorted[idx - 1];
+    const lowerBound = (idx > 0 && prevSeg) ? prevSeg.end : 0;
+    seg.start = Math.max(lowerBound, Math.min(value, seg.end - minDuration));
+  } else {
+    const nextSeg = sorted[idx + 1];
+    const upperBound = (idx < sorted.length - 1 && nextSeg) ? nextSeg.start : duration;
+    seg.end = Math.min(upperBound, Math.max(value, seg.start + minDuration));
+  }
+
+  const result = [...sorted];
+  result[idx] = seg;
+  return result;
+}
+
+/**
+ * Calculates the total output duration from all kept segments.
+ */
+export function totalSegmentsDuration(segments: TrimSegment[]): number {
+  return segments.reduce((sum, seg) => sum + (seg.end - seg.start), 0);
+}
+
+/**
+ * Validates that segments are well-formed for export.
+ * Returns null if valid, or an error message string.
+ */
+export function validateSegments(
+  segments: TrimSegment[],
+  duration: number
+): string | null {
+  if (segments.length === 0) {
+    return "At least one segment must be kept.";
+  }
+
+  for (const seg of segments) {
+    if (seg.start < 0) {
+      return "Segment start time cannot be negative.";
+    }
+    if (seg.end > duration + 0.01) {
+      return `Segment end time cannot exceed the video duration (${Math.floor(duration)}s).`;
+    }
+  }
+
+  const sorted = [...segments].sort((a, b) => a.start - b.start);
+  for (let i = 0; i < sorted.length - 1; i++) {
+    const current = sorted[i];
+    const next = sorted[i + 1];
+    if (current && next && current.end > next.start) {
+      return "Segments must not overlap.";
+    }
+  }
+
+  if (totalSegmentsDuration(segments) <= 0) {
+    return "Total output duration must be greater than 0.";
+  }
+
+  return null;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,14 @@
-export const RECIPE_VERSION = 1;
+export const RECIPE_VERSION = 2;
+
+/**
+ * A single "keep" segment for multi-segment trimming.
+ * Each segment defines a continuous time range to preserve in the output.
+ */
+export interface TrimSegment {
+  id: string;
+  start: number; // Start time in seconds
+  end: number;   // End time in seconds
+}
 
 /**
  * Text overlay data structure for rendering custom text on videos.
@@ -22,6 +32,7 @@ export interface EditRecipe {
   framing: "fit" | "fill";
   trimStart: number;
   trimEnd: number | null;
+  trimSegments: TrimSegment[];
   rotate: 0 | 90 | 180 | 270;
   keepAudio: boolean;
   normalizeAudio: boolean;
@@ -81,17 +92,39 @@ export const MAX_FILE_SIZE =
 export const WARNING_FILE_SIZE =
   500 * 1024 * 1024; // 500MB
 
+/**
+ * Validates that trimSegments are well-formed:
+ * - Each segment has valid id, start, end
+ * - start < end
+ * - Segments are sorted and non-overlapping
+ */
+function isValidTrimSegments(segments: unknown): segments is TrimSegment[] {
+  if (!Array.isArray(segments)) return false;
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    if (!seg || typeof seg !== "object") return false;
+    if (typeof seg.id !== "string") return false;
+    if (typeof seg.start !== "number" || !isFinite(seg.start) || seg.start < 0) return false;
+    if (typeof seg.end !== "number" || !isFinite(seg.end)) return false;
+    if (seg.start >= seg.end) return false;
+    if (i > 0 && seg.start < segments[i - 1].end) return false;
+  }
+  return true;
+}
+
 export function isValidRecipe(value: unknown): value is EditRecipe {
   if (!value || typeof value !== "object") return false;
   const v = value as any;
 
-  if (typeof v.version !== "number" || v.version !== RECIPE_VERSION) return false;
+  // Accept both v1 and v2 recipes
+  if (typeof v.version !== "number" || (v.version !== RECIPE_VERSION && v.version !== 1)) return false;
   if (typeof v.preset !== "string") return false;
   if (typeof v.customWidth !== "number" || !isFinite(v.customWidth)) return false;
   if (typeof v.customHeight !== "number" || !isFinite(v.customHeight)) return false;
   if (v.framing !== "fit" && v.framing !== "fill") return false;
   if (typeof v.trimStart !== "number" || !isFinite(v.trimStart)) return false;
   if (!(v.trimEnd === null || (typeof v.trimEnd === "number" && isFinite(v.trimEnd)))) return false;
+  if (v.trimSegments !== undefined && !isValidTrimSegments(v.trimSegments)) return false;
   if (![0, 90, 180, 270].includes(v.rotate)) return false;
   if (typeof v.keepAudio !== "boolean") return false;
   if (typeof v.normalizeAudio !== "boolean") return false;


### PR DESCRIPTION
## Commit messages
- Add TrimSegment data model and trim-segments.ts utility library
- Implement multi-cut UI with visual timeline, segment list, and controls
- Support click-to-split at any point on the timeline
- Support drag-to-adjust segment boundaries with min-duration clamping
- Support double-click on split handles to merge/remove splits
- Add hover-to-delete trash icon on timeline segments
- Wire up FFmpeg filter_complex for multi-segment trim + concatenation
- Playhead-aware splitting via Add Split button
- Prevent accidental splits from drag release events
- Full backward compatibility with legacy single-trim mode
## Description

This PR implements **Multi-Segment Trimming** — the ability for users to cut out unwanted sections from the middle of a video and seamlessly join the remaining portions. Previously, Reframe only supported trimming from the start or end of a video. With this feature, users can now make unlimited cuts anywhere in the timeline.

### What was built

**Core Library — `trim-segments.ts`**
- New `TrimSegment` data model (`{ id, start, end }`) added to the type system
- Pure utility functions: `addSplitPoint`, `removeSegment`, `updateSegmentBound`, `mergeWithNextSegment`, `getCutRegions`, `validateSegments`, `totalSegmentsDuration`
- All functions are immutable — they return new arrays without mutating state

**Multi-Cut UI — `TrimControl.tsx`**
- Toggle button to enter/exit multi-cut mode
- Interactive visual timeline showing kept segments (blue) and cut zones (red-striped)
- **Click the timeline** to place a split point exactly where you want it
- **Drag the blue handles** to adjust segment boundaries with min-duration clamping (0.1s)
- **Double-click a handle** to remove the split and merge segments back together
- **Hover a segment** on the timeline to reveal a trash icon for quick deletion
- Numbered segment list with start/end times, durations, and delete buttons
- "+ ADD SPLIT" button that splits at the current video playhead position

**FFmpeg Engine — `useVideoEditor.ts`**
- Generates an optimized `filter_complex` command that trims each segment individually and concatenates them with proper audio sync
- Falls back to the legacy single-trim path when multi-cut is disabled

**Bug Fixes & Polish**
- Prevented accidental splits caused by `click` events firing after drag releases (via `wasDragging` ref)
- Segments physically cannot go below 0.1s duration — the UI clamps instead of showing errors
- Full backward compatibility with existing single-trim workflows

## Related Issue
Closes #1221

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: shyam-medh
- Contribution level (Beginner/Intermediate/Advanced): Advanced

## Screen Recording
**Recording / Loom link:** https://www.loom.com/share/d2ed0602b3d34a908e8e103c49b7ab75

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [X] **Screen recording attached above** (required for UI/feature/design changes)
