### PR TITLE
fix: transfer custom font files to FFmpeg WASM VFS during export

### DIFF
--- a/src/hooks/useFontManager.ts
+++ b/src/hooks/useFontManager.ts
@@ -11,6 +11,7 @@ import {
   initializeFontRegistry,
   clearCustomFonts,
   ensureFontLoaded,
+  storeFontFile,
 } from "@/utils/fontLoader";
 
 export interface CustomFont {
@@ -91,6 +92,7 @@ export function useFontManager(): UseFontManagerReturn {
         // Register in DOM
         try {
           registerCustomFont(fontName, blobUrl);
+          storeFontFile(fontName, file);
           
           // Ensure font is loaded before allowing render
           // This prevents fallback font flashing

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -1,6 +1,7 @@
 import { EditRecipe, ExportResult, BackgroundMusicOptions, ImageOverlayOptions } from "./types";
 import { getPresetById } from "./presets";
 import { buildTextFilter } from "./text-overlay";
+import { getFontFileEntry } from "@/utils/fontLoader";
 
 export class FFmpegLoadError extends Error {}
 
@@ -8,6 +9,12 @@ export class FFmpegLoadError extends Error {}
 type SerializedFile = {
   name: string;
   type: string;
+  data: ArrayBuffer;
+};
+
+type FontSerializedFile = {
+  name: string;
+  extension: string;
   data: ArrayBuffer;
 };
 
@@ -21,6 +28,7 @@ type WorkerExportRequest = {
   musicOptions?: BackgroundMusicOptions;
   overlayFile?: SerializedFile;
   overlayOptions?: ImageOverlayOptions;
+  fontFiles?: FontSerializedFile[];
 };
 
 type WorkerLoadResponse = { type: "ready" };
@@ -252,6 +260,19 @@ export async function exportVideo(
     ? { ...overlayOptions, file: null }
     : undefined;
 
+  const seenFonts = new Set<string>();
+  const fontFiles: FontSerializedFile[] = [];
+  for (const overlay of recipe.textOverlays) {
+    if (overlay.fontFamily && !seenFonts.has(overlay.fontFamily)) {
+      seenFonts.add(overlay.fontFamily);
+      const entry = getFontFileEntry(overlay.fontFamily);
+      if (entry) {
+        const data = await entry.file.arrayBuffer();
+        fontFiles.push({ name: overlay.fontFamily, extension: entry.extension, data });
+      }
+    }
+  }
+
   pendingProgress = onProgress;
 
   const exportPromise = new Promise<ExportResult>((resolve, reject) => {
@@ -273,6 +294,7 @@ export async function exportVideo(
   const transfers: Transferable[] = [arrayBuffer];
   if (musicFilePayload) transfers.push(musicFilePayload.data);
   if (overlayFilePayload) transfers.push(overlayFilePayload.data);
+  for (const f of fontFiles) transfers.push(f.data);
 
   ffmpegWorker.postMessage(
     {
@@ -285,6 +307,7 @@ export async function exportVideo(
       musicOptions: sanitizedMusicOptions,
       overlayFile: overlayFilePayload,
       overlayOptions: sanitizedOverlayOptions,
+      fontFiles: fontFiles.length > 0 ? fontFiles : undefined,
     } as WorkerExportRequest,
     transfers
   );

--- a/src/lib/ffmpeg.worker.ts
+++ b/src/lib/ffmpeg.worker.ts
@@ -17,6 +17,12 @@ type SerializedFile = {
   data: ArrayBuffer;
 };
 
+type FontSerializedFile = {
+  name: string;
+  extension: string;
+  data: ArrayBuffer;
+};
+
 type ExportRequest = {
   type: "export";
   id: string;
@@ -27,6 +33,7 @@ type ExportRequest = {
   musicOptions?: BackgroundMusicOptions;
   overlayFile?: SerializedFile;
   overlayOptions?: ImageOverlayOptions;
+  fontFiles?: FontSerializedFile[];
 };
 
 type LoadRequest = { type: "load" };
@@ -429,6 +436,31 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
     });
   }
 
+  const fontVfsPaths = new Map<string, string>();
+  if (request.fontFiles) {
+    for (const fontFile of request.fontFiles) {
+      const vfsPath = `custom_font_${sessionId}_${fontFile.name}.${fontFile.extension}`;
+      await ffmpeg.writeFile(vfsPath, new Uint8Array(fontFile.data), {
+        signal: activeExportAbortController?.signal,
+      });
+      cleanupFiles.add(vfsPath);
+      fontVfsPaths.set(fontFile.name, vfsPath);
+    }
+  }
+
+  let patchedRecipe: EditRecipe = recipe;
+  if (fontVfsPaths.size > 0) {
+    patchedRecipe = {
+      ...recipe,
+      textOverlays: recipe.textOverlays.map(o => {
+        if (o.fontFamily && fontVfsPaths.has(o.fontFamily)) {
+          return { ...o, fontPath: fontVfsPaths.get(o.fontFamily)! };
+        }
+        return o;
+      }),
+    };
+  }
+
   const videoDuration = request.videoDuration;
 
   const handleProgress = ({ progress }: { progress: number }) => {
@@ -441,7 +473,7 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
 
   try {
     if (recipe.format === "gif") {
-      const vf = buildVideoFilter(recipe, targetW, targetH);
+      const vf = buildVideoFilter(patchedRecipe, targetW, targetH);
       const vfWithPalette = vf ? `${vf},palettegen` : "palettegen";
       const vfWithPaletteUse = vf
         ? `[0:v]${vf}[x];[x][1:v]paletteuse`
@@ -499,8 +531,8 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
     ffmpeg.on("log", logListener);
 
     let args = buildArguments(
-      recipe,
-      recipe.format,
+      patchedRecipe,
+      patchedRecipe.format,
       outputName,
       inputName,
       targetW,
@@ -522,8 +554,8 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
     if (exitCode !== 0 && missingAudioDetected) {
       missingAudioDetected = false;
       args = buildArguments(
-        recipe,
-        recipe.format,
+        patchedRecipe,
+        patchedRecipe.format,
         outputName,
         inputName,
         targetW,
@@ -544,7 +576,7 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
 
     if (exitCode !== 0) {
       args = buildArguments(
-        recipe,
+        patchedRecipe,
         "webm",
         fallbackOutputName,
         inputName,

--- a/src/utils/__tests__/fontLoader.test.ts
+++ b/src/utils/__tests__/fontLoader.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  storeFontFile,
+  getFontFileEntry,
+  getFFmpegFontArg,
+  registerCustomFont,
+  clearCustomFonts,
+} from "@/utils/fontLoader";
+
+function makeMockFile(name: string): File {
+  return new File(["mock content"], name, { type: "font/ttf" });
+}
+
+describe("storeFontFile / getFontFileEntry", () => {
+  beforeEach(() => {
+    clearCustomFonts();
+  });
+
+  it("stores and retrieves a font file entry", () => {
+    const file = makeMockFile("OpenSans.ttf");
+    storeFontFile("OpenSans", file);
+    const entry = getFontFileEntry("OpenSans");
+    expect(entry).toBeDefined();
+    expect(entry!.file).toBe(file);
+    expect(entry!.extension).toBe("ttf");
+  });
+
+  it("extracts extension from file name", () => {
+    const file = makeMockFile("CustomFont.otf");
+    storeFontFile("CustomFont", file);
+    expect(getFontFileEntry("CustomFont")!.extension).toBe("otf");
+  });
+
+  it("lowers extension case", () => {
+    const file = makeMockFile("Test.TTF");
+    storeFontFile("Test", file);
+    expect(getFontFileEntry("Test")!.extension).toBe("ttf");
+  });
+
+  it("returns undefined for unknown font", () => {
+    expect(getFontFileEntry("NonExistent")).toBeUndefined();
+  });
+
+  it("overwrites existing entry with same name", () => {
+    const fileA = makeMockFile("A.ttf");
+    const fileB = makeMockFile("A.ttf");
+    storeFontFile("MyFont", fileA);
+    storeFontFile("MyFont", fileB);
+    expect(getFontFileEntry("MyFont")!.file).toBe(fileB);
+  });
+});
+
+describe("getFFmpegFontArg", () => {
+  beforeEach(() => {
+    clearCustomFonts();
+  });
+
+  it("returns empty string when no fontFamily and no fontPath", () => {
+    expect(getFFmpegFontArg("", "")).toBe("");
+  });
+
+  it("returns empty string when fontName is empty even if fontPath is set", () => {
+    expect(getFFmpegFontArg("", "/vfs/font.ttf")).toBe("");
+  });
+
+  it("returns empty string for known custom font without fontPath", () => {
+    registerCustomFont("TestFont", "blob:http://test/font");
+    expect(getFFmpegFontArg("TestFont", "")).toBe("");
+  });
+
+  it("returns fontfile arg for custom font with fontPath", () => {
+    registerCustomFont("MyCustomFont", "blob:http://test/font");
+    const result = getFFmpegFontArg("MyCustomFont", "/vfs/custom_font.ttf");
+    expect(result).toBe("fontfile=/vfs/custom_font.ttf");
+  });
+
+  it("returns empty string for built-in fonts regardless of fontPath", () => {
+    expect(getFFmpegFontArg("Arial", "")).toBe("");
+    expect(getFFmpegFontArg("Inter", "/vfs/font.ttf")).toBe("");
+  });
+
+  it("escapes colons in fontPath", () => {
+    registerCustomFont("PathFont", "blob:http://test/font");
+    const result = getFFmpegFontArg("PathFont", "/vfs:with:colons/font.ttf");
+    expect(result).toBe("fontfile=/vfs\\:with\\:colons/font.ttf");
+  });
+});

--- a/src/utils/fontLoader.ts
+++ b/src/utils/fontLoader.ts
@@ -180,6 +180,8 @@ export function clearCustomFonts(): void {
   customFonts.forEach((font) => {
     unregisterCustomFont(font);
   });
+
+  fontFileRegistry.clear();
 }
 
 /**
@@ -275,4 +277,20 @@ export async function ensureFontLoaded(
     // The browser will use fallback fonts
     console.warn(`Font "${fontName}" failed to load:`, err);
   }
+}
+
+type FontFileEntry = {
+  file: File;
+  extension: string;
+};
+
+const fontFileRegistry = new Map<string, FontFileEntry>();
+
+export function storeFontFile(name: string, file: File): void {
+  const ext = (file.name.split(".").pop() || "ttf").toLowerCase();
+  fontFileRegistry.set(name, { file, extension: ext });
+}
+
+export function getFontFileEntry(name: string): FontFileEntry | undefined {
+  return fontFileRegistry.get(name);
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vitest/config'
+import path from 'path'
 
 export default defineConfig({
   oxc: {
     jsx: {
       runtime: 'automatic',
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

Custom fonts uploaded by users via the font manager were never transferred to the FFmpeg WebAssembly virtual filesystem. The drawtext filter received fontfile= arguments pointing to nonexistent paths, causing FFmpeg to silently fall back to Arial for all user fonts. This PR closes the gap by collecting font file data at export time and writing it to the VFS before FFmpeg execution.

## Changes

### `src/utils/fontLoader.ts`
- Added `fontFileRegistry` — a static `Map<string, FontFileEntry>` that stores font `File` objects alongside their file extension
- Added `storeFontFile(name, file)` — called from `useFontManager` when a font is uploaded
- Added `getFontFileEntry(name)` — called from `exportVideo` to retrieve font data
- `clearCustomFonts()` now also clears the font file registry

### `src/hooks/useFontManager.ts`
- Wires `storeFontFile(fontName, file)` after `registerCustomFont()` in the `addFonts` method

### `src/lib/ffmpeg.ts`
- Added `FontSerializedFile` type for transferring font data across Worker postMessage
- Extended `WorkerExportRequest` with optional `fontFiles` array
- Added font collection logic in `exportVideo()`: deduplicates fonts across all `textOverlays`, reads each font file as `ArrayBuffer`, includes in the transfer list for zero-copy semantics

### `src/lib/ffmpeg.worker.ts`
- Extended `ExportRequest` type with `fontFiles` field
- Before export execution, writes each font file to VFS as `custom_font_<sessionId>_<name>.<ext>`
- Creates a `patchedRecipe` copy with `fontPath` set on each overlay pointing to the correct VFS path
- All `buildVideoFilter` and `buildArguments` calls now use the patched recipe

### `vitest.config.ts`
- Added `resolve.alias` for `@/` → `./src` path resolution so tests can import from `@/utils/fontLoader`

## Testing

- 11 new unit tests covering `storeFontFile`, `getFontFileEntry`, and `getFFmpegFontArg` edge cases
- All 88 tests pass
- TypeScript compiles clean (`tsc --noEmit`)
- ESLint passes (`next lint`)

Closes #1350