### PR TITLE
fix: add catch handler for clipboard writeText in handleCopyLink #1227

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -258,6 +258,8 @@ export default function VideoEditor() {
     navigator.clipboard.writeText(url.toString()).then(() => {
       setShareCopied(true);
       setTimeout(() => setShareCopied(false), 2000);
+    }).catch((err) => {
+      console.error("Failed to copy link to clipboard:", err);
     });
   };
 


### PR DESCRIPTION
## Purpose & Rationale
The "Copy Link" button in VideoEditor called navigator.clipboard.writeText() without a .catch() handler. If the Clipboard API rejects due to permission denial, insecure context, or focus loss, the unhandled promise rejection propagates silently with no user feedback.

## Technical Resolution Details
Added a .catch((err) => { console.error(...); }) handler after the existing .then() in the handleCopyLink function at src/components/VideoEditor.tsx:261-263. The fix mirrors the identical error-handling pattern already used for the "Copy error" clipboard call at line 663. Closes #1227.

## Local Testing Execution
1. ran bunx tsc --noEmit — zero type errors
2. Manually confirmed the .catch() syntax matches the established error-handling pattern at VideoEditor.tsx line 663

## Desired Review Feedback Type
Verify the error message text is appropriate and confirm no additional user-facing toast is needed for clipboard failure.

## Integrity & AI Usage Disclosure
In compliance with the GSSoC 2026 AI Conduct rules, I disclose that AI tools were used solely as learning and boilerplate aids. The final logic was fully reviewed, tested, and manually adapted to match human styling and clean-code design.