### PR TITLE
fix: apply brightness/contrast/saturation CSS filter to video preview

### DIFF
--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -233,6 +233,11 @@ export default function VideoPreview({
           ref={videoRef}
           controls
           className={cn("w-full h-full object-contain transition-opacity duration-300", isLoading ? "opacity-0" : "opacity-100")}
+          style={{
+            filter: recipe
+              ? `brightness(${1 + (recipe.brightness ?? 0)}) contrast(${recipe.contrast ?? 1}) saturate(${recipe.saturation ?? 1})`
+              : undefined,
+          }}
           onLoadedData={() => setIsLoading(false)}
           playsInline
           muted={!recipe?.keepAudio}


### PR DESCRIPTION
## Description
Brightness, contrast, and saturation sliders in the Adjustments section were not visually affecting the video preview. The `recipe` values were correctly stored in state and passed as a prop to `VideoPreview`, but were never applied to the `<video>` element itself.

Fixed by adding a `style` prop to the `<video>` element in `VideoPreview.tsx` that computes a CSS `filter` string from the recipe values:

```tsx
style={{
  filter: recipe
    ? `brightness(${1 + (recipe.brightness ?? 0)}) contrast(${recipe.contrast ?? 1}) saturate(${recipe.saturation ?? 1})`
    : undefined,
}}
```

**Why `1 + recipe.brightness`:** The brightness slider range is `-1` to `1` with `0` as neutral. CSS `brightness()` uses `1` as neutral, so the offset maps correctly — e.g. `recipe.brightness = 0` → `brightness(1)` (no change), `recipe.brightness = 1` → `brightness(2)` (max bright). Contrast and saturation already use `1` as their neutral default and map directly.

**Only one file changed:** `src/components/VideoPreview.tsx`

## Related Issue
Closes #1364 

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: shrutisharma-sh
- Contribution level (Beginner/Intermediate/Advanced): Intermediate


### Screenshot 
<img width="1366" height="768" alt="Screenshot (415)" src="https://github.com/user-attachments/assets/afec26c0-3dc8-4bcd-b7ef-43217ba49f39" />
<img width="1366" height="768" alt="Screenshot (416)" src="https://github.com/user-attachments/assets/736572a6-ce0b-4500-bc26-4f7518717764" />
