### PR TITLE
feat: Smart Auto Reframe with canvas saliency analysis (closes #1186)

### DIFF
--- a/src/components/AutoReframeControl.tsx
+++ b/src/components/AutoReframeControl.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+import { Crosshair, Loader2, Info } from 'lucide-react';
+import { analyzeBestCropRegion } from '@/lib/analyzeFrame';
+import type { AutoReframeSettings } from '@/lib/types';
+
+interface Props {
+  videoFile: File | null;
+  targetWidth: number;
+  targetHeight: number;
+  autoReframe: AutoReframeSettings | undefined;
+  onChange: (settings: AutoReframeSettings | undefined) => void;
+}
+
+export function AutoReframeControl({
+  videoFile,
+  targetWidth,
+  targetHeight,
+  autoReframe,
+  onChange,
+}: Props) {
+  const [analyzing, setAnalyzing] = useState(false);
+  const isEnabled = autoReframe?.enabled ?? false;
+
+  const handleToggle = async () => {
+    if (!videoFile) return;
+
+    if (isEnabled) {
+      onChange(undefined);
+      return;
+    }
+
+    setAnalyzing(true);
+    try {
+      const aspect = targetWidth / targetHeight;
+      const { cropX, cropY } = await analyzeBestCropRegion(videoFile, aspect);
+      onChange({ enabled: true, cropX, cropY });
+    } catch {
+      onChange({ enabled: true, cropX: 0.5, cropY: 0.5 });
+    } finally {
+      setAnalyzing(false);
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-zinc-700 bg-zinc-800/50 p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Crosshair className="h-4 w-4 text-purple-400 shrink-0" />
+          <div>
+            <p className="text-sm font-medium text-zinc-100">Smart Auto Reframe</p>
+            <p className="text-xs text-zinc-400">
+              Finds the best crop position for your subject
+            </p>
+          </div>
+        </div>
+
+        <button
+          onClick={handleToggle}
+          disabled={!videoFile || analyzing}
+          className={`flex items-center gap-1.5 rounded px-3 py-1.5 text-sm font-medium transition-colors
+            ${isEnabled
+              ? 'bg-purple-600 text-white hover:bg-purple-700'
+              : 'bg-zinc-700 text-zinc-300 hover:bg-zinc-600'
+            }
+            disabled:cursor-not-allowed disabled:opacity-50`}
+        >
+          {analyzing ? (
+            <>
+              <Loader2 className="h-3 w-3 animate-spin" />
+              Analyzing…
+            </>
+          ) : isEnabled ? (
+            'On'
+          ) : (
+            'Off'
+          )}
+        </button>
+      </div>
+
+      {isEnabled && autoReframe && (
+        <div className="mt-2 flex items-center gap-1.5 text-xs text-zinc-400">
+          <Info className="h-3 w-3 shrink-0" />
+          <span>
+            Crop origin: {Math.round(autoReframe.cropX * 100)}%,{' '}
+            {Math.round(autoReframe.cropY * 100)}%
+          </span>
+        </div>
+      )}
+
+      {!videoFile && (
+        <p className="mt-2 text-xs text-zinc-500">Upload a video to enable smart reframe</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -16,8 +16,9 @@ import FormatSelector from "./FormatSelector";
 import ExportSettings from "./ExportSettings";
 import ExportOverlay from "./ExportOverlay";
 import DownloadResult from "./DownloadResult";
-import ImageOverlay from "./ImageOverlay"
+import ImageOverlay from "./ImageOverlay";
 import { getPresetById } from "@/lib/presets";
+import { AutoReframeControl } from "./AutoReframeControl";
 
 import { cn } from "@/lib/utils";
 import {
@@ -122,37 +123,37 @@ function KeyboardShortcutsPanel() {
   const [open, setOpen] = useState(false);
 
   const shortcuts: { keys: React.ReactNode[]; label: string }[] = [
-  {
-    keys: [
-      <Kbd key="ctrl">Ctrl</Kbd>,
-      <span key="plus1" className="text-[var(--muted)] text-xs">+</span>,
-      <Kbd key="shift">Shift</Kbd>,
-      <span key="plus2" className="text-[var(--muted)] text-xs">+</span>,
-      <Kbd key="e">E</Kbd>
-    ],
-    label: "Export video",
-  },
-  {
-    keys: [<Kbd key="m">M</Kbd>],
-    label: "Toggle audio mute",
-  },
-  {
-    keys: [<Kbd key="r">R</Kbd>],
-    label: "Reset all settings",
-  },
-  {
-    keys: [<Kbd key="esc">Esc</Kbd>],
-    label: "Cancel export",
-  },
-  {
-    keys: [<Kbd key="1">1</Kbd>, <span key="dash" className="text-[var(--muted)] text-xs">–</span>, <Kbd key="9">9</Kbd>],
-    label: "Switch preset by index",
-  },
-  {
-    keys: [<Kbd key="question">?</Kbd>],
-    label: "Toggle this panel",
-  },
-];
+    {
+      keys: [
+        <Kbd key="ctrl">Ctrl</Kbd>,
+        <span key="plus1" className="text-[var(--muted)] text-xs">+</span>,
+        <Kbd key="shift">Shift</Kbd>,
+        <span key="plus2" className="text-[var(--muted)] text-xs">+</span>,
+        <Kbd key="e">E</Kbd>
+      ],
+      label: "Export video",
+    },
+    {
+      keys: [<Kbd key="m">M</Kbd>],
+      label: "Toggle audio mute",
+    },
+    {
+      keys: [<Kbd key="r">R</Kbd>],
+      label: "Reset all settings",
+    },
+    {
+      keys: [<Kbd key="esc">Esc</Kbd>],
+      label: "Cancel export",
+    },
+    {
+      keys: [<Kbd key="1">1</Kbd>, <span key="dash" className="text-[var(--muted)] text-xs">–</span>, <Kbd key="9">9</Kbd>],
+      label: "Switch preset by index",
+    },
+    {
+      keys: [<Kbd key="question">?</Kbd>],
+      label: "Toggle this panel",
+    },
+  ];
 
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] animate-fade-in overflow-hidden">
@@ -468,7 +469,7 @@ export default function VideoEditor() {
 
                     <div className="mt-4 space-y-4">
                       <AccordionSection
-                        id="rotation"
+                        id="rotation-advanced"
                         icon={<RotateCw size={12} />}
                         title="Rotation"
                         isOpen={openSections.rotation}
@@ -478,7 +479,7 @@ export default function VideoEditor() {
                       </AccordionSection>
 
                       <AccordionSection
-                        id="export"
+                        id="export-advanced"
                         icon={<SlidersHorizontal size={12} />}
                         title="Export"
                         isOpen={openSections.export}
@@ -587,7 +588,7 @@ export default function VideoEditor() {
                     <FormatSelector recipe={recipe} onChange={updateRecipe} />
                   </Section>
                   <AccordionSection
-                    id="export"
+                    id="export-bottom"
                     icon={<SlidersHorizontal size={12} />}
                     title="Export"
                     isOpen={openSections.export}
@@ -618,7 +619,7 @@ export default function VideoEditor() {
 
                   <div className="mt-4 space-y-4">
                     <AccordionSection
-                      id="rotation"
+                      id="rotation-adv2"
                       icon={<RotateCw size={12} />}
                       title="Rotation"
                       isOpen={openSections.rotation}
@@ -628,7 +629,7 @@ export default function VideoEditor() {
                     </AccordionSection>
 
                     <AccordionSection
-                      id="export"
+                      id="export-adv2"
                       icon={<SlidersHorizontal size={12} />}
                       title="Export"
                       isOpen={openSections.export}
@@ -719,6 +720,17 @@ export default function VideoEditor() {
                 <div className="space-y-3">
                   <PresetSelector recipe={recipe} onChange={updateRecipe} />
                   <FramingControl recipe={recipe} onChange={updateRecipe} />
+
+                  {/* ---- Smart Auto Reframe (only for Fill mode) ---- */}
+                  {recipe.framing === "fill" && (
+                    <AutoReframeControl
+                      videoFile={file}
+                      targetWidth={recipe.preset === "custom" ? recipe.customWidth : (getPresetById(recipe.preset)?.width ?? 0)}
+                      targetHeight={recipe.preset === "custom" ? recipe.customHeight : (getPresetById(recipe.preset)?.height ?? 0)}
+                      autoReframe={recipe.autoReframe}
+                      onChange={(settings) => updateRecipe({ autoReframe: settings })}
+                    />
+                  )}
                 </div>
               </AccordionSection>
 

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -188,16 +188,23 @@ export function useVideoEditor() {
   const [overlaySize, setOverlaySize] = useState(150);
   const [overlayOpacity, setOverlayOpacity] = useState(100);
   const [currentTime, setCurrentTime] = useState(0);
- const updateRecipe = useCallback((patch: Partial<EditRecipe>) => {
-  setRecipe((prev) => {
-    const next = { ...prev, ...patch };
-    // GIF has no audio — force keepAudio off
-    if (next.format === "gif") {
-      next.keepAudio = false;
-    }
-    return next;
-  });
-}, []);
+
+  // *** UPDATED: reset autoReframe when preset changes ***
+  const updateRecipe = useCallback((patch: Partial<EditRecipe>) => {
+    setRecipe((prev) => {
+      const next = { ...prev, ...patch };
+      // If preset changed, reset autoReframe (aspect ratio may differ)
+      if (patch.preset !== undefined) {
+        next.autoReframe = undefined;
+      }
+      // GIF has no audio — force keepAudio off
+      if (next.format === "gif") {
+        next.keepAudio = false;
+      }
+      return next;
+    });
+  }, []);
+
   const isValidValue = (key: keyof EditRecipe, val: any): boolean => {
     switch (key) {
       case "preset":
@@ -437,6 +444,7 @@ export function useVideoEditor() {
           ...prev,
           trimStart: 0,
           trimEnd: null,
+          autoReframe: undefined, // reset on file change (aspect ratio may be different)
           ...(shouldApplySuggestion ? { preset: suggestedPreset } : {}),
         };
       });
@@ -689,8 +697,8 @@ export function useVideoEditor() {
   },[]);
 
   const toggleSound = useCallback(() => {
-  updateRecipe({ soundOnCompletion: !recipe.soundOnCompletion });
-}, [recipe.soundOnCompletion, updateRecipe]);
+    updateRecipe({ soundOnCompletion: !recipe.soundOnCompletion });
+  }, [recipe.soundOnCompletion, updateRecipe]);
 
   return {
     file,

--- a/src/lib/analyzeFrame.ts
+++ b/src/lib/analyzeFrame.ts
@@ -1,0 +1,133 @@
+/**
+ * Client‑side smart crop analyzer.
+ * Draws a video frame onto a canvas, scans a grid of possible
+ * crop windows to find the one with the highest visual activity
+ * (brightness variance = edges/detail = likely subject area).
+ */
+
+export async function analyzeBestCropRegion(
+  videoFile: File,
+  targetAspectRatio: number // e.g. 9/16 ≈ 0.5625 for portrait
+): Promise<{ cropX: number; cropY: number }> {
+  return new Promise((resolve) => {
+    const video = document.createElement('video');
+    const url = URL.createObjectURL(videoFile);
+    video.src = url;
+    video.muted = true;
+    video.preload = 'metadata';
+
+    video.addEventListener('loadedmetadata', () => {
+      video.currentTime = Math.max(0.1, video.duration * 0.1);
+    });
+
+    video.addEventListener('seeked', () => {
+      try {
+        const W = 320;
+        const H = 180;
+        const canvas = document.createElement('canvas');
+        canvas.width = W;
+        canvas.height = H;
+        const ctx = canvas.getContext('2d');
+
+        if (!ctx) {
+          resolve({ cropX: 0.5, cropY: 0.5 });
+          return;
+        }
+
+        ctx.drawImage(video, 0, 0, W, H);
+        const imageData = ctx.getImageData(0, 0, W, H);
+
+        const result = findBestCropWindow(imageData, W, H, targetAspectRatio);
+        URL.revokeObjectURL(url);
+        resolve(result);
+      } catch {
+        URL.revokeObjectURL(url);
+        resolve({ cropX: 0.5, cropY: 0.5 }); // safe fallback
+      }
+    });
+
+    video.addEventListener('error', () => {
+      URL.revokeObjectURL(url);
+      resolve({ cropX: 0.5, cropY: 0.5 });
+    });
+
+    video.load();
+  });
+}
+
+function findBestCropWindow(
+  imageData: ImageData,
+  W: number,
+  H: number,
+  targetAspect: number
+): { cropX: number; cropY: number } {
+  // Size of the crop window in the 320x180 canvas space
+  let cropW: number, cropH: number;
+  const sourceAspect = W / H;
+
+  if (targetAspect < sourceAspect) {
+    // Target is taller → crop width
+    cropH = H;
+    cropW = Math.round(H * targetAspect);
+  } else {
+    // Target is wider → crop height
+    cropW = W;
+    cropH = Math.round(W / targetAspect);
+  }
+
+  cropW = Math.min(cropW, W);
+  cropH = Math.min(cropH, H);
+
+  const GRID = 8; // 8×8 = 64 candidates
+  let bestScore = -1;
+  let bestCX = 0.5;
+  let bestCY = 0.5;
+
+  for (let gy = 0; gy <= GRID; gy++) {
+    for (let gx = 0; gx <= GRID; gx++) {
+      const startX = Math.round((gx / GRID) * (W - cropW));
+      const startY = Math.round((gy / GRID) * (H - cropH));
+      const score = computeActivityScore(imageData.data, W, startX, startY, cropW, cropH);
+
+      if (score > bestScore) {
+        bestScore = score;
+        bestCX = (startX + cropW / 2) / W;
+        bestCY = (startY + cropH / 2) / H;
+      }
+    }
+  }
+
+  return {
+    cropX: Math.max(0, Math.min(1, bestCX)),
+    cropY: Math.max(0, Math.min(1, bestCY)),
+  };
+}
+
+/** Variance of pixel brightness → higher = more detail/edges */
+function computeActivityScore(
+  data: Uint8ClampedArray,
+  W: number,
+  x: number,
+  y: number,
+  w: number,
+  h: number
+): number {
+  const STEP = 3;
+  let sum = 0;
+  let sumSq = 0;
+  let count = 0;
+
+  for (let py = y; py < y + h; py += STEP) {
+    for (let px = x; px < x + w; px += STEP) {
+      const i = (py * W + px) * 4;
+      const brightness = 0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2];
+      sum += brightness;
+      sumSq += brightness * brightness;
+      count++;
+    }
+  }
+
+  if (count === 0) return 0;
+  const mean = sum / count;
+  return sumSq / count - mean * mean; // variance
+}

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -4,7 +4,6 @@ import { buildTextFilter } from "./text-overlay";
 
 export class FFmpegLoadError extends Error {}
 
-
 type SerializedFile = {
   name: string;
   type: string;
@@ -351,9 +350,23 @@ export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: n
       `pad=${targetW}:${targetH}:(ow-iw)/2:(oh-ih)/2:color=black`
     );
   } else {
+    // ---- Smart Auto Reframe integration ----
+    const auto = recipe.autoReframe;
+    const useSmartCrop = auto?.enabled && auto.cropX !== undefined && auto.cropY !== undefined;
+
+    const cropX = useSmartCrop ? auto!.cropX : 0.5;
+    const cropY = useSmartCrop ? auto!.cropY : 0.5;
+
+    // After scale, the input to crop has dimensions (iw,ih) that are larger
+    // or equal to targetW,targetH. Compute crop offset so that the crop window
+    // is centered at (cropX*iw, cropY*ih) – with clamping to keep it valid.
+    const cropFilter = `crop=${targetW}:${targetH}` +
+      `:x='max(0,min(iw-${targetW}, ${cropX}*iw - ${targetW}/2))'` +
+      `:y='max(0,min(ih-${targetH}, ${cropY}*ih - ${targetH}/2))'`;
+
     filters.push(
       `scale=${targetW}:${targetH}:force_original_aspect_ratio=increase`,
-      `crop=${targetW}:${targetH}`
+      cropFilter
     );
   }
 
@@ -469,31 +482,31 @@ function buildArguments(
       videoOut = "[vbase]";
     }
 
-if (hasOverlay) {
-  const scaledW = overlayOptions!.size;
-  const alpha = (overlayOptions!.opacity / 100).toFixed(2);
-  const posMap: Record<string, string> = {
-    "top-left":     "20:20",
-    "top-right":    "main_w-w-20:20",
-    "bottom-left":  "20:main_h-h-20",
-    "bottom-right": "main_w-w-20:main_h-h-20",
-  };
+    if (hasOverlay) {
+      const scaledW = overlayOptions!.size;
+      const alpha = (overlayOptions!.opacity / 100).toFixed(2);
+      const posMap: Record<string, string> = {
+        "top-left":     "20:20",
+        "top-right":    "main_w-w-20:20",
+        "bottom-left":  "20:main_h-h-20",
+        "bottom-right": "main_w-w-20:main_h-h-20",
+      };
 
-interface PositionCoords {
-    x: number;
-    y: number;
-  }
+      interface PositionCoords {
+        x: number;
+        y: number;
+      }
 
-  const pos = typeof overlayOptions?.position === "string"
-    ? (posMap[overlayOptions.position] ?? "main_w-w-20:main_h-h-20")
-    : overlayOptions?.position
-    ? `(main_w)*${(overlayOptions.position as PositionCoords).x}/100:(main_h)*${(overlayOptions.position as PositionCoords).y}/100`
-    : "main_w-w-20:main_h-h-20";
+      const pos = typeof overlayOptions?.position === "string"
+        ? (posMap[overlayOptions.position] ?? "main_w-w-20:main_h-h-20")
+        : overlayOptions?.position
+        ? `(main_w)*${(overlayOptions.position as PositionCoords).x}/100:(main_h)*${(overlayOptions.position as PositionCoords).y}/100`
+        : "main_w-w-20:main_h-h-20";
 
-  filterParts.push(`[${overlayIdx}:v]scale=${scaledW}:-2,format=rgba,colorchannelmixer=aa=${alpha}[logo]`);
-  filterParts.push(`${videoOut}[logo]overlay=${pos}[vout]`);
-  videoOut = "[vout]";
-}
+      filterParts.push(`[${overlayIdx}:v]scale=${scaledW}:-2,format=rgba,colorchannelmixer=aa=${alpha}[logo]`);
+      filterParts.push(`${videoOut}[logo]overlay=${pos}[vout]`);
+      videoOut = "[vout]";
+    }
 
     let audioOut = "";
     if (shouldKeepAudio) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,6 +15,12 @@ export interface TextOverlay {
   fontPath?: string; // Path/URL to custom font file for export
 }
 
+export interface AutoReframeSettings {
+  enabled: boolean;
+  cropX: number; // Normalized 0–1 (0.5 = center)
+  cropY: number; // Normalized 0–1 (0.5 = center)
+}
+
 export interface EditRecipe {
   preset: string;
   customWidth: number;
@@ -36,6 +42,7 @@ export interface EditRecipe {
   soundOnCompletion: boolean;
   textOverlays: TextOverlay[];
   version: number;
+  autoReframe?: AutoReframeSettings;  // ← added
 }
 
 export type OverlayPosition =


### PR DESCRIPTION
## What
Adds Smart Auto Reframe — analyzes the uploaded video frame using canvas
pixel variance to find the most visually active crop region, then passes
that origin into the FFmpeg crop filter.

## Why
Fixes the dead-center crop problem when converting landscape → portrait
(or any aspect ratio change) for off-center subjects.

## How
- 100% client-side, no ML server needed
- Canvas draws a downscaled frame (320×180), scans 64 candidate crop
  windows, picks the one with highest brightness variance (= most detail)
- Falls back to center crop on any error
- Auto-resets when preset changes (new aspect ratio = new analysis needed)
- Only shown when framing mode is "fill"

## Testing
- Uploaded a 16:9 video, selected 9:16 preset, Fill mode, toggled Smart Auto Reframe ON
- Crop origin displayed: 33%, 50%
- Exported successfully: 1080×1920, 2.5 MB, 1 min 37 sec
- Toggle OFF reverts to center crop
- Preset change resets the feature

## Files changed
- `src/lib/types.ts` — added `AutoReframeSettings`
- `src/lib/analyzeFrame.ts` — new canvas frame analyzer
- `src/lib/ffmpeg.ts` — dynamic crop offset in `buildVideoFilter`
- `src/hooks/useVideoEditor.ts` — reset autoReframe on preset/file change
- `src/components/AutoReframeControl.tsx` — new toggle UI
- `src/components/VideoEditor.tsx` — wired up the control

Closes #1186