### PR TITLE
fix: enforce -t flag on export to prevent infinite loop with backgrou…

### DIFF
--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -556,13 +556,12 @@ interface PositionCoords {
     if (shouldKeepAudio) args.push("-c:a", "aac", "-b:a", "128k");
   }
 
-  // Add explicit output duration when speed != 1 to prevent slight duration
-  // overshoot caused by encoder/filter pipeline frame flush at stream end.
-  if (recipe.speed !== 1) {
-    const sourceDuration = (recipe.trimEnd ?? videoDuration) - recipe.trimStart;
-    const outputDuration = sourceDuration / recipe.speed;
-    args.push("-t", outputDuration.toFixed(6));
-  }
+  // Add explicit output duration to prevent slight duration overshoot
+  // caused by encoder/filter pipeline frame flush at stream end,
+  // and to prevent infinite loops when adding looped audio to silent videos.
+  const sourceDuration = (recipe.trimEnd ?? videoDuration) - recipe.trimStart;
+  const outputDuration = sourceDuration / recipe.speed;
+  args.push("-t", outputDuration.toFixed(6));
 
   args.push(outputName);
   return args;


### PR DESCRIPTION
## Description
Fixes an issue where adding a looped background music track to a silent video at 1x speed causes FFmpeg to export indefinitely. 

By enforcing the `-t` duration flag on all exports (rather than just those where speed != 1), FFmpeg is strictly told exactly when to stop encoding, preventing infinite loops caused by `-stream_loop -1` combined with no native audio track.

## Related Issue
Fixes #1577

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] Screen recording attached above