### PR TITLE
fix: resolve video export crash when text overlays are added

### DIFF
--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -3,6 +3,10 @@ import { getPresetById } from "./presets";
 import { buildTextFilter } from "./text-overlay";
 
 export class FFmpegLoadError extends Error {}
+// Force worker rebuild after final cleanups
+
+
+
 
 
 type SerializedFile = {

--- a/src/lib/ffmpeg.worker.ts
+++ b/src/lib/ffmpeg.worker.ts
@@ -343,6 +343,11 @@ async function loadCore(onProgress?: (percent: number) => void): Promise<void> {
       }),
     });
 
+    // Fetch and write a default font file to MEMFS so that drawtext has a fallback font
+    const fontRes = await fetch("https://cdnjs.cloudflare.com/ajax/libs/ink/3.0.1/fonts/Roboto/roboto-regular-webfont.ttf");
+    const fontBuf = await fontRes.arrayBuffer();
+    await ffmpeg.writeFile("default.ttf", new Uint8Array(fontBuf));
+
     ffmpegLoaded = true;
     onProgress?.(100);
   } finally {

--- a/src/lib/text-overlay.ts
+++ b/src/lib/text-overlay.ts
@@ -78,29 +78,17 @@ export function buildTextFilter(
   const pixelX = Math.round((overlay.x / 100) * targetWidth);
   const pixelY = Math.round((overlay.y / 100) * targetHeight);
 
-  // Build font parameters
-  const fontWeightParam = overlay.fontWeight === "900"
-    ? "bold"
-    : overlay.fontWeight === "bold"
-    ? "bold"
-    : "normal";
-
   // Get font file parameter for custom fonts (if available)
   const fontFileParam = getFFmpegFontArg(overlay.fontFamily, overlay.fontPath);
 
-  // Build the drawtext filter with font support
-  let filter = `drawtext=text='${escapedText}':x=${pixelX}:y=${pixelY}:fontsize=${overlay.fontSize}:fontcolor=${overlay.color}:fontweight=${fontWeightParam}`;
+  // Build the drawtext filter with font support (FFmpeg drawtext does not have a 'fontweight' option)
+  let filter = `drawtext=text='${escapedText}':x=${pixelX}:y=${pixelY}:fontsize=${overlay.fontSize}:fontcolor=${overlay.color}`;
 
-  // Add font family if specified
-  if (overlay.fontFamily) {
-    // Sanitize font name for FFmpeg
-    const safeFontName = overlay.fontFamily.replace(/[^a-zA-Z0-9-]/g, "");
-    filter += `:fontfile='${safeFontName}'`;
-  }
-
-  // Add custom font file path if available
+  // Add custom font file path if available, otherwise fall back to the default font file
   if (fontFileParam) {
     filter += `:${fontFileParam}`;
+  } else {
+    filter += `:fontfile='default.ttf'`;
   }
 
   return filter;


### PR DESCRIPTION
## Description

Resolves the issue where exporting videos containing any text overlay crashes the FFmpeg engine. Removed the invalid `fontweight` argument and added a fallback font file (`default.ttf`) in the WASM virtual filesystem for built-in fonts (Arial, Inter, etc.) so FFmpeg doesn't throw a "No font filename provided" error.

Closes #1343

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

 ## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [ ] **Screen recording attached above** (required for UI/feature/design changes)