### PR TITLE
feat: make playback speed step labels interactive in AudioSpeedControl

### DIFF
--- a/src/components/AudioSpeedControl.tsx
+++ b/src/components/AudioSpeedControl.tsx
@@ -103,14 +103,25 @@ export default function AudioSpeedControl({ recipe, onChange }: Props) {
           className="w-full h-11 accent-film-600 cursor-pointer"
         />
         <div className="flex justify-between mt-1 overflow-hidden">
-          {SPEED_STEPS.map((s) => (
-            <span
-              key={s}
-              className="text-sm text-[var(--muted)] truncate text-center min-w-0 px-[1px]"
-            >
-              {s}x
-            </span>
-          ))}
+          {SPEED_STEPS.map((s) => {
+            const isActive = recipe.speed === s;
+            return (
+              <button
+                key={s}
+                type="button"
+                onClick={() => onChange({ speed: s })}
+                aria-label={`Set speed to ${s}x`}
+                className={cn(
+                  "text-xs transition-colors duration-150 px-1.5 py-0.5 rounded hover:text-[var(--text)] hover:bg-[var(--accent-muted)]",
+                  isActive 
+                    ? "text-film-600 font-bold bg-[var(--accent-muted)]" 
+                    : "text-[var(--muted)]"
+                )}
+              >
+                {s}x
+              </button>
+            );
+          })}
         </div>
       </div>
 


### PR DESCRIPTION
### Description
In the audio speed control panel, the step labels (`0.25x`, `0.5x`, etc.) below the slider were static text. Users had to manually drag the slider thumb, which could be frustrating or imprecise.

### Solution
This PR converts these static `<span>` elements into fully interactive `<button>` elements. Clicking any speed label now instantly updates the playback speed and range slider. It also applies theme-consistent hover states and highlights the active speed step with a high-contrast style.

Closes #1321

---
I am contributing on behalf of GSSoc’26.