### PR TITLE
fix(a11y): announce export loading states

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -318,8 +318,9 @@ export default function VideoEditor() {
       />
       <OnboardingTour />
 
-      <div aria-live="polite" aria-atomic="true" className="sr-only">
-        {status === "exporting" && `Exporting video: ${progress}%`}
+      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+        {status === "loading-engine" && "Loading engine. Video processing engine is loading, please wait."}
+        {status === "exporting" && `Export started. Exporting video: ${progress}%`}
         {status === "done" && "Export complete! Video ready to download."}
         {status === "error" && `Export failed: ${error}`}
       </div>


### PR DESCRIPTION
## Summary
- Adds a polite `role="status"` live region for FFmpeg engine loading.
- Announces `Export started` when the app transitions into exporting while preserving export progress text for screen readers.

## Validation
- `git diff --check`
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `npm run test -- --run` *(currently fails on existing repo test setup/import issues: missing `localStorage` setup and unresolved `@/utils/fontLoader` in existing tests)*

Closes #168
