### PR TITLE
feat: keyboard shortcuts trim in out

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -152,6 +152,14 @@ function KeyboardShortcutsPanel() {
     keys: [<Kbd key="question">?</Kbd>],
     label: "Toggle this panel",
   },
+  {
+    keys: [<Kbd key="i">I</Kbd>],
+    label: "Set trim in point",
+  },
+  {
+    keys: [<Kbd key="o">O</Kbd>],
+    label: "Set trim out point",
+  },
 ];
 
   return (

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -221,6 +221,8 @@ export default function VideoEditor() {
     status,
     cancelExport,
     onToggleShortcutsModal: () => {},
+    currentTime,
+    duration,
   });
 
   const [copied, setCopied] = useState(false);

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,6 +1,6 @@
-import { useEffect } from "react";
 import { EditRecipe, ExportStatus } from "@/lib/types";
 import { PRESETS } from "@/lib/presets";
+import { useEffect, useRef } from "react";
 
 interface UseKeyboardShortcutsProps {
   file: File | null;
@@ -27,6 +27,10 @@ export function useKeyboardShortcuts({
   currentTime,
   duration,
 }: UseKeyboardShortcutsProps) {
+  const currentTimeRef = useRef(currentTime);
+  useEffect(() => {
+    currentTimeRef.current = currentTime;
+  }, [currentTime]);
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement;
@@ -68,11 +72,11 @@ export function useKeyboardShortcuts({
           break;
         case "i":
         case "I":
-          updateRecipe({trimStart: Math.floor(currentTime)});
+          updateRecipe({trimStart: Math.floor(currentTimeRef.current)});
           break;
         case "o":
         case "O":
-          updateRecipe({trimEnd: Math.floor(currentTime)});
+          updateRecipe({trimEnd: Math.floor(currentTimeRef.current)});
           break;
 
         default:

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -11,6 +11,8 @@ interface UseKeyboardShortcutsProps {
   status: ExportStatus;
   cancelExport: () => void;
   onToggleShortcutsModal: () => void;
+  currentTime: number;
+  duration: number;
 }
 
 export function useKeyboardShortcuts({
@@ -22,6 +24,8 @@ export function useKeyboardShortcuts({
   status,
   cancelExport,
   onToggleShortcutsModal,
+  currentTime,
+  duration,
 }: UseKeyboardShortcutsProps) {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -62,6 +66,14 @@ export function useKeyboardShortcuts({
         case "?":
           onToggleShortcutsModal();
           break;
+        case "i":
+        case "I":
+          updateRecipe({trimStart: Math.floor(currentTime)});
+          break;
+        case "o":
+        case "O":
+          updateRecipe({trimEnd: Math.floor(currentTime)});
+          break;
 
         default:
           if (e.key >= "1" && e.key <= "9") {
@@ -75,5 +87,5 @@ export function useKeyboardShortcuts({
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [file, recipe, resetSettings, updateRecipe, handleExport, status, cancelExport, onToggleShortcutsModal]);
+  }, [file, recipe, resetSettings, updateRecipe, handleExport, status, cancelExport, onToggleShortcutsModal, currentTime, duration]);
 }

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -686,7 +686,7 @@ export function useVideoEditor() {
     const handleTimeUpdate = () => setCurrentTime(video.currentTime);
     video.addEventListener("timeupdate", handleTimeUpdate);
     return () => video.removeEventListener("timeupdate", handleTimeUpdate);
-  },[]);
+  });
 
   const toggleSound = useCallback(() => {
   updateRecipe({ soundOnCompletion: !recipe.soundOnCompletion });


### PR DESCRIPTION
## Description
Added `I` and `O` keyboard shortcuts to set trim in/out points at the current playback position, following the industry-standard video editor convention. Pressing `I` sets the trim start and `O` sets the trim end to the current video timestamp.

Also fixed a bug discovered during implementation: the `useEffect` responsible for tracking `currentTime` in `useVideoEditor.ts` had an empty dependency array `[]`, which caused `videoRef.current` to always be `null` on the first render, meaning the `timeupdate` listener was never attached and `currentTime` always stayed `0`. Removing the dependency array fixes this — the cleanup function ensures no listener stacking occurs.

## Related Issue
Closes #1158 
## Type of Contribution
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor



- [x] GSSoC contribution

## Participant Info
- GitHub username: @Kr1491 
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Screen Recording
https://github.com/user-attachments/assets/ebbadeb3-2d01-457b-8282-531ffe4d7e22

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [ ] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue