### PR TITLE
fix: preserve original aspect ratio in custom video exports

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -437,6 +437,8 @@ export function useVideoEditor() {
           ...prev,
           trimStart: 0,
           trimEnd: null,
+          customWidth: width,
+          customHeight: height,
           ...(shouldApplySuggestion ? { preset: suggestedPreset } : {}),
         };
       });


### PR DESCRIPTION
## Description
Fixes an issue where exporting a portrait (9:16) video with the 'Custom' preset incorrectly falls back to the default 1920x1080 resolution, resulting in forced 16:9 letterboxing. 

The fix updates the `setRecipe` logic in `src/hooks/useVideoEditor.ts` to ensure that `customWidth` and `customHeight` are properly initialized with the uploaded video's intrinsic dimensions, preserving its original aspect ratio when the Custom preset is selected.

## Related Issue
Fixes #1297

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: @anshika1179
- Contribution level (Beginner/Intermediate/Advanced): Intermediate




## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [ ] **Screen recording attached above** (required for UI/feature/design changes)