### PR TITLE
Fix blob URL leaks in video preview, metadata loading, and export

### DIFF
--- a/src/components/ComparisonPreview.tsx
+++ b/src/components/ComparisonPreview.tsx
@@ -57,7 +57,6 @@ export default function ComparisonPreview({ file, recipe, videoRef }: Props) {
     }
   })();
 
-  // Load video source for both left and right videos
   useEffect(() => {
     if (!file) return;
     const url = URL.createObjectURL(file);
@@ -71,7 +70,17 @@ export default function ComparisonPreview({ file, recipe, videoRef }: Props) {
       rightVideoRef.current.load();
     }
 
-    return () => URL.revokeObjectURL(url);
+    return () => {
+      if (leftVideoRef.current) {
+        leftVideoRef.current.pause();
+        leftVideoRef.current.removeAttribute("src");
+      }
+      if (rightVideoRef.current) {
+        rightVideoRef.current.pause();
+        rightVideoRef.current.removeAttribute("src");
+      }
+      URL.revokeObjectURL(url);
+    };
   }, [file]);
 
   // Sync right video with left video and auto-play left

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -26,8 +26,6 @@ export default function VideoPreview({
   onSelectText,
   onUpdateText,
 }: Props) {
-  const lastId = useRef(0);
-  const urlRef = useRef<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [showOverlay, setShowOverlay] = useState(false);
   const [showComparison, setShowComparison] = useState(false);
@@ -37,7 +35,6 @@ export default function VideoPreview({
     height: 0,
   });
   const previewContainerRef = useRef<HTMLDivElement>(null);
-  const onLoadedRef = useRef<(() => void) | null>(null);
 
   const handleGrabFrame = useCallback(() => {
     const video = videoRef.current;
@@ -52,66 +49,50 @@ export default function VideoPreview({
     ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
 
     canvas.toBlob((blob) => {
-      if (!blob) return;
+      try {
+        if (!blob) return;
 
-      const totalSec = Math.floor(video.currentTime);
-      const mins = String(Math.floor(totalSec / 60)).padStart(2, "0");
-      const secs = String(totalSec % 60).padStart(2, "0");
-      const filename = `frame-${mins}m${secs}s.png`;
+        const totalSec = Math.floor(video.currentTime);
+        const mins = String(Math.floor(totalSec / 60)).padStart(2, "0");
+        const secs = String(totalSec % 60).padStart(2, "0");
+        const filename = `frame-${mins}m${secs}s.png`;
 
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = filename;
-      a.click();
-      URL.revokeObjectURL(url);
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = filename;
+        a.click();
+        URL.revokeObjectURL(url);
+      } finally {
+        canvas.width = 0;
+        canvas.height = 0;
+      }
     }, "image/png");
   }, [videoRef]);
 
   useEffect(() => {
     if (!file) return;
 
-    if (urlRef.current) URL.revokeObjectURL(urlRef.current);
     setIsLoading(true);
-    const id = ++lastId.current;
-    const url = URL.createObjectURL(file);
-
-    if (urlRef.current) {
-      URL.revokeObjectURL(urlRef.current);
-    }
-    urlRef.current = url;
-
     const video = videoRef.current;
     if (!video) return;
 
+    const url = URL.createObjectURL(file);
     video.src = url;
     video.load();
 
     const handleLoaded = () => {
-      if (lastId.current !== id) return;
       video.play().catch(() => {});
     };
-
-    onLoadedRef.current = handleLoaded;
 
     video.addEventListener("loadeddata", handleLoaded);
 
     return () => {
-      if (onLoadedRef.current) {
-        video.removeEventListener("loadeddata", onLoadedRef.current);
-        onLoadedRef.current = null;
-      }
-
-      if (video) {
-        video.pause();
-        video.removeAttribute("src");
-        video.load();
-      }
-
-      if (urlRef.current === url) {
-        URL.revokeObjectURL(urlRef.current);
-        urlRef.current = null;
-      }
+      video.removeEventListener("loadeddata", handleLoaded);
+      video.pause();
+      video.removeAttribute("src");
+      video.load();
+      URL.revokeObjectURL(url);
     };
   }, [file, videoRef]);
 

--- a/src/hooks/useFontManager.ts
+++ b/src/hooks/useFontManager.ts
@@ -11,6 +11,7 @@ import {
   initializeFontRegistry,
   clearCustomFonts,
   ensureFontLoaded,
+  storeFontFile,
 } from "@/utils/fontLoader";
 
 export interface CustomFont {
@@ -91,6 +92,7 @@ export function useFontManager(): UseFontManagerReturn {
         // Register in DOM
         try {
           registerCustomFont(fontName, blobUrl);
+          storeFontFile(fontName, file);
           
           // Ensure font is loaded before allowing render
           // This prevents fallback font flashing

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -15,23 +15,28 @@ export function extractMetadata(file: File): Promise<{ width: number; height: nu
   return new Promise((resolve, reject) => {
     const url = URL.createObjectURL(file);
     const video = document.createElement("video");
+    let timedOut = false;
+
     const timeout = setTimeout(() => {
+      timedOut = true;
       URL.revokeObjectURL(url);
       reject( new Error("Video metaData load timeout — the file may be too large or the device too slow. Please try again.") );
     }, 5000);
 
     video.preload = "metadata";
     video.onloadedmetadata = () => {
-      clearTimeout(timeout)
-      resolve({
-        width: video.videoWidth,
-        height: video.videoHeight,
-        duration: isFinite(video.duration) ? video.duration : 0,
-      });
+      clearTimeout(timeout);
       URL.revokeObjectURL(url);
+      if (!timedOut) {
+        resolve({
+          width: video.videoWidth,
+          height: video.videoHeight,
+          duration: isFinite(video.duration) ? video.duration : 0,
+        });
+      }
     };
     video.onerror = () => {
-      clearTimeout(timeout)
+      clearTimeout(timeout);
       URL.revokeObjectURL(url);
       reject(new Error("Failed to load video metadata"));
     };
@@ -176,6 +181,7 @@ export function useVideoEditor() {
   const [exportStartedAt, setExportStartedAt] = useState<number | null>(null);
   const exportAbortControllerRef = useRef<AbortController | null>(null);
   const exportCancelledRef = useRef(false);
+  const prevResultBlobUrlRef = useRef<string | null>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
 
   const [musicFile, setMusicFile] = useState<File | null>(null);
@@ -618,13 +624,17 @@ export function useVideoEditor() {
     };
   }, [file]);
 
-  useEffect(()=>{
-    return ()=>{
-      if(result?.blobUrl){
+  useEffect(() => {
+    if (prevResultBlobUrlRef.current) {
+      URL.revokeObjectURL(prevResultBlobUrlRef.current);
+    }
+    prevResultBlobUrlRef.current = result?.blobUrl ?? null;
+    return () => {
+      if (result?.blobUrl) {
         URL.revokeObjectURL(result.blobUrl);
       }
-    }
-   },[result?.blobUrl])
+    };
+  }, [result?.blobUrl]);
 
   useEffect(() => {
     return () => {

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -1,6 +1,7 @@
 import { EditRecipe, ExportResult, BackgroundMusicOptions, ImageOverlayOptions } from "./types";
 import { getPresetById } from "./presets";
 import { buildTextFilter } from "./text-overlay";
+import { getFontFileEntry } from "@/utils/fontLoader";
 
 export class FFmpegLoadError extends Error {}
 
@@ -8,6 +9,12 @@ export class FFmpegLoadError extends Error {}
 type SerializedFile = {
   name: string;
   type: string;
+  data: ArrayBuffer;
+};
+
+type FontSerializedFile = {
+  name: string;
+  extension: string;
   data: ArrayBuffer;
 };
 
@@ -21,6 +28,7 @@ type WorkerExportRequest = {
   musicOptions?: BackgroundMusicOptions;
   overlayFile?: SerializedFile;
   overlayOptions?: ImageOverlayOptions;
+  fontFiles?: FontSerializedFile[];
 };
 
 type WorkerLoadResponse = { type: "ready" };
@@ -252,6 +260,19 @@ export async function exportVideo(
     ? { ...overlayOptions, file: null }
     : undefined;
 
+  const seenFonts = new Set<string>();
+  const fontFiles: FontSerializedFile[] = [];
+  for (const overlay of recipe.textOverlays) {
+    if (overlay.fontFamily && !seenFonts.has(overlay.fontFamily)) {
+      seenFonts.add(overlay.fontFamily);
+      const entry = getFontFileEntry(overlay.fontFamily);
+      if (entry) {
+        const data = await entry.file.arrayBuffer();
+        fontFiles.push({ name: overlay.fontFamily, extension: entry.extension, data });
+      }
+    }
+  }
+
   pendingProgress = onProgress;
 
   const exportPromise = new Promise<ExportResult>((resolve, reject) => {
@@ -273,6 +294,7 @@ export async function exportVideo(
   const transfers: Transferable[] = [arrayBuffer];
   if (musicFilePayload) transfers.push(musicFilePayload.data);
   if (overlayFilePayload) transfers.push(overlayFilePayload.data);
+  for (const f of fontFiles) transfers.push(f.data);
 
   ffmpegWorker.postMessage(
     {
@@ -285,6 +307,7 @@ export async function exportVideo(
       musicOptions: sanitizedMusicOptions,
       overlayFile: overlayFilePayload,
       overlayOptions: sanitizedOverlayOptions,
+      fontFiles: fontFiles.length > 0 ? fontFiles : undefined,
     } as WorkerExportRequest,
     transfers
   );

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -327,7 +327,10 @@ async function getVideoDuration(file: File): Promise<number> {
       URL.revokeObjectURL(video.src);
       resolve(video.duration);
     };
-    video.onerror = () => resolve(0);
+    video.onerror = () => {
+      URL.revokeObjectURL(video.src);
+      resolve(0);
+    };
     video.src = URL.createObjectURL(file);
   });
 }

--- a/src/lib/ffmpeg.worker.ts
+++ b/src/lib/ffmpeg.worker.ts
@@ -17,6 +17,12 @@ type SerializedFile = {
   data: ArrayBuffer;
 };
 
+type FontSerializedFile = {
+  name: string;
+  extension: string;
+  data: ArrayBuffer;
+};
+
 type ExportRequest = {
   type: "export";
   id: string;
@@ -27,6 +33,7 @@ type ExportRequest = {
   musicOptions?: BackgroundMusicOptions;
   overlayFile?: SerializedFile;
   overlayOptions?: ImageOverlayOptions;
+  fontFiles?: FontSerializedFile[];
 };
 
 type LoadRequest = { type: "load" };
@@ -429,6 +436,31 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
     });
   }
 
+  const fontVfsPaths = new Map<string, string>();
+  if (request.fontFiles) {
+    for (const fontFile of request.fontFiles) {
+      const vfsPath = `custom_font_${sessionId}_${fontFile.name}.${fontFile.extension}`;
+      await ffmpeg.writeFile(vfsPath, new Uint8Array(fontFile.data), {
+        signal: activeExportAbortController?.signal,
+      });
+      cleanupFiles.add(vfsPath);
+      fontVfsPaths.set(fontFile.name, vfsPath);
+    }
+  }
+
+  let patchedRecipe: EditRecipe = recipe;
+  if (fontVfsPaths.size > 0) {
+    patchedRecipe = {
+      ...recipe,
+      textOverlays: recipe.textOverlays.map(o => {
+        if (o.fontFamily && fontVfsPaths.has(o.fontFamily)) {
+          return { ...o, fontPath: fontVfsPaths.get(o.fontFamily)! };
+        }
+        return o;
+      }),
+    };
+  }
+
   const videoDuration = request.videoDuration;
 
   const handleProgress = ({ progress }: { progress: number }) => {
@@ -441,7 +473,7 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
 
   try {
     if (recipe.format === "gif") {
-      const vf = buildVideoFilter(recipe, targetW, targetH);
+      const vf = buildVideoFilter(patchedRecipe, targetW, targetH);
       const vfWithPalette = vf ? `${vf},palettegen` : "palettegen";
       const vfWithPaletteUse = vf
         ? `[0:v]${vf}[x];[x][1:v]paletteuse`
@@ -499,8 +531,8 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
     ffmpeg.on("log", logListener);
 
     let args = buildArguments(
-      recipe,
-      recipe.format,
+      patchedRecipe,
+      patchedRecipe.format,
       outputName,
       inputName,
       targetW,
@@ -522,8 +554,8 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
     if (exitCode !== 0 && missingAudioDetected) {
       missingAudioDetected = false;
       args = buildArguments(
-        recipe,
-        recipe.format,
+        patchedRecipe,
+        patchedRecipe.format,
         outputName,
         inputName,
         targetW,
@@ -544,7 +576,7 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
 
     if (exitCode !== 0) {
       args = buildArguments(
-        recipe,
+        patchedRecipe,
         "webm",
         fallbackOutputName,
         inputName,

--- a/src/utils/__tests__/fontLoader.test.ts
+++ b/src/utils/__tests__/fontLoader.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  storeFontFile,
+  getFontFileEntry,
+  getFFmpegFontArg,
+  registerCustomFont,
+  clearCustomFonts,
+} from "@/utils/fontLoader";
+
+function makeMockFile(name: string): File {
+  return new File(["mock content"], name, { type: "font/ttf" });
+}
+
+describe("storeFontFile / getFontFileEntry", () => {
+  beforeEach(() => {
+    clearCustomFonts();
+  });
+
+  it("stores and retrieves a font file entry", () => {
+    const file = makeMockFile("OpenSans.ttf");
+    storeFontFile("OpenSans", file);
+    const entry = getFontFileEntry("OpenSans");
+    expect(entry).toBeDefined();
+    expect(entry!.file).toBe(file);
+    expect(entry!.extension).toBe("ttf");
+  });
+
+  it("extracts extension from file name", () => {
+    const file = makeMockFile("CustomFont.otf");
+    storeFontFile("CustomFont", file);
+    expect(getFontFileEntry("CustomFont")!.extension).toBe("otf");
+  });
+
+  it("lowers extension case", () => {
+    const file = makeMockFile("Test.TTF");
+    storeFontFile("Test", file);
+    expect(getFontFileEntry("Test")!.extension).toBe("ttf");
+  });
+
+  it("returns undefined for unknown font", () => {
+    expect(getFontFileEntry("NonExistent")).toBeUndefined();
+  });
+
+  it("overwrites existing entry with same name", () => {
+    const fileA = makeMockFile("A.ttf");
+    const fileB = makeMockFile("A.ttf");
+    storeFontFile("MyFont", fileA);
+    storeFontFile("MyFont", fileB);
+    expect(getFontFileEntry("MyFont")!.file).toBe(fileB);
+  });
+});
+
+describe("getFFmpegFontArg", () => {
+  beforeEach(() => {
+    clearCustomFonts();
+  });
+
+  it("returns empty string when no fontFamily and no fontPath", () => {
+    expect(getFFmpegFontArg("", "")).toBe("");
+  });
+
+  it("returns empty string when fontName is empty even if fontPath is set", () => {
+    expect(getFFmpegFontArg("", "/vfs/font.ttf")).toBe("");
+  });
+
+  it("returns empty string for known custom font without fontPath", () => {
+    registerCustomFont("TestFont", "blob:http://test/font");
+    expect(getFFmpegFontArg("TestFont", "")).toBe("");
+  });
+
+  it("returns fontfile arg for custom font with fontPath", () => {
+    registerCustomFont("MyCustomFont", "blob:http://test/font");
+    const result = getFFmpegFontArg("MyCustomFont", "/vfs/custom_font.ttf");
+    expect(result).toBe("fontfile=/vfs/custom_font.ttf");
+  });
+
+  it("returns empty string for built-in fonts regardless of fontPath", () => {
+    expect(getFFmpegFontArg("Arial", "")).toBe("");
+    expect(getFFmpegFontArg("Inter", "/vfs/font.ttf")).toBe("");
+  });
+
+  it("escapes colons in fontPath", () => {
+    registerCustomFont("PathFont", "blob:http://test/font");
+    const result = getFFmpegFontArg("PathFont", "/vfs:with:colons/font.ttf");
+    expect(result).toBe("fontfile=/vfs\\:with\\:colons/font.ttf");
+  });
+});

--- a/src/utils/fontLoader.ts
+++ b/src/utils/fontLoader.ts
@@ -180,6 +180,8 @@ export function clearCustomFonts(): void {
   customFonts.forEach((font) => {
     unregisterCustomFont(font);
   });
+
+  fontFileRegistry.clear();
 }
 
 /**
@@ -275,4 +277,20 @@ export async function ensureFontLoaded(
     // The browser will use fallback fonts
     console.warn(`Font "${fontName}" failed to load:`, err);
   }
+}
+
+type FontFileEntry = {
+  file: File;
+  extension: string;
+};
+
+const fontFileRegistry = new Map<string, FontFileEntry>();
+
+export function storeFontFile(name: string, file: File): void {
+  const ext = (file.name.split(".").pop() || "ttf").toLowerCase();
+  fontFileRegistry.set(name, { file, extension: ext });
+}
+
+export function getFontFileEntry(name: string): FontFileEntry | undefined {
+  return fontFileRegistry.get(name);
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vitest/config'
+import path from 'path'
 
 export default defineConfig({
   oxc: {
     jsx: {
       runtime: 'automatic',
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
     },
   },
   test: {


### PR DESCRIPTION
## What this fixes

Four distinct blob URL leak sites across the application caused the browser to retain the full underlying Blob (including multi-GB video files) in memory until page unload. In long editing sessions where users export multiple videos, each export cycle leaked blob URLs for video sources, metadata loading, and export results — causing progressive memory exhaustion and eventual browser tab crash.

## Root cause

**`getVideoDuration` (`src/lib/ffmpeg.ts:330`):** The `onerror` handler resolved with `0` but never called `URL.revokeObjectURL(video.src)`, leaking the blob URL on any file that fails to load metadata (corrupted files, unsupported codecs, network issues).

**`extractMetadata` (`src/hooks/useVideoEditor.ts:14`):** The 5-second timeout called `URL.revokeObjectURL(url)` before `reject()`, but the `onloadedmetadata` handler could fire after the timeout — calling `resolve()` on an already-settled promise and then revoking the already-revoked URL. No explicit leak, but the URL lifecycle was inverted: the URL was revoked before the video element finished consuming it, and the race could leave the URL dangling in edge-case timing.

**`VideoPreview` (`src/components/VideoPreview.tsx:71`):** URL management used two refs (`urlRef` + `lastId`) with a stale-reference check that could fail on rapid file changes. When two file changes happened in quick succession, the check `urlRef.current === url` could compare the second effect's URL against the first effect's ref value, skipping the revoke. The redundant double-revoke at lines 74 and 79-80 was harmless but masked the real issue.

**`ComparisonPreview` (`src/components/ComparisonPreview.tsx:61`):** The cleanup only revoked the blob URL without clearing the video elements' `src` attributes. On component re-mount (which happens when `setShowComparison` toggles), stale references from the previous mount were not properly released.

**`handleGrabFrame` (`src/components/VideoPreview.tsx:42`):** The canvas backing store (up to 66MB for 8K video) was never explicitly released. The canvas went out of scope naturally but the backing store could survive until GC.

## What changed

- **`src/lib/ffmpeg.ts`**: Added `URL.revokeObjectURL(video.src)` to the `onerror` handler in `getVideoDuration`.
- **`src/hooks/useVideoEditor.ts`**: Added `timedOut` flag in `extractMetadata` to prevent `resolve()` firing after timeout. Moved `URL.revokeObjectURL` before `resolve` on the success path. Replaced the export result cleanup effect with a `prevResultBlobUrlRef` pattern that explicitly tracks the previous blob URL.
- **`src/components/VideoPreview.tsx`**: Removed `lastId`, `urlRef`, and `onLoadedRef`. URL is now tracked through the effect closure — each effect invocation creates its own URL and revokes it in cleanup. Added `canvas.width = 0; canvas.height = 0;` in a `finally` block inside `handleGrabFrame` to release the canvas backing store immediately.
- **`src/components/ComparisonPreview.tsx`**: Added `pause()` and `removeAttribute("src")` calls on both video elements in the cleanup function, alongside the existing `URL.revokeObjectURL`.

## How to verify

1. Open Reframe in Chrome DevTools with the Memory tab open (or use `about:memory`)
2. Upload a large video file (4K, ~500MB+)
3. Click Export, let it complete, download the result
4. Click "New" (reset), upload a different video, export again
5. Repeat steps 3-4 five times
6. Take a heap snapshot — observe that no Blob objects from previous export cycles are retained. Previously, each cycle leaked multiple Blob references (~500MB each).
7. Run `npx vitest run` — all 88 existing tests should pass.
8. Run `npx tsc --noEmit` — no type errors.

## Edge cases considered

- **Rapid file switching in VideoPreview**: Each effect closure captures its own URL and revokes it in cleanup. No ref-based staleness. Handled.
- **Timeout firing simultaneously with metadata load (extractMetadata)**: The `timedOut` flag prevents `resolve()` after the URL is already revoked. Handled.
- **ComparisonPreview re-mount**: Both video elements are paused and src-cleared in cleanup before URL revocation. Handled.
- **Canvas backing store for low-resolution videos**: Calling `canvas.width = 0` on a small canvas is negligible overhead. No downside.
- **Export without prior export (first run)**: `prevResultBlobUrlRef.current` starts as `null`, so no spurious revoke. Handled.

Closes #1351