### PR TITLE
feat: improve ScrollToTop button visibility, iconography, and animations

### DIFF
--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { ArrowUp } from "lucide-react";
 
 export default function ScrollToTop() {
   const [isVisible, setIsVisible] = useState(false);
@@ -36,10 +37,12 @@ export default function ScrollToTop() {
         h-12 w-12 rounded-full
         bg-[var(--accent)] text-white shadow-[var(--shadow)]
         flex items-center justify-center
-        md:hidden
+        transition-[background-color,transform] duration-200
+        hover:bg-[var(--accent-hover)] hover:scale-110 active:scale-95
+        focus:outline-none focus:ring-2 focus:ring-[var(--accent)] focus:ring-offset-2 focus:ring-offset-[var(--bg)]
       "
     >
-      ↑
+      <ArrowUp size={20} aria-hidden="true" />
     </button>
   );
 }


### PR DESCRIPTION
### Description
The current `ScrollToTop` button had a few visibility and styling shortcomings:
1. It was hidden on desktop viewports via `md:hidden`, despite being beneficial for all screen sizes.
2. It used a raw Unicode character `↑` rather than the standard Lucide icons used throughout the project.
3. It lacked smooth micro-interactions (hover scale transitions) and focus states for keyboard accessibility.

### Solution
This PR:
1. Removes the `md:hidden` class to show the button on all viewports when scrolling past 300px.
2. Replaces the text arrow with the standard `<ArrowUp size={20} />` icon from `lucide-react`.
3. Adds smooth hover and active scale animations (`hover:scale-110 active:scale-95`), background shifts, and proper keyboard focus ring outlines.

Closes #1322

---
I am contributing on behalf of GSSoc’26.