### PR TITLE
fix: add aria-labels to video elements in ComparisonPreview

### DIFF
--- a/src/components/ComparisonPreview.tsx
+++ b/src/components/ComparisonPreview.tsx
@@ -178,6 +178,7 @@ export default function ComparisonPreview({ file, recipe, videoRef }: Props) {
           className="absolute inset-0 w-full h-full object-contain"
           playsInline
           muted
+          aria-label="Original video"
         >
           <track kind="captions" />
         </video>
@@ -197,6 +198,7 @@ export default function ComparisonPreview({ file, recipe, videoRef }: Props) {
             muted
             autoPlay
             loop
+            aria-label="Reframed video preview"
           >
             <track kind="captions" />
           </video>


### PR DESCRIPTION
## What does this PR do?
Adds `aria-label` attributes to both video elements in 
`ComparisonPreview.tsx` so screen reader users can distinguish 
between the original and reframed video in the comparison view.

## Related issue
Closes #1090

## Changes made
- `src/components/ComparisonPreview.tsx` — added `aria-label="Original video"` 
  to the left video element and `aria-label="Reframed video preview"` 
  to the right video element

## How to test
1. Open the editor at localhost:3000
2. Upload a video file
3. Click the Compare button in the video preview
4. Open DevTools (F12) → Accessibility tab
5. Inspect both video elements — confirm aria-labels are present
6. Use a screen reader — confirm each video is announced correctly

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue