### PR TITLE
feat: add real-time rotate preview transformations

### DIFF
--- a/src/components/ComparisonPreview.tsx
+++ b/src/components/ComparisonPreview.tsx
@@ -175,7 +175,10 @@ export default function ComparisonPreview({ file, recipe, videoRef }: Props) {
         {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
         <video
           ref={leftVideoRef}
-          className="absolute inset-0 w-full h-full object-contain"
+          className="absolute inset-0 w-full h-full object-contain transition-all duration-300"
+          style={{
+            transform: `rotate(${recipe?.rotate || 0}deg)`,
+          }}
           playsInline
           muted
         >
@@ -192,7 +195,10 @@ export default function ComparisonPreview({ file, recipe, videoRef }: Props) {
           {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
           <video
             ref={rightVideoRef}
-            className="w-full h-full object-contain"
+            className="w-full h-full object-contain transition-all duration-300"
+            style={{
+              transform: `rotate(${recipe?.rotate || 0}deg)`,
+            }}
             playsInline
             muted
             autoPlay

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -233,7 +233,13 @@ export default function VideoPreview({
         <video
           ref={videoRef}
           controls
-          className={cn("w-full h-full object-contain transition-opacity duration-300", isLoading ? "opacity-0" : "opacity-100")}
+          className={cn(
+            "w-full h-full object-contain transition-all duration-300",
+            isLoading ? "opacity-0" : "opacity-100"
+          )}
+          style={{
+            transform: `rotate(${recipe?.rotate || 0}deg)`,
+          }}
           onLoadedData={() => setIsLoading(false)}
           playsInline
           muted={!recipe?.keepAudio}


### PR DESCRIPTION
## Description

Added real-time rotate transformation previews for both `VideoPreview` and `ComparisonPreview` components using CSS transforms.

Users can now instantly preview rotate transformations (90°, 180°, 270°) before exporting videos.

## Related Issue

Closes #1185

## Type of Contribution

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [ ] Refactor
* [x] GSSoC contribution

## Participant Info

* GitHub username: srinidhi-2006-bit
* Contribution level: Intermediate

## Screen Recording

**Recording / Loom link: 

https://github.com/user-attachments/assets/3323a996-d890-4db5-96ce-20c8e024dec7



## Changes Made

* Added real-time rotation preview support
* Applied CSS transform rotation in `VideoPreview`
* Applied rotation transforms in `ComparisonPreview`
* Added smooth transition effects for rotation updates
* Improved UX by reflecting transformations before export

## How to Test

1. Run:

   ```bash
   npm run dev
   ```

2. Upload a sample video

3. Apply rotate transformations:

   * 90°
   * 180°
   * 270°

4. Verify preview updates instantly before export

5. Verify comparison preview also reflects rotation changes

## Checklist

* [x] I have read the contribution guidelines
* [x] My changes follow the project structure
* [x] I have tested my changes locally
* [x] `npm run lint` passes (no ESLint errors)
* [x] `npx tsc --noEmit` passes (no TypeScript errors)
* [x] New interactive elements have accessible labels
* [x] No `console.log` statements left in
* [x] This PR is related to a valid issue
* [x] Screen recording attached above
