### PR TITLE
chore: add .prettierrc and .prettierignore configuration files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,26 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Build output
+.next/
+out/
+dist/
+build/
+
+# Generated files
+*.min.js
+*.min.css
+public/
+
+# Environment files
+.env
+.env.*
+!.env.example
+
+# Package manager lock files (formatting not needed)
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+bun.lockb

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,15 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "quoteProps": "as-needed",
+  "jsxSingleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "arrowParens": "always",
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "endOfLine": "lf",
+  "plugins": []
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest"
+    "test": "vitest",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@ffmpeg/ffmpeg": "^0.12.10",


### PR DESCRIPTION
Closes #1272.

Adds explicit Prettier configuration to ensure consistent formatting across all contributors' environments.

**.prettierrc** — Standard formatting rules aligned with modern TypeScript/React/Next.js best practices:
- Double quotes (matching JSX convention)
- 2-space indentation
- 80-character print width
- \es5\ trailing commas
- \lf\ line endings (cross-platform consistency)
- Arrow function parens always

**.prettierignore** — Excludes build output, dependencies, lock files, and generated assets from formatting.

**\package.json\** — Adds two new scripts for convenience:
- \
pm run format\ — formats all files in-place
- \
pm run format:check\ — CI-safe check that fails if any file is not formatted