### PR TITLE
fix: check RIFF subtype bytes 8-11 to reject WAV/WebP as valid AVI

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -54,7 +54,7 @@ function verifyMagicBytes(file: File): Promise<boolean> {
       // WebM / MKV
       if (hex.startsWith("1A45DFA3")) resolve(true);
       // AVI
-      else if (hex.startsWith("52494646")) resolve(true);
+      else if (hex.startsWith("52494646") && hex.substring(16, 24) === "41564920") resolve(true);
       // MP4 / MOV (checks for 'ftyp' in first 12 bytes)
       else if (ascii.substring(0, 12).includes("ftyp")) resolve(true);
       else resolve(false);


### PR DESCRIPTION
Fixes #1245

## Problem
verifyMagicBytes in src/hooks/useVideoEditor.ts was checking only 
the first 4 bytes (RIFF header) to validate AVI files. Since WAV 
and WebP also start with RIFF, audio/image files were incorrectly 
passing all validation layers and reaching FFmpeg.

## Fix
Also verify bytes 8–11 equal "AVI " (hex: 41564920), which is the 
RIFF subtype identifier unique to AVI containers.

## Before
else if (hex.startsWith("52494646")) resolve(true);

## After
else if (hex.startsWith("52494646") && hex.substring(16, 24) === "41564920") resolve(true);