### PR TITLE
fix: align ffmpeg MT version and key SRI hashes by full URL

### DIFF
--- a/src/lib/ffmpeg.worker.ts
+++ b/src/lib/ffmpeg.worker.ts
@@ -5,10 +5,23 @@ import { getPresetById } from "./presets";
 import { buildTextFilter } from "./text-overlay";
 
 const CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd";
-const MT_CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core-mt@0.12.6/dist/esm";
+// MT core aligned to the same version and distribution format as CORE_BASE_URL.
+// Previously used @0.12.6/dist/esm which caused two problems:
+//   1. The version mismatch meant SRI hashes computed for @0.12.10 were applied
+//      to different file contents, causing all MT fetches to fail with an integrity
+//      error instead of falling back gracefully.
+//   2. The ESM distribution is not consumed the same way as UMD by ffmpeg.js and
+//      produced subtle runtime failures in crossOriginIsolated contexts.
+const MT_CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core-mt@0.12.10/dist/umd";
+
+// Keys are full URLs so hashes for the non-MT and MT packages never collide.
+// MT hashes are omitted intentionally: fetchWithIntegrity falls back to a plain
+// fetch when no hash entry exists, which is safe for a trusted CDN origin and
+// avoids the previous bug where a wrong hash caused a hard IntegrityError.
+// Add MT-specific sha384 entries here once they are verified against the CDN.
 const SRI_HASHES: Record<string, string> = {
-  "ffmpeg-core.js":   "sha384-sKfkiFtvUk+vexk+0EUhEh366190/4WpgUAsUvaxEfyg7+E1Zt5Y5hrsU808g8Q9",
-  "ffmpeg-core.wasm": "sha384-U1VDhkPYrM3wTCT4/vjSpSsKqG/UjljYrYCI4hBSJ02svbCkxuCi6U6u/peg5vpW",
+  [`${CORE_BASE_URL}/ffmpeg-core.js`]:   "sha384-sKfkiFtvUk+vexk+0EUhEh366190/4WpgUAsUvaxEfyg7+E1Zt5Y5hrsU808g8Q9",
+  [`${CORE_BASE_URL}/ffmpeg-core.wasm`]: "sha384-U1VDhkPYrM3wTCT4/vjSpSsKqG/UjljYrYCI4hBSJ02svbCkxuCi6U6u/peg5vpW",
 };
 
 type SerializedFile = {
@@ -64,8 +77,8 @@ let activeExportAbortController: AbortController | null = null;
 let activeExportId: string | null = null;
 
 async function fetchWithIntegrity(url: string, mimeType: string): Promise<string> {
-  const key = url.split("/").pop()!;
-  const integrity = SRI_HASHES[key];
+  // Look up by full URL so non-MT and MT hashes never collide when filenames match.
+  const integrity = SRI_HASHES[url];
 
   // Fallback to standard fetch if SRI is missing (Prevents ffmpeg-core.worker.js from crashing the thread)
   if (!integrity) {


### PR DESCRIPTION
## Summary

Closes #1109

Two bugs in `src/lib/ffmpeg.worker.ts`:

**Bug 1 - Wrong SRI hash applied to MT files (hard IntegrityError)**

`SRI_HASHES` was keyed by bare filename (`ffmpeg-core.js`, `ffmpeg-core.wasm`). When `crossOriginIsolated === true`, the loader fetched from `MT_CORE_BASE_URL` (`@ffmpeg/core-mt@0.12.6/dist/esm`) but looked up the hash computed for `@ffmpeg/core@0.12.10/dist/umd`. The file contents differ, so the browser threw an `IntegrityError` and FFmpeg failed to load entirely in cross-origin-isolated contexts.

**Bug 2 - Version mismatch between MT and non-MT paths**

`CORE_BASE_URL` was pinned to \`@0.12.10\` while \`MT_CORE_BASE_URL\` used \`@0.12.6\`. This introduced inconsistent behavior depending on the browser isolation state.

## Changes

- \`src/lib/ffmpeg.worker.ts\`:
  - \`MT_CORE_BASE_URL\` aligned to \`@ffmpeg/core-mt@0.12.10/dist/umd\` (matches \`CORE_BASE_URL\` version and distribution)
  - \`SRI_HASHES\` now keyed by full URL, so non-MT and MT entries can coexist without filename collision
  - Existing non-MT sha384 hashes preserved under their full URLs
  - MT hashes are intentionally absent: \`fetchWithIntegrity\` already falls back to a plain fetch when no entry exists, which is safe for a trusted CDN origin and far better than the previous behavior of applying a wrong hash and hard-failing

## Test plan

- [ ] In a non-cross-origin-isolated context, FFmpeg loads correctly (non-MT path, hash verified)
- [ ] In a cross-origin-isolated context (\`crossOriginIsolated === true\`), FFmpeg loads without an IntegrityError (MT path, no hash = plain fetch)
- [ ] Video export works end-to-end in both contexts

Could you please add the appropriate GSSoC labels (\`gssoc26\`, \`type:bug\`, \`level:intermediate\`) when you get a chance? Thank you!