### PR TITLE
Fix: resolve tutorial popup overflow on small screens

### DIFF
--- a/src/components/OnboardingTour.tsx
+++ b/src/components/OnboardingTour.tsx
@@ -63,6 +63,10 @@ function getTooltipStyle(
   const tw = tooltip?.offsetWidth ?? 320;
   const th = tooltip?.offsetHeight ?? 140;
 
+  const VIEWPORT_MARGIN = 12; // minimum gap from viewport edge
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+
   const sr = {
     top: rect.top - PADDING,
     left: rect.left - PADDING,
@@ -70,29 +74,71 @@ function getTooltipStyle(
     height: rect.height + PADDING * 2,
   };
 
-  switch (position) {
-    case "top":
-      return {
-        top: sr.top - th - TOOLTIP_OFFSET,
-        left: sr.left + sr.width / 2 - tw / 2,
-      };
-    case "left":
-      return {
-        top: sr.top + sr.height / 2 - th / 2,
-        left: sr.left - tw - TOOLTIP_OFFSET,
-      };
-    case "right":
-      return {
-        top: sr.top + sr.height / 2 - th / 2,
-        left: sr.left + sr.width + TOOLTIP_OFFSET,
-      };
-    case "bottom":
-    default:
-      return {
-        top: sr.top + sr.height + TOOLTIP_OFFSET,
-        left: sr.left + sr.width / 2 - tw / 2,
-      };
+  // Compute position for a given side
+  const calcPos = (side: TourStep["position"]): { top: number; left: number } => {
+    switch (side) {
+      case "top":
+        return {
+          top: sr.top - th - TOOLTIP_OFFSET,
+          left: sr.left + sr.width / 2 - tw / 2,
+        };
+      case "left":
+        return {
+          top: sr.top + sr.height / 2 - th / 2,
+          left: sr.left - tw - TOOLTIP_OFFSET,
+        };
+      case "right":
+        return {
+          top: sr.top + sr.height / 2 - th / 2,
+          left: sr.left + sr.width + TOOLTIP_OFFSET,
+        };
+      case "bottom":
+      default:
+        return {
+          top: sr.top + sr.height + TOOLTIP_OFFSET,
+          left: sr.left + sr.width / 2 - tw / 2,
+        };
+    }
+  };
+
+  // Check if a position fits within the viewport
+  const fits = (pos: { top: number; left: number }): boolean =>
+    pos.top >= VIEWPORT_MARGIN &&
+    pos.left >= VIEWPORT_MARGIN &&
+    pos.top + th <= vh - VIEWPORT_MARGIN &&
+    pos.left + tw <= vw - VIEWPORT_MARGIN;
+
+  const opposite: Record<string, TourStep["position"]> = {
+    top: "bottom",
+    bottom: "top",
+    left: "right",
+    right: "left",
+  };
+
+  // Try preferred side first, then opposite, then remaining sides
+  let pos = calcPos(position);
+  if (!fits(pos)) {
+    const oppPos = calcPos(opposite[position ?? "bottom"]);
+    if (fits(oppPos)) {
+      pos = oppPos;
+    } else {
+      // Try all sides and pick the first that fits
+      const sides: TourStep["position"][] = ["bottom", "right", "top", "left"];
+      for (const side of sides) {
+        const sidePos = calcPos(side);
+        if (fits(sidePos)) {
+          pos = sidePos;
+          break;
+        }
+      }
+    }
   }
+
+  // Final clamp: ensure tooltip never exceeds viewport bounds
+  pos.top = Math.max(VIEWPORT_MARGIN, Math.min(pos.top, vh - th - VIEWPORT_MARGIN));
+  pos.left = Math.max(VIEWPORT_MARGIN, Math.min(pos.left, vw - tw - VIEWPORT_MARGIN));
+
+  return { top: pos.top, left: pos.left };
 }
 
 interface SpotlightProps {


### PR DESCRIPTION
## Description
### Root Cause
The `getTooltipStyle` function previously positioned the onboarding tooltip relative to the target element using a simple offset, but failed to validate whether the computed position remained within the visible viewport. For steps like step 2 ("Pick an output format"), where the tooltip was configured to render on the `left` of the preset selector, this produced a negative `left` coordinate value that pushed the container entirely off the left edge of smaller screens.

### Fix Applied
The updated `getTooltipStyle` function introduces a dynamic fallback mechanism to keep the tutorial readable across all viewport sizes:
1. **Tries the preferred side** first (as configured per step).
2. **Flips to the opposite side** if the preferred layout would overflow (e.g., `left` → `right`).
3. **Falls back through all four sides** (`bottom`, `right`, `top`, `left`) if the opposite direction doesn't fit either.
4. **Clamps the final coordinates** as a safety net, ensuring the tooltip always maintains at least a `12px` buffer inside the viewport on all edges.

## Related Issue
Closes #[1356](https://github.com/issues/assigned?issue=magic-peach%7Creframe%7C1356)

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: lavanya1486
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [ ] **Screen recording attached above** (required for UI/feature/design changes)