### PR TITLE
fix: use font= for system fonts and avoid duplicate fontfile= in buildTextFilter

### DIFF
--- a/src/lib/text-overlay.ts
+++ b/src/lib/text-overlay.ts
@@ -92,10 +92,10 @@ export function buildTextFilter(
   let filter = `drawtext=text='${escapedText}':x=${pixelX}:y=${pixelY}:fontsize=${overlay.fontSize}:fontcolor=${overlay.color}:fontweight=${fontWeightParam}`;
 
   // Add font family if specified
-  if (overlay.fontFamily) {
+  if (overlay.fontFamily && !fontFileParam) {
     // Sanitize font name for FFmpeg
     const safeFontName = overlay.fontFamily.replace(/[^a-zA-Z0-9-]/g, "");
-    filter += `:fontfile='${safeFontName}'`;
+    filter += `:font='${safeFontName}'`;
   }
 
   // Add custom font file path if available


### PR DESCRIPTION
Fixes #1243

## Problem
buildTextFilter in src/lib/text-overlay.ts had two bugs:

1. System fonts (Arial, Roboto, Poppins etc.) were passed as
   fontfile='Arial' — but fontfile expects a filesystem path, not a 
   font name. FFmpeg silently fell back to its default font (Vera), 
   so the user's chosen font was never applied to the exported video.

2. Custom uploaded fonts ended up with duplicate fontfile= arguments:
   fontfile='CustomName':fontfile=/path/to/font.ttf
   causing FFmpeg to reject the export entirely.

## Fix
- System fonts now use :font='FamilyName' (correct FFmpeg parameter)
  only when no custom fontfile path exists
- Custom fonts continue using :fontfile=/path only, with no redundant
  font-family argument added