### PR TITLE
grid addition and theme bug fixed

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import { useTheme } from "./ThemeProvider";
-import { useEffect, useState } from "react";
 
 export function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
@@ -10,6 +9,9 @@ export function ThemeToggle() {
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  const isDark = theme === "dark";
+  
   if (!mounted) {
     return (
       <button
@@ -25,9 +27,6 @@ export function ThemeToggle() {
       />
     );
   }
-
-  const isDark = theme === "dark";
-  const [mounted, setMounted] = useState(false);
 
   return (
     <button

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -31,6 +31,7 @@ export default function VideoPreview({
   const [isLoading, setIsLoading] = useState(true);
   const [showOverlay, setShowOverlay] = useState(false);
   const [showComparison, setShowComparison] = useState(false);
+  const [showGridOverlay, setShowGridOverlay] = useState(false);
   const [containerDimensions, setContainerDimensions] = useState({
     width: 0,
     height: 0,
@@ -272,6 +273,18 @@ export default function VideoPreview({
           </div>
         )}
 
+        {/* 3x3 Grid Overlay */}
+        {showGridOverlay && (
+          <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
+            {/* Vertical lines */}
+            <div className="absolute top-0 bottom-0 left-1/3 border-l-2 border-dotted border-black" />
+            <div className="absolute top-0 bottom-0 right-1/3 border-l-2 border-dotted border-black" />
+            {/* Horizontal lines */}
+            <div className="absolute left-0 right-0 top-1/3 border-t-2 border-dotted border-black" />
+            <div className="absolute left-0 right-0 bottom-1/3 border-t-2 border-dotted border-black" />
+          </div>
+        )}
+
         {/* Draggable Text Overlays */}
         {recipe && !isLoading && containerDimensions.width > 0 && (
           <DraggableTextOverlays
@@ -299,6 +312,24 @@ export default function VideoPreview({
             title={showOverlay ? "Hide framing overlay" : "Show framing overlay"}
           >
             {showOverlay ? "Hide overlay" : "Show overlay"}
+          </button>
+        )}
+
+        {/* Grid overlay button */}
+        {recipe && !isLoading && (
+          <button
+            type="button"
+            onClick={() => setShowGridOverlay((v) => !v)}
+            className={`absolute top-2 left-32 px-2 py-1 text-[10px] font-heading font-bold uppercase tracking-wider rounded transition-colors z-10 pointer-events-auto ${
+              showGridOverlay
+                ? "bg-[var(--accent)] text-white"
+                : "bg-[var(--surface)] text-[var(--muted)] hover:bg-[var(--accent-muted)] hover:text-[var(--text)]"
+            }`}
+            aria-pressed={showGridOverlay}
+            aria-label={showGridOverlay ? "Hide grid overlay" : "Show grid overlay"}
+            title={showGridOverlay ? "Hide grid overlay" : "Show grid overlay"}
+          >
+            {showGridOverlay ? "Hide grid" : "Show grid"}
           </button>
         )}
 


### PR DESCRIPTION
feat: add grids to video preview

## Description 
added a feature which shows grids in the video preview to better have the idea of centert
## Related Issue
Closes #1283
## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username:  Tatsu26
- Contribution level (Beginner/Intermediate/Advanced): Beginner

https://github.com/user-attachments/assets/481b72bf-b34e-40d9-95a1-6a7b1ad040ef



## Screen Recording
> **How to record:** run `bun run dev` → open http://localhost:3000 → demonstrate the full working flow of your change, including any edge cases.
>
> - **macOS**: `Cmd + Shift + 5` → Record Selected Portion, or use QuickTime Player
> - **Windows**: `Win + G` → Xbox Game Bar → Capture
> - **Linux**: OBS Studio, GNOME Screenshot tool, or `kazam`
> - **Any OS**: [Loom](https://loom.com) (free screen recorder, great for sharing)

**Recording / Loom link:** ## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)