### PR TITLE
feat: surface estimated export size near Export button and fix preset…

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -18,6 +18,10 @@ import ExportOverlay from "./ExportOverlay";
 import DownloadResult from "./DownloadResult";
 import ImageOverlay from "./ImageOverlay"
 import { getPresetById } from "@/lib/presets";
+import {
+  estimateExportSize,
+  formatEstimatedSize,
+} from "@/lib/exportEstimate";
 
 import { cn } from "@/lib/utils";
 import {
@@ -301,6 +305,15 @@ export default function VideoEditor() {
 
     return `Exporting to ${width}×${height} ${recipe.format.toUpperCase()} • ${framingLabel} • ${speedLabel} • Quality: ${qualityLabel}`;
   }, [recipe]);
+
+  const estimatedSizeMb = useMemo(
+    () => estimateExportSize(recipe, duration),
+    [recipe, duration]
+  );
+  const estimatedSizeLabel = useMemo(
+    () => formatEstimatedSize(estimatedSizeMb),
+    [estimatedSizeMb]
+  );
 
   useEffect(() => {
     return () => {
@@ -747,6 +760,24 @@ export default function VideoEditor() {
               <p className="rounded-xl border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-xs text-[var(--muted)] leading-relaxed">
                 {exportSummary}
               </p>
+            )}
+
+            {file && (
+              <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3 animate-fade-in">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-heading font-semibold uppercase tracking-wider text-[var(--muted)]">
+                    Estimated size
+                  </span>
+                  <span className="text-sm font-heading font-bold text-film-600">
+                    {estimatedSizeLabel}
+                  </span>
+                </div>
+                {recipe.format === "gif" && estimatedSizeMb >= 100 && (
+                  <p className="mt-2 text-xs text-[var(--warning)] font-medium">
+                    ⚠ Large GIF detected ({estimatedSizeLabel}). Consider trimming the clip or switching to MP4/WebM for a smaller file.
+                  </p>
+                )}
+              </div>
             )}
 
             <button

--- a/src/lib/exportEstimate.test.ts
+++ b/src/lib/exportEstimate.test.ts
@@ -1,11 +1,12 @@
 import { estimateExportSize, formatEstimatedSize } from "./exportEstimate";
 import { EditRecipe } from "./types";
+import { PRESETS } from "./presets";
 import { describe, test, expect } from "vitest";
 
 // Minimal recipe factory — only the fields estimateExportSize cares about
 function makeRecipe(overrides: Partial<EditRecipe> = {}): EditRecipe {
   return {
-    preset: "1080p",
+    preset: "landscape-16-9",
     customWidth: 1920,
     customHeight: 1080,
     quality: 23,       // default CRF
@@ -13,6 +14,7 @@ function makeRecipe(overrides: Partial<EditRecipe> = {}): EditRecipe {
     trimStart: 0,
     trimEnd: null,
     format: "mp4",
+    keepAudio: true,
     // fields estimateExportSize doesn't touch — kept minimal
     stabilization: false,
     soundOnCompletion: false,
@@ -20,7 +22,11 @@ function makeRecipe(overrides: Partial<EditRecipe> = {}): EditRecipe {
     contrast: 1,
     saturation: 1,
     framing: "fit",
-    rotation: 0,
+    rotate: 0,
+    denoise: false,
+    normalizeAudio: false,
+    textOverlays: [],
+    version: 1,
     ...overrides,
   } as EditRecipe;
 }
@@ -49,9 +55,9 @@ describe("estimateExportSize", () => {
     expect(long / short).toBeCloseTo(4, 0);
   });
 
-  test("higher resolution (4k) produces a larger estimate than 720p", () => {
-    const hd  = estimateExportSize(makeRecipe({ preset: "720p" }), 60);
-    const uhd = estimateExportSize(makeRecipe({ preset: "4k"   }), 60);
+  test("higher resolution (ultrawide-21-9) produces a larger estimate than twitter-hd", () => {
+    const hd  = estimateExportSize(makeRecipe({ preset: "twitter-hd" }), 60);
+    const uhd = estimateExportSize(makeRecipe({ preset: "ultrawide-21-9" }), 60);
     expect(uhd).toBeGreaterThan(hd);
   });
 
@@ -80,7 +86,7 @@ describe("estimateExportSize", () => {
     expect(large).toBeGreaterThan(small);
   });
 
-  test("returns a reasonable size for a 1-minute 1080p CRF-23 mp4 (2–5 MB)", () => {
+  test("returns a reasonable size for a 1-minute 1080p CRF-23 mp4 (5–200 MB)", () => {
     // Real-world expectation: a 1-min 1080p H.264 file at CRF 23 is typically
     // 20–100 MB depending on content. Our estimate should be in the right ballpark.
     const size = estimateExportSize(makeRecipe(), 60);
@@ -92,6 +98,30 @@ describe("estimateExportSize", () => {
     // trimStart === trimEnd → clamped to 1 s minimum inside the function
     const size = estimateExportSize(makeRecipe({ trimStart: 10, trimEnd: 10 }), 60);
     expect(size).toBeGreaterThan(0);
+  });
+
+  test("all canonical preset IDs resolve to correct dimensions", () => {
+    // Ensures getOutputDimensions uses the real preset registry
+    for (const preset of PRESETS) {
+      if (preset.id === "custom") continue;
+      const withPreset = makeRecipe({ preset: preset.id });
+      const size = estimateExportSize(withPreset, 60);
+      expect(size).toBeGreaterThan(0);
+
+      // A wider/taller preset should yield a larger estimate than a very
+      // small custom preset at the same settings
+      const tiny = estimateExportSize(
+        makeRecipe({ preset: "custom", customWidth: 160, customHeight: 90 }),
+        60
+      );
+      expect(size).toBeGreaterThan(tiny);
+    }
+  });
+
+  test("muting audio produces a slightly smaller estimate", () => {
+    const withAudio    = estimateExportSize(makeRecipe({ keepAudio: true }), 60);
+    const withoutAudio = estimateExportSize(makeRecipe({ keepAudio: false }), 60);
+    expect(withoutAudio).toBeLessThan(withAudio);
   });
 });
 
@@ -119,4 +149,4 @@ describe("formatEstimatedSize", () => {
       expect(formatEstimatedSize(n)).toMatch(/^~/);
     });
   });
-});
+});

--- a/src/lib/exportEstimate.ts
+++ b/src/lib/exportEstimate.ts
@@ -1,33 +1,16 @@
 import { EditRecipe } from "./types";
-
-// ---------------------------------------------------------------------------
-// Preset dimension map
-// Keep in sync with src/lib/presets.ts. Width × height for every named preset.
-// ---------------------------------------------------------------------------
-const PRESET_DIMENSIONS: Record<string, { width: number; height: number }> = {
-  "1080p":       { width: 1920, height: 1080 },
-  "720p":        { width: 1280, height: 720  },
-  "480p":        { width: 854,  height: 480  },
-  "360p":        { width: 640,  height: 360  },
-  "4k":          { width: 3840, height: 2160 },
-  "2k":          { width: 2560, height: 1440 },
-  // Square / portrait presets
-  "square-1080": { width: 1080, height: 1080 },
-  "square-720":  { width: 720,  height: 720  },
-  "portrait-1080": { width: 1080, height: 1920 },
-  "portrait-720":  { width: 720,  height: 1280 },
-  // Fallback — if a preset name is unrecognised we fall through to customWidth/H
-};
+import { getPresetById } from "./presets";
 
 /**
  * Resolve the actual output pixel dimensions for a recipe.
- * When a named preset is active we look it up; otherwise we use
- * the custom width/height the user typed in.
+ * Uses the canonical preset registry from presets.ts so IDs stay in sync
+ * automatically. Falls back to customWidth/customHeight for the "custom"
+ * preset or any unrecognised ID.
  */
 function getOutputDimensions(recipe: EditRecipe): { width: number; height: number } {
   if (recipe.preset !== "custom") {
-    const dims = PRESET_DIMENSIONS[recipe.preset];
-    if (dims) return dims;
+    const preset = getPresetById(recipe.preset);
+    if (preset) return { width: preset.width, height: preset.height };
   }
   return { 
     width: recipe.customWidth || 1920, 


### PR DESCRIPTION
## Description
Surfaces the estimated export file size prominently near the Export button 
in the sidebar, so users can see it without opening the Export Settings 
accordion. Also fixes a stale preset dimension lookup in exportEstimate.ts 
that used legacy IDs like "1080p" instead of the actual preset IDs like 
"landscape-16-9". Adds a GIF warning when estimated size is >= 100 MB.

## Related Issue
Closes #645

## Type of Contribution
- [x] New feature
- [x] GSSoC contribution

## Participant Info
- GitHub username: Lost-glitched
- Contribution level (Beginner/Intermediate/Advanced): Advanced

## Screen Recording

https://github.com/user-attachments/assets/886112c2-6125-499e-b4d1-51e544bc8c61



## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] bun run lint passes (no ESLint errors)
- [x] bunx tsc --noEmit passes (no TypeScript errors)
- [x] No console.log statements left in
- [x] This PR is related to a valid issue
- [x] Screen recording attached above