### PR TITLE
fix: abort ffmpeg asset downloads on cancel

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import { useTheme } from "./ThemeProvider";
-import { useEffect, useState } from "react";
 
 export function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
@@ -27,7 +26,6 @@ export function ThemeToggle() {
   }
 
   const isDark = theme === "dark";
-  const [mounted, setMounted] = useState(false);
 
   return (
     <button

--- a/src/lib/ffmpeg.worker.ts
+++ b/src/lib/ffmpeg.worker.ts
@@ -61,20 +61,25 @@ type WorkerResponse = ProgressPayload | ReadyPayload | ResultPayload | ErrorPayl
 let ffmpeg: FFmpeg | null = null;
 let ffmpegLoaded = false;
 let activeExportAbortController: AbortController | null = null;
+let activeLoadAbortController: AbortController | null = null;
 let activeExportId: string | null = null;
 
-async function fetchWithIntegrity(url: string, mimeType: string): Promise<string> {
+async function fetchWithIntegrity(
+  url: string,
+  mimeType: string,
+  signal?: AbortSignal
+): Promise<string> {
   const key = url.split("/").pop()!;
   const integrity = SRI_HASHES[key];
 
   // Fallback to standard fetch if SRI is missing (Prevents ffmpeg-core.worker.js from crashing the thread)
   if (!integrity) {
-    const response = await fetch(url, { credentials: "omit" });
+    const response = await fetch(url, { credentials: "omit" , signal });
     const blob = new Blob([await response.arrayBuffer()], { type: mimeType });
     return URL.createObjectURL(blob);
   }
 
-  const response = await fetch(url, { integrity, credentials: "omit" });
+  const response = await fetch(url, { integrity, credentials: "omit" , signal });
   const blob = new Blob([await response.arrayBuffer()], { type: mimeType });
   return URL.createObjectURL(blob);
 }
@@ -317,10 +322,14 @@ interface PositionCoords {
   return args;
 }
 
-async function loadCore(onProgress?: (percent: number) => void): Promise<void> {
+async function loadCore(signal?: AbortSignal, onProgress?: (percent: number) => void): Promise<void> {
   if (ffmpegLoaded) {
     onProgress?.(100);
     return;
+  }
+
+  if (signal?.aborted) {
+    throw new DOMException("Loading aborted", "AbortError");
   }
 
   ffmpeg = new FFmpeg();
@@ -335,12 +344,22 @@ async function loadCore(onProgress?: (percent: number) => void): Promise<void> {
   ffmpeg.on("progress", handleProgress);
 
   try {
+    const coreURL = await fetchWithIntegrity(`${baseURL}/ffmpeg-core.js`, "text/javascript", signal);
+    const wasmURL = await fetchWithIntegrity(`${baseURL}/ffmpeg-core.wasm`, "application/wasm", signal);
+    let workerURL: string | undefined = undefined;
+    
+    if (isIsolated) {
+      workerURL = await fetchWithIntegrity(`${baseURL}/ffmpeg-core.worker.js`, "text/javascript", signal);
+    }
+
+    if (signal?.aborted) {
+      throw new DOMException("Loading aborted", "AbortError");
+    }
+
     await ffmpeg.load({
-      coreURL: await fetchWithIntegrity(`${baseURL}/ffmpeg-core.js`, "text/javascript"),
-      wasmURL: await fetchWithIntegrity(`${baseURL}/ffmpeg-core.wasm`, "application/wasm"),
-      ...(isIsolated && {
-        workerURL: await fetchWithIntegrity(`${baseURL}/ffmpeg-core.worker.js`, "text/javascript"),
-      }),
+      coreURL,
+      wasmURL,
+      ...(isIsolated && { workerURL }),
     });
 
     ffmpegLoaded = true;
@@ -631,11 +650,22 @@ function handleWorkerMessage(event: MessageEvent<WorkerResponse>) {
 async function handleCommand(message: WorkerCommand) {
   switch (message.type) {
     case "load": {
-      try {
-        await loadCore();
+      if (ffmpegLoaded) {
         postMessage({ type: "ready" });
-      } catch (error) {
-        postMessage({ type: "error", message: (error as Error).message });
+        return;
+      }
+      activeLoadAbortController = new AbortController();
+      try {
+        await loadCore(activeLoadAbortController.signal);
+        postMessage({ type: "ready" });
+      } catch (error: any) {
+        if (activeLoadAbortController?.signal.aborted || error?.name === "AbortError") {
+          postMessage({ type: "cancelled" });
+        } else {
+          postMessage({ type: "error", message: error?.message || String(error) });
+        }
+      } finally {
+        activeLoadAbortController = null;
       }
       return;
     }
@@ -659,11 +689,11 @@ async function handleCommand(message: WorkerCommand) {
           return;
         }
         postMessage({ ...result }, [result.data]);
-      } catch (error) {
-        if (activeExportAbortController?.signal.aborted) {
+      } catch (error: any) {
+        if (activeExportAbortController?.signal.aborted || error?.name === "AbortError") {
           postMessage({ type: "cancelled", id: message.id });
         } else {
-          postMessage({ type: "error", id: message.id, message: (error as Error).message });
+          postMessage({ type: "error", id: message.id, message: error?.message || String(error) });
         }
       } finally {
         activeExportAbortController = null;
@@ -674,6 +704,9 @@ async function handleCommand(message: WorkerCommand) {
     case "cancel": {
       if (activeExportAbortController && !activeExportAbortController.signal.aborted) {
         activeExportAbortController.abort();
+      }
+      if (activeLoadAbortController && !activeLoadAbortController.signal.aborted) {
+        activeLoadAbortController.abort();
       }
       return;
     }


### PR DESCRIPTION
## Description

Implements proper cancellation support for FFmpeg core asset loading inside the worker pipeline.

Previously, cancelling export/loading only stopped the UI flow while large FFmpeg assets (ffmpeg-core.js, ffmpeg-core.wasm, and ffmpeg-core.worker.js) continued downloading in the background without interruption.

This PR propagates AbortSignal support through all FFmpeg asset fetches and worker loading flows to ensure downloads are immediately terminated when a cancel action is triggered.

## Related Issue

Closes #1247 

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: Sammmyyyyyyy
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

##Changes Made
- Added AbortSignal support to fetchWithIntegrity
- Propagated abort signals through loadCore
- Added dedicated worker-level AbortController handling
- Added cancellation handling for:
  - ffmpeg-core.js
  - ffmpeg-core.wasm
  -ffmpeg-core.worker.js
- Added safer AbortError handling during load/export cancellation
- Prevented stale FFmpeg initialization after cancellation events

##Impact
- Stops unnecessary ~32 MB background downloads immediately on cancel
- Prevents wasted bandwidth usage on slow or metered connections
- Avoids stale worker state and resource leaks during interrupted export sessions

**Recording / Loom link:** ## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [ ] **Screen recording attached above** (required for UI/feature/design changes)