### PR TITLE
feat: background rendering queue for exports 

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,7 @@
 import VideoEditor from "@/components/VideoEditor";
 import Footer from "@/components/Footer";
+import { ExportQueueProvider } from "@/context/ExportQueueContext";
+import { ExportQueuePanel } from "@/components/ExportQueuePanel";
 
 export default function Home() {
   return (
@@ -14,7 +16,10 @@ export default function Home() {
       </a>
 
       <main id="main-content" tabIndex={-1}>
-        <VideoEditor />
+        <ExportQueueProvider>
+          <VideoEditor />
+          <ExportQueuePanel />
+        </ExportQueueProvider>
       </main>
 
       <Footer />

--- a/src/components/ExportQueuePanel.tsx
+++ b/src/components/ExportQueuePanel.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import React, { useState } from "react";
+import { useExportQueue, ExportJob } from "@/context/ExportQueueContext";
+import { X, Play, AlertCircle, Download, CheckCircle2, Loader2, ChevronUp, ChevronDown } from "lucide-react";
+
+function formatElapsed(startedAt?: number): string {
+  if (!startedAt) return "0:00";
+  const totalSeconds = Math.max(0, Math.floor((Date.now() - startedAt) / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+function JobItem({ job, onCancel, onDismiss }: { job: ExportJob; onCancel: (id: string) => void; onDismiss: (id: string) => void }) {
+  const [elapsed, setElapsed] = useState(() => formatElapsed(job.startedAt));
+
+  React.useEffect(() => {
+    if (job.status !== "exporting") return;
+    const timer = setInterval(() => setElapsed(formatElapsed(job.startedAt)), 1000);
+    return () => clearInterval(timer);
+  }, [job.status, job.startedAt]);
+
+  const handleDownload = () => {
+    if (job.result) {
+      const a = document.createElement("a");
+      a.href = job.result.blobUrl;
+      a.download = `reframe_export_${job.result.format}`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+    }
+  };
+
+  return (
+    <div className="bg-[var(--surface)] border border-[var(--border)] rounded-lg p-3 text-sm flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-medium text-[var(--text)] truncate flex-1" title={job.name}>
+          {job.name}
+        </span>
+        <div className="flex items-center gap-1 shrink-0">
+          {job.status === "queued" && (
+            <span className="text-xs text-[var(--muted)] flex items-center gap-1">
+              <Loader2 className="w-3 h-3 animate-spin" /> Queued
+            </span>
+          )}
+          {job.status === "exporting" && (
+            <span className="text-xs text-[var(--accent)] font-medium flex items-center gap-1">
+              <Loader2 className="w-3 h-3 animate-spin" /> {job.progress}%
+            </span>
+          )}
+          {job.status === "done" && (
+            <span className="text-xs text-green-500 font-medium flex items-center gap-1">
+              <CheckCircle2 className="w-3 h-3" /> Done
+            </span>
+          )}
+          {job.status === "error" && (
+            <span className="text-xs text-red-500 font-medium flex items-center gap-1">
+              <AlertCircle className="w-3 h-3" /> Error
+            </span>
+          )}
+        </div>
+      </div>
+
+      {(job.status === "exporting" || job.status === "queued") && (
+        <div className="w-full h-1.5 bg-[var(--bg)] rounded-full overflow-hidden">
+          <div
+            className="h-full bg-[var(--accent)] transition-all duration-300"
+            style={{ width: `${job.progress}%` }}
+          />
+        </div>
+      )}
+
+      {job.status === "exporting" && (
+        <div className="text-[10px] text-[var(--muted)] text-right">
+          {elapsed} elapsed
+        </div>
+      )}
+
+      {job.status === "error" && job.error && (
+        <div className="text-xs text-red-400 truncate" title={job.error}>
+          {job.error}
+        </div>
+      )}
+
+      <div className="flex items-center justify-end gap-2 mt-1">
+        {(job.status === "queued" || job.status === "exporting") && (
+          <button
+            onClick={() => onCancel(job.id)}
+            className="text-xs px-2 py-1 hover:bg-[var(--bg)] rounded text-[var(--muted)] transition-colors"
+          >
+            Cancel
+          </button>
+        )}
+        {job.status === "done" && (
+          <>
+            <button
+              onClick={handleDownload}
+              className="text-xs px-2 py-1 bg-[var(--accent)] text-black font-medium rounded hover:opacity-90 transition-opacity flex items-center gap-1"
+            >
+              <Download className="w-3 h-3" /> Save
+            </button>
+            <button
+              onClick={() => onDismiss(job.id)}
+              className="text-xs px-2 py-1 hover:bg-[var(--bg)] rounded text-[var(--muted)] transition-colors"
+            >
+              Dismiss
+            </button>
+          </>
+        )}
+        {job.status === "error" && (
+          <button
+            onClick={() => onDismiss(job.id)}
+            className="text-xs px-2 py-1 hover:bg-[var(--bg)] rounded text-[var(--muted)] transition-colors"
+          >
+            Dismiss
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ExportQueuePanel() {
+  const { jobs, cancelJob, dismissJob } = useExportQueue();
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  if (jobs.length === 0) return null;
+
+  const activeJobs = jobs.filter(j => j.status === "exporting" || j.status === "queued").length;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-[100] w-80 max-w-[calc(100vw-32px)] flex flex-col gap-2">
+      <div 
+        className="bg-[var(--surface)] border border-[var(--border)] rounded-lg shadow-xl overflow-hidden animate-in slide-in-from-bottom-5 fade-in duration-300"
+      >
+        <button 
+          className="w-full flex items-center justify-between p-3 cursor-pointer bg-[var(--bg)] border-b border-[var(--border)] text-left"
+          onClick={() => setIsExpanded(!isExpanded)}
+        >
+          <div className="flex items-center gap-2">
+            <span className="font-heading font-semibold text-sm">Export Queue</span>
+            {activeJobs > 0 && (
+              <span className="bg-[var(--accent)] text-black text-[10px] font-bold px-1.5 py-0.5 rounded-full">
+                {activeJobs}
+              </span>
+            )}
+          </div>
+          <div className="text-[var(--muted)] hover:text-[var(--text)] transition-colors p-1">
+            {isExpanded ? <ChevronDown className="w-4 h-4" /> : <ChevronUp className="w-4 h-4" />}
+          </div>
+        </button>
+
+        {isExpanded && (
+          <div className="max-h-[60vh] overflow-y-auto p-2 flex flex-col gap-2 scrollbar-thin scrollbar-thumb-[var(--border)] scrollbar-track-transparent">
+            {jobs.map(job => (
+              <JobItem 
+                key={job.id} 
+                job={job} 
+                onCancel={cancelJob}
+                onDismiss={dismissJob}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useRef, useEffect, useMemo } from "react";
+import { useState, useRef, useEffect, useMemo, useCallback } from "react";
 import { useVideoEditor } from "@/hooks/useVideoEditor";
+import { useExportQueue } from "@/context/ExportQueueContext";
 import { TextOverlay } from "@/lib/types";
 import FileUpload from "./FileUpload";
 import VideoPreview from "./VideoPreview";
@@ -14,9 +15,8 @@ import TextControls from "./TextControls";
 import AudioSpeedControl from "./AudioSpeedControl";
 import FormatSelector from "./FormatSelector";
 import ExportSettings from "./ExportSettings";
-import ExportOverlay from "./ExportOverlay";
 import DownloadResult from "./DownloadResult";
-import ImageOverlay from "./ImageOverlay"
+import ImageOverlay from "./ImageOverlay";
 import { getPresetById } from "@/lib/presets";
 
 import { cn } from "@/lib/utils";
@@ -198,11 +198,12 @@ function KeyboardShortcutsPanel() {
 
 export default function VideoEditor() {
   const {
-    file, duration, recipe, status, progress,
-    result, error, exportStartedAt, updateRecipe,
-    handleFileSelect, fileError, handleExport, cancelExport, reset, resetSettings,
+    file, duration, recipe,
+    videoMetadata, fileError, updateRecipe,
+    handleFileSelect, reset, resetSettings,
     videoRef,
     seekTo,
+    musicFile, musicVolume, originalAudioVolume, loopMusic,
     overlayFile, setOverlayFile,
     overlayPosition, setOverlayPosition,
     overlaySize, setOverlaySize,
@@ -212,14 +213,26 @@ export default function VideoEditor() {
     toggleSound,
   } = useVideoEditor();
 
+  const { enqueueExport } = useExportQueue();
+
+  const handleExport = useCallback(() => {
+    if (!file) return;
+    enqueueExport(
+      file,
+      recipe,
+      { file: musicFile, musicVolume, originalAudioVolume, loopMusic },
+      { file: overlayFile, position: overlayPosition, size: overlaySize, opacity: overlayOpacity }
+    );
+  }, [file, recipe, musicFile, musicVolume, originalAudioVolume, loopMusic, overlayFile, overlayPosition, overlaySize, overlayOpacity, enqueueExport]);
+
   useKeyboardShortcuts({
     file,
     recipe,
     resetSettings,
     updateRecipe,
     handleExport,
-    status,
-    cancelExport,
+    status: "idle",
+    cancelExport: () => {},
     onToggleShortcutsModal: () => {},
   });
 
@@ -262,16 +275,9 @@ export default function VideoEditor() {
   };
 
   useEffect(() => {
-    if (status === "done" && downloadRef.current) {
-      const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-      downloadRef.current.scrollIntoView({
-        behavior: prefersReducedMotion ? "instant" : "smooth",
-        block: "center",
-      });
-    }
-  }, [status]);
+    // Scroll behavior if needed
+  }, []);
 
-  const isProcessing = status === "loading-engine" || status === "exporting";
   const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
 
   const intervalSeconds = useMemo(() => {
@@ -310,19 +316,7 @@ export default function VideoEditor() {
 
   return (
     <div className="min-h-screen relative flex flex-col" style={{ background: "var(--bg)" }}>
-      <ExportOverlay
-        status={status}
-        progress={progress}
-        exportStartedAt={exportStartedAt}
-        onCancel={cancelExport}
-      />
       <OnboardingTour />
-
-      <div aria-live="polite" aria-atomic="true" className="sr-only">
-        {status === "exporting" && `Exporting video: ${progress}%`}
-        {status === "done" && "Export complete! Video ready to download."}
-        {status === "error" && `Export failed: ${error}`}
-      </div>
 
       <div className="max-w-6xl mx-auto px-4 py-8 pb-6 flex-1 w-full">
         <header className="mb-10 flex flex-col items-center justify-center gap-4 animate-fade-in">
@@ -412,8 +406,7 @@ export default function VideoEditor() {
             )}
             {file && (
               <div className={cn(
-                "grid grid-cols-1 gap-4",
-                isProcessing && "pointer-events-none opacity-50"
+                "grid grid-cols-1 gap-4"
               )}>
                 <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6">
                   <AccordionSection
@@ -642,53 +635,12 @@ export default function VideoEditor() {
               </div>
             )}
 
-            {status === "error" && error && (
-              <div
-                role="status"
-                className="flex items-start gap-3 p-4 bg-film-50 border border-film-200 rounded-xl text-film-800 text-sm animate-fade-in"
-              >
-                <AlertTriangle size={16} className="shrink-0 mt-0.5 text-film-500" />
-                <div className="flex-1">
-                  <p className="font-heading font-bold text-sm">Error</p>
-                  <p className="text-film-600 text-sm mt-1">{error}</p>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => {
-                    navigator.clipboard.writeText(error).then(() => {
-                      setCopied(true);
-                      setTimeout(() => setCopied(false), 2000);
-                    }).catch((err) => {
-                      console.error("Failed to copy error to clipboard:", err);
-                    });
-                  }}
-                  className="px-3 py-1.5 bg-[var(--border)] border border-[var(--border)] rounded-lg text-sm font-semibold hover:opacity-80 transition-colors shrink-0 whitespace-nowrap"
-                  aria-label="Copy error message to clipboard"
-                >
-                  {copied ? "Copied!" : "Copy error"}
-                </button>
-                {!error.includes("Validation Failed") && (
-                  <button
-                    type="button"
-                    onClick={handleExport}
-                    className="px-3 py-1.5 bg-[var(--error-bg)] border border-[var(--error-border)] rounded-lg text-sm font-semibold hover:bg-[var(--error-hover)] hover:border-[var(--error)] text-[var(--text)] transition-colors shrink-0 whitespace-nowrap"
-                  >
-                    Retry Export
-                  </button>
-                )}
-              </div>
-            )}
 
-            {status === "done" && result && (
-              <div role="status" className="animate-fade-in" ref={downloadRef}>
-                <DownloadResult result={result} onReset={reset} soundOnCompletion={recipe.soundOnCompletion} onToggleSound={toggleSound} />
-              </div>
-            )}
           </div>
 
           <div className={cn(
             "space-y-5 transition-opacity duration-300 sticky top-8 self-start",
-            (isProcessing || !file) && "pointer-events-none opacity-50"
+            (!file) && "pointer-events-none opacity-50"
           )}>
             {!file && (
               <div className="bg-[var(--surface)] border border-[var(--border)] rounded-xl p-4 animate-fade-in">
@@ -753,23 +705,23 @@ export default function VideoEditor() {
               id="export-button"
               type="button"
               onClick={handleExport}
-                disabled={!file || isProcessing}
+                disabled={!file}
                 aria-label='Export video'
-                aria-disabled={!file || isProcessing ? "true" : undefined}
+                aria-disabled={!file ? "true" : undefined}
                 title={!file ? "Upload a video to enable export" : undefined}
               className={cn(
                 "w-full flex items-center justify-center gap-3 py-5 min-h-[44px] rounded-xl",
                 "font-display text-2xl tracking-widest transition-all duration-200",
-                file && !isProcessing
-                  ? "bg-[var(--accent)] hover:bg-[var(--accent-hover)] hover:scale-[1.02] text-white shadow-[var(--shadow)] active:scale-[0.98] cursor-pointer"
+                file
+                  ? "bg-[var(--accent)] hover:bg-[var(--accent-hover)] hover:scale-[1.02] text-black shadow-[var(--shadow)] active:scale-[0.98] cursor-pointer"
                   : "bg-[var(--border)] text-[var(--muted)] cursor-not-allowed"
               )}
             >
-             <Zap size={20} className={cn(file && !isProcessing && "animate-pulse")} />
-              {isProcessing ? "PROCESSING" : "EXPORT"}
+             <Zap size={20} className={cn(file && "animate-pulse")} />
+              EXPORT
             </button>
 
-            {file && !isProcessing && (
+            {file && (
               <p className="text-xs text-center font-mono text-[var(--muted)] opacity-50 mt-1">
                 {isMac ? "⌘" : "Ctrl"} + Enter to export
               </p>

--- a/src/context/ExportQueueContext.tsx
+++ b/src/context/ExportQueueContext.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from "react";
+import { ExportResult, EditRecipe, BackgroundMusicOptions, ImageOverlayOptions } from "@/lib/types";
+import { exportVideo } from "@/lib/ffmpeg";
+
+export type ExportJobStatus = "queued" | "exporting" | "done" | "error";
+
+export interface ExportJob {
+  id: string;
+  name: string;
+  status: ExportJobStatus;
+  progress: number;
+  result?: ExportResult;
+  error?: string;
+  startedAt?: number;
+  file: File;
+  recipe: EditRecipe;
+  musicOptions?: BackgroundMusicOptions;
+  overlayOptions?: ImageOverlayOptions;
+  abortController: AbortController;
+}
+
+interface ExportQueueContextType {
+  jobs: ExportJob[];
+  enqueueExport: (
+    file: File,
+    recipe: EditRecipe,
+    musicOptions?: BackgroundMusicOptions,
+    overlayOptions?: ImageOverlayOptions
+  ) => void;
+  cancelJob: (id: string) => void;
+  dismissJob: (id: string) => void;
+}
+
+const ExportQueueContext = createContext<ExportQueueContextType | null>(null);
+
+export function useExportQueue() {
+  const ctx = useContext(ExportQueueContext);
+  if (!ctx) throw new Error("useExportQueue must be used within ExportQueueProvider");
+  return ctx;
+}
+
+export function ExportQueueProvider({ children }: { children: React.ReactNode }) {
+  const [jobs, setJobs] = useState<ExportJob[]>([]);
+  const isProcessingRef = useRef(false);
+
+  const enqueueExport = useCallback((
+    file: File,
+    recipe: EditRecipe,
+    musicOptions?: BackgroundMusicOptions,
+    overlayOptions?: ImageOverlayOptions
+  ) => {
+    const newJob: ExportJob = {
+      id: crypto.randomUUID(),
+      name: file.name,
+      status: "queued",
+      progress: 0,
+      file,
+      recipe,
+      musicOptions,
+      overlayOptions,
+      abortController: new AbortController(),
+    };
+    setJobs((prev) => [...prev, newJob]);
+  }, []);
+
+  const cancelJob = useCallback((id: string) => {
+    setJobs((prev) => {
+      const job = prev.find(j => j.id === id);
+      if (job && (job.status === "queued" || job.status === "exporting")) {
+        job.abortController.abort();
+        return prev.map(j => j.id === id ? { ...j, status: "error", error: "Cancelled by user" } : j);
+      }
+      return prev;
+    });
+  }, []);
+
+  const dismissJob = useCallback((id: string) => {
+    setJobs((prev) => prev.filter((j) => j.id !== id));
+  }, []);
+
+  const processNextJob = useCallback(async () => {
+    if (isProcessingRef.current) return;
+
+    let nextJob: ExportJob | undefined;
+    setJobs((prev) => {
+      nextJob = prev.find(j => j.status === "queued");
+      if (!nextJob) return prev;
+      return prev.map((j) => (j.id === nextJob!.id ? { ...j, status: "exporting", startedAt: Date.now() } : j));
+    });
+
+    if (!nextJob) return;
+
+    isProcessingRef.current = true;
+
+    try {
+      const result = await exportVideo(
+        nextJob.file,
+        nextJob.recipe,
+        (progress) => {
+          setJobs((prev) =>
+            prev.map((j) => (j.id === nextJob!.id ? { ...j, progress } : j))
+          );
+        },
+        nextJob.abortController.signal,
+        nextJob.musicOptions,
+        nextJob.overlayOptions
+      );
+
+      setJobs((prev) =>
+        prev.map((j) => (j.id === nextJob!.id ? { ...j, status: "done", result, progress: 100 } : j))
+      );
+    } catch (err) {
+      setJobs((prev) =>
+        prev.map((j) => {
+          if (j.id !== nextJob!.id) return j;
+          if (nextJob!.abortController.signal.aborted) {
+            return { ...j, status: "error", error: "Cancelled by user" };
+          }
+          return { ...j, status: "error", error: err instanceof Error ? err.message : "Export failed" };
+        })
+      );
+    } finally {
+      isProcessingRef.current = false;
+      setJobs((prev) => [...prev]);
+    }
+  }, []);
+
+  useEffect(() => {
+    const hasQueued = jobs.some(j => j.status === "queued");
+    if (hasQueued && !isProcessingRef.current) {
+      processNextJob();
+    }
+  }, [jobs, processNextJob]);
+
+  useEffect(() => {
+    const hasExporting = jobs.some(j => j.status === "exporting");
+    if (!hasExporting) return;
+
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [jobs]);
+
+  return (
+    <ExportQueueContext.Provider value={{ jobs, enqueueExport, cancelJob, dismissJob }}>
+      {children}
+    </ExportQueueContext.Provider>
+  );
+}

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -168,14 +168,7 @@ export function useVideoEditor() {
         localStorage.getItem("soundOnCompletion") === "true",
     });
   });
-  const [status, setStatus] = useState<ExportStatus>("idle");
-  const [progress, setProgress] = useState(0);
-  const [result, setResult] = useState<ExportResult | null>(null);
-  const [error, setError] = useState<string | null>(null);
   const [fileError, setFileError] = useState("");
-  const [exportStartedAt, setExportStartedAt] = useState<number | null>(null);
-  const exportAbortControllerRef = useRef<AbortController | null>(null);
-  const exportCancelledRef = useRef(false);
   const videoRef = useRef<HTMLVideoElement>(null);
 
   const [musicFile, setMusicFile] = useState<File | null>(null);
@@ -366,9 +359,7 @@ export function useVideoEditor() {
   }, [videoMetadata]);
 
   const handleFileSelect = useCallback(async (selectedFile: File) => {
-    setResult(null);
-    setStatus("idle");
-    setError(null);
+    setFileError("");
     setFile(null);
     setVideoMetadata(null);
     if (!selectedFile.type.startsWith("video/")) {
@@ -380,8 +371,7 @@ export function useVideoEditor() {
 
     // LAYER 0: Size check
     if (selectedFile.size > MAX_FILE_SIZE) {
-      setError(`Validation Failed: File too large. Maximum size is 2GB.`);
-      setStatus("error");
+      setFileError(`Validation Failed: File too large. Maximum size is 2GB.`);
       return;
     }
 
@@ -389,21 +379,18 @@ export function useVideoEditor() {
     const filename = selectedFile.name.toLowerCase();
     const hasValidExtension = validExtensions.some(ext => filename.endsWith(ext));
     if (!hasValidExtension) {
-      setError(`Layer 1 Validation Failed: Invalid file extension. Expected one of: ${validExtensions.join(', ')}`);
-      setStatus("error");
+      setFileError(`Layer 1 Validation Failed: Invalid file extension. Expected one of: ${validExtensions.join(', ')}`);
       return;
     }
 
     if (!selectedFile.type.startsWith("video/")) {
-      setError(`Layer 2 Validation Failed: Invalid MIME type. Expected video/*, got ${selectedFile.type || 'unknown'}`);
-      setStatus("error");
+      setFileError(`Layer 2 Validation Failed: Invalid MIME type. Expected video/*, got ${selectedFile.type || 'unknown'}`);
       return;
     }
 
     const isVideo = await verifyMagicBytes(selectedFile);
     if (!isVideo) {
-      setError("Layer 3 Validation Failed: Invalid file content. The file's magic bytes do not match known video formats.");
-      setStatus("error");
+      setFileError("Layer 3 Validation Failed: Invalid file content. The file's magic bytes do not match known video formats.");
       return;
     }
 
@@ -414,11 +401,10 @@ export function useVideoEditor() {
       const dimensionCheck = validateDimensions(width, height);
       if (dimensionCheck === "blocked") {
         const suggested = getDownscaledDimensions(width, height);
-        setError(
+        setFileError(
           `Layer 5 Validation Failed: Resolution too high (${width}×${height}). ` +
           `Maximum supported is 8K. Suggested safe size: ${suggested.width}×${suggested.height}.`
         );
-        setStatus("error");
         return;
       }
 
@@ -441,114 +427,15 @@ export function useVideoEditor() {
         };
       });
     } catch (err) {
-      setError(`Layer 4 Validation Failed: ${err instanceof Error ? err.message : "Unknown error"}`);
-      setStatus("error");
+      setFileError(`Layer 4 Validation Failed: ${err instanceof Error ? err.message : "Unknown error"}`);
     }
   }, []);
 
-  const handleExport = useCallback(async () => {
-    if (!file) return;
-    if (status === "loading-engine" || status === "exporting") {
-      return;
-    }
 
-    const validationError = validateRecipe(recipe, duration);
-    if (validationError) {
-      setError(validationError);
-      setStatus("error");
-      return;
-    }
-
-    const abortController = new AbortController();
-    exportAbortControllerRef.current = abortController;
-    exportCancelledRef.current = false;
-
-    try {
-      setStatus("loading-engine");
-      setProgress(0);
-      setError(null);
-      setExportStartedAt(null);
-      if (result?.blobUrl) URL.revokeObjectURL(result.blobUrl);
-      setResult(null);
-
-      await loadFFmpeg(abortController.signal, setProgress);
-      if (exportCancelledRef.current) return;
-
-      const startedAt = Date.now();
-      setExportStartedAt(startedAt);
-      setStatus("exporting");
-
-      const exportResult = await exportVideo(
-        file,
-        recipe,
-        setProgress,
-        abortController.signal,
-        {
-          file: musicFile,
-          musicVolume,
-          originalAudioVolume,
-          loopMusic,
-        },
-        {
-          file: overlayFile,
-          position: overlayPosition,
-          size: overlaySize,
-          opacity: overlayOpacity,
-        }
-      );
-      if (exportCancelledRef.current) return;
-
-      setResult({
-        ...exportResult,
-        exportDurationMs: Date.now() - startedAt,
-      });
-      setStatus("done");
-     }  catch (err) {
-      if (exportCancelledRef.current) return;
-
-      console.error("export failed:", err);
-      if (err instanceof FFmpegLoadError) {
-        setError(err.message);
-      } else if (err instanceof Error && err.message.includes('network')) {
-        setError('Network error. Check your internet connection and try again.');
-      } else if (err instanceof Error && err.message.includes('codec')) {
-        setError('This video format is not supported. Try converting to MP4 first.');
-      } else {
-        setError('Export failed. Please try again or use a different video.');
-      }
-      setExportStartedAt(null);
-      setStatus("error");
-    }
-    finally {
-      if (exportAbortControllerRef.current === abortController) {
-        exportAbortControllerRef.current = null;
-      }
-    }
-  }, [
-    duration,
-    file,
-    loopMusic,
-    musicFile,
-    musicVolume,
-    originalAudioVolume,
-    overlayFile,
-    overlayOpacity,
-    overlayPosition,
-    overlaySize,
-    recipe,
-    result,
-    status,
-  ]);
 
 
   useEffect(() => {
-    if (status === "exporting") {
-      document.title = `Exporting ${progress}% | Reframe`;
-    } else if (status === "loading-engine") {
-      document.title = `Loading engine... | Reframe`;
-    } else if (status === "done") {
-      document.title = `Export complete | Reframe`;
-    } else if (file) {
+    if (file) {
       document.title = `Editing: ${file.name} | Reframe`;
     } else {
       document.title = DEFAULT_TITLE;
@@ -556,42 +443,7 @@ export function useVideoEditor() {
     return () => {
       document.title = DEFAULT_TITLE;
     };
-  }, [status, progress, file]);
-
-  useEffect(() => {
-    const shouldWarn =
-      status === "exporting" ||
-      status === "loading-engine";
-
-    if (!shouldWarn) return;
-
-    const handler = (e: BeforeUnloadEvent) => {
-      e.preventDefault();
-      e.returnValue = "";
-    };
-
-    window.addEventListener("beforeunload", handler);
-    return () => window.removeEventListener("beforeunload", handler);
-  }, [status]);
-  
-  useEffect(() => {
-    const handleKeydown = (e: KeyboardEvent) => {
-      if (
-        (e.ctrlKey || e.metaKey) &&
-        e.key === "Enter" &&
-        file &&
-        status !== "loading-engine" &&
-        status !== "exporting"
-      ) {
-        handleExport();
-      }
-    };
-
-    document.addEventListener("keydown", handleKeydown);
-    return () => {
-      document.removeEventListener("keydown", handleKeydown);
-    };
-  }, [file, status, handleExport]);
+  }, [file]);
 
   // M key: toggle audio mute — only when a file is loaded and focus isn't in a text field
   useEffect(() => {
@@ -618,13 +470,7 @@ export function useVideoEditor() {
     };
   }, [file]);
 
-  useEffect(()=>{
-    return ()=>{
-      if(result?.blobUrl){
-        URL.revokeObjectURL(result.blobUrl);
-      }
-    }
-   },[result?.blobUrl])
+
 
   useEffect(() => {
     return () => {
@@ -641,35 +487,18 @@ export function useVideoEditor() {
     }
   }, []);
 
-  const cancelExport = useCallback(() => {
-    exportCancelledRef.current = true;
-    exportAbortControllerRef.current?.abort();
-    exportAbortControllerRef.current = null;
-    terminateFFmpeg();
-    setStatus("idle");
-    setProgress(0);
-    setError(null);
-    setExportStartedAt(null);
-  }, []);
-
-
   const reset = useCallback(() => {
-    if (result?.blobUrl) URL.revokeObjectURL(result.blobUrl);
     setFile(null);
     setVideoMetadata(null);
     setDuration(0);
     setRecipe(DEFAULT_RECIPE);
-    setStatus("idle");
-    setProgress(0);
-    setResult(null);
-    setError(null);
-    setExportStartedAt(null);
+    setFileError("");
     try {
       localStorage.removeItem(STORAGE_KEY);
     } catch {
       // ignore
     }
-  }, [result]);
+  }, []);
 
 
   useEffect(() => {
@@ -696,18 +525,12 @@ export function useVideoEditor() {
     file,
     duration,
     recipe,
-    status,
-    progress,
-    exportStartedAt,
-    result,
-    error,
+    videoMetadata,
     videoRef,
     seekTo,
     updateRecipe,
     handleFileSelect,
     fileError,
-    handleExport,
-    cancelExport,
     reset,
     resetSettings,
     musicFile,


### PR DESCRIPTION
## Description

This PR introduces a background rendering queue for video exports, resolving #1253. It unblocks the main editor UI during exports, allowing users to continue interacting with the app, change settings, or upload new files while FFmpeg processes videos in the background.

### Closes
Closes #1253

### Changes Included
- **Global Export Context**: Implemented `ExportQueueContext` which acts as the single source of truth for all export jobs. It manages state globally rather than being tied to the editor lifecycle.
- **Floating Queue UI**: Added `ExportQueuePanel`, a floating panel that tracks the progress of queued, active, completed, and failed jobs. Users can minimize/maximize this panel, cancel jobs, and download their finished videos directly from here.
- **Sequential Mutex Processing**: FFmpeg jobs are now processed sequentially via a queue mutex. This ensures the browser does not run out of memory or crash the CPU by attempting parallel `ffmpeg.wasm` operations.
- **Decoupled Editor UI**: Removed the blocking full-screen `ExportOverlay` and inline `DownloadResult` from `VideoEditor.tsx`.
- **Hooks Refactor**: Cleaned up `useVideoEditor.ts` to no longer handle individual local export tracking, shifting responsibilities to the central queue manager.

### How to Test
1. Upload a video file into the editor.
2. Hit the "Export" button. Observe that the main editor UI remains unlocked.
3. Check the floating queue panel in the bottom right corner—it should accurately reflect the active export progress.
4. Upload a second video and initiate another export while the first is running. Ensure the second job is added to the "Queued" list and begins strictly after the first one finishes.
5. Once a job is complete, test the download button within the queue panel.
6. Trigger an export and hit the cancel ("X") button in the queue to verify termination of the FFmpeg process.

