### PR TITLE
fix: revoke blob URL in handleFileSelect to prevent memory leak

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -366,6 +366,7 @@ export function useVideoEditor() {
   }, [videoMetadata]);
 
   const handleFileSelect = useCallback(async (selectedFile: File) => {
+    if (result?.blobUrl) URL.revokeObjectURL(result.blobUrl);
     setResult(null);
     setStatus("idle");
     setError(null);


### PR DESCRIPTION
Fixes #1244

## Problem
handleFileSelect called setResult(null) to clear the previous export 
from React state but never called URL.revokeObjectURL on the old blob 
URL first. The exported ArrayBuffer remained in memory for the full 
browser session, leaking the full export size on every new file load.

## Fix
Added URL.revokeObjectURL(result.blobUrl) in handleFileSelect before 
setResult(null), matching the existing pattern already used in 
handleExport and reset.