### PR TITLE
feat(ux): add auto-save recovery system for editing sessions #1251

### DIFF
--- a/src/components/RecoveryPrompt.tsx
+++ b/src/components/RecoveryPrompt.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Clock, Trash2, RotateCcw } from "lucide-react";
+
+interface RecoveryPromptProps {
+  lastSavedAt: number;
+  onRestore: () => void;
+  onDiscard: () => void;
+}
+
+export function RecoveryPrompt({ lastSavedAt, onRestore, onDiscard }: RecoveryPromptProps) {
+  const timeString = new Date(lastSavedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  const dateString = new Date(lastSavedAt).toLocaleDateString();
+
+  return (
+    <div className="bg-[var(--surface)] border border-[var(--border)] rounded-xl p-5 animate-fade-in shadow-lg mb-6">
+      <div className="flex items-start sm:items-center gap-4 flex-col sm:flex-row">
+        <div className="w-10 h-10 rounded-full bg-film-100 flex items-center justify-center shrink-0">
+          <Clock size={20} className="text-film-600" />
+        </div>
+        <div className="flex-1">
+          <h3 className="font-heading font-bold text-[var(--text)] text-base">Unsaved Session Found</h3>
+          <p className="text-sm text-[var(--muted)] mt-1">
+            We found an editing session from {dateString} at {timeString}. Would you like to restore it?
+          </p>
+        </div>
+        <div className="flex items-center gap-3 w-full sm:w-auto mt-2 sm:mt-0">
+          <button
+            onClick={onDiscard}
+            className="flex-1 sm:flex-none px-4 py-2 border border-[var(--border)] hover:bg-[var(--border)] rounded-lg text-sm font-semibold transition-colors flex items-center justify-center gap-2"
+          >
+            <Trash2 size={16} />
+            <span>Discard</span>
+          </button>
+          <button
+            onClick={onRestore}
+            className="flex-1 sm:flex-none px-4 py-2 bg-film-600 hover:bg-film-700 text-white rounded-lg text-sm font-semibold transition-colors flex items-center justify-center gap-2"
+          >
+            <RotateCcw size={16} />
+            <span>Restore</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -17,6 +17,7 @@ import ExportSettings from "./ExportSettings";
 import ExportOverlay from "./ExportOverlay";
 import DownloadResult from "./DownloadResult";
 import ImageOverlay from "./ImageOverlay"
+import { RecoveryPrompt } from "./RecoveryPrompt";
 import { getPresetById } from "@/lib/presets";
 
 import { cn } from "@/lib/utils";
@@ -210,6 +211,10 @@ export default function VideoEditor() {
     recommendedPreset,
     currentTime,
     toggleSound,
+    recoverySession,
+    isRestoring,
+    restoreSession,
+    discardSession,
   } = useVideoEditor();
 
   useKeyboardShortcuts({
@@ -369,6 +374,14 @@ export default function VideoEditor() {
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-5">
 
           <div className="space-y-4 min-w-0">
+            {recoverySession && !file && !isRestoring && (
+              <RecoveryPrompt
+                lastSavedAt={recoverySession.lastSavedAt}
+                onRestore={restoreSession}
+                onDiscard={discardSession}
+              />
+            )}
+
             <div className="bg-[var(--surface)] rounded-xl p-3 border border-[var(--border)] animate-fade-in">
               <FileUpload onFileSelect={handleFileSelect} currentFile={file} fileError={fileError} duration={duration} />
 

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -7,6 +7,7 @@ import { getPresetById } from "@/lib/presets";
 import { loadFFmpeg, exportVideo, terminateFFmpeg, FFmpegLoadError } from "@/lib/ffmpeg";
 import { suggestPreset } from "@/lib/presetSuggestion";
 import { validateDimensions, getDownscaledDimensions } from "@/utils/video-validation";
+import { saveSession, loadSession, clearSession, RecoverySession } from "@/lib/db";
 
 const DEFAULT_TITLE = "Reframe — Resize, trim, and export videos in your browser";
   const STORAGE_KEY = "reframe:recipe";
@@ -145,6 +146,8 @@ function migrateRecipe(recipe: Partial<EditRecipe>): EditRecipe {
 }
 
 export function useVideoEditor() {
+  const [recoverySession, setRecoverySession] = useState<RecoverySession | null>(null);
+  const [isRestoring, setIsRestoring] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [duration, setDuration] = useState<number>(0);
   const [videoMetadata, setVideoMetadata] = useState<{
@@ -669,6 +672,7 @@ export function useVideoEditor() {
     } catch {
       // ignore
     }
+    clearSession();
   }, [result]);
 
 
@@ -691,6 +695,53 @@ export function useVideoEditor() {
   const toggleSound = useCallback(() => {
   updateRecipe({ soundOnCompletion: !recipe.soundOnCompletion });
 }, [recipe.soundOnCompletion, updateRecipe]);
+
+  // Load session on mount
+  useEffect(() => {
+    loadSession().then((session) => {
+      if (session && session.file) {
+        setRecoverySession(session);
+      }
+    });
+  }, []);
+
+  // Auto-save logic
+  useEffect(() => {
+    if (!file) return;
+
+    const timer = setTimeout(() => {
+      saveSession({
+        file,
+        musicFile,
+        overlayFile,
+        recipe,
+        duration,
+        videoMetadata,
+        lastSavedAt: Date.now(),
+      }).catch(console.error);
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, [file, musicFile, overlayFile, recipe, duration, videoMetadata]);
+
+  // Restore session
+  const restoreSession = useCallback(async () => {
+    if (!recoverySession) return;
+    setIsRestoring(true);
+    setFile(recoverySession.file);
+    setMusicFile(recoverySession.musicFile);
+    setOverlayFile(recoverySession.overlayFile);
+    setRecipe(recoverySession.recipe);
+    setDuration(recoverySession.duration);
+    setVideoMetadata(recoverySession.videoMetadata);
+    setRecoverySession(null);
+    setIsRestoring(false);
+  }, [recoverySession]);
+
+  const discardSession = useCallback(async () => {
+    await clearSession();
+    setRecoverySession(null);
+  }, []);
 
   return {
     file,
@@ -729,5 +780,9 @@ export function useVideoEditor() {
     recommendedPreset,
     currentTime,
     toggleSound,
+    recoverySession,
+    isRestoring,
+    restoreSession,
+    discardSession,
   };
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,91 @@
+import { EditRecipe } from "@/lib/types";
+
+export interface RecoverySession {
+  id: string;
+  file: File | null;
+  musicFile: File | null;
+  overlayFile: File | null;
+  recipe: EditRecipe;
+  duration: number;
+  videoMetadata: { width: number; height: number; duration: number } | null;
+  lastSavedAt: number;
+}
+
+const DB_NAME = "ReframeDB";
+const STORE_NAME = "sessions";
+const DB_VERSION = 1;
+
+export function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    if (typeof window === "undefined" || !window.indexedDB) {
+      return reject(new Error("IndexedDB not supported"));
+    }
+    const request = window.indexedDB.open(DB_NAME, DB_VERSION);
+    
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve(request.result);
+    
+    request.onupgradeneeded = (e) => {
+      const db = (e.target as IDBOpenDBRequest).result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: "id" });
+      }
+    };
+  });
+}
+
+export async function saveSession(session: Omit<RecoverySession, "id">): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.put({ ...session, id: "current-session" });
+    
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function loadSession(): Promise<RecoverySession | null> {
+  try {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(STORE_NAME, "readonly");
+      const store = transaction.objectStore(STORE_NAME);
+      const request = store.get("current-session");
+      
+      request.onsuccess = () => {
+        const result = request.result as RecoverySession | undefined;
+        if (!result) return resolve(null);
+        
+        // Check if it's older than 24 hours
+        const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
+        if (Date.now() - result.lastSavedAt > TWENTY_FOUR_HOURS) {
+          clearSession().catch(console.error);
+          return resolve(null);
+        }
+        resolve(result);
+      };
+      request.onerror = () => reject(request.error);
+    });
+  } catch (err) {
+    console.error("Failed to load session from IndexedDB:", err);
+    return null;
+  }
+}
+
+export async function clearSession(): Promise<void> {
+  try {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(STORE_NAME, "readwrite");
+      const store = transaction.objectStore(STORE_NAME);
+      const request = store.delete("current-session");
+      
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  } catch (err) {
+    console.error("Failed to clear session from IndexedDB:", err);
+  }
+}


### PR DESCRIPTION
## Problem
If the browser crashes, the tab reloads unexpectedly, or the user accidentally closes the app, all unsaved editing progress (including the uploaded video file, overlays, and trim metadata) is lost.

## Closes: #1251 

## Proposed Solution
This PR adds a robust, privacy-first Auto-save Recovery System using IndexedDB. 

- **Session Persistence:** Saves the entire editing session (including the primary video `File` object, music, overlays, and recipe settings) to a native local IndexedDB store every 3 seconds after a change is made.
- **Recovery Prompt:** When launching an empty editor, if an unfinished session is found in IndexedDB, the app displays an inline "Restore previous session?" banner allowing users to instantly jump back to where they left off.
- **Privacy & Storage Cleanup:** The recovery snapshot stays 100% local. To prevent bloated disk usage, the snapshot is automatically cleared when the user successfully exports, clicks the Reset button, manually hits 'Discard', or if the snapshot is older than 24 hours. 
- **Legacy Support:** The older `localStorage` settings cache remains untouched as a fallback and to avoid conflict with existing workflows.

## Verification Plan

### Manual Verification
1. Open the app, upload a video, trim it, and add text.
2. Hard refresh the page (F5 or close/re-open tab).
3. Ensure the "Restore previous session?" prompt appears.
4. Click "Restore" and verify that the video, trims, texts, and duration are restored accurately.
5. Click "Reset" and ensure the recovery snapshot is deleted from Chrome DevTools -> Application -> IndexedDB.
