### PR TITLE
fix: configure path alias resolution in Vitest to fix broken tests

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config'
+import path from 'path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   oxc: {
     jsx: {
       runtime: 'automatic',


### PR DESCRIPTION
### Description
Currently, when running the test suite with `bun run test`, several test files fail because Vitest cannot resolve the `@/` path alias. This happens because Next.js path aliases are not automatically configured in `vitest.config.ts`.

### Solution
This PR adds standard Node `path` resolution configuration to `vitest.config.ts` mapping `@/` to the `./src` directory. This is extremely clean, uses no extra npm packages, and enables all 77 tests across all 10 test files to run and pass successfully.

Closes #1320

---
I am contributing on behalf of GSSoc’26.