### PR TITLE
chore: add .gitattributes file to normalize cross-platform line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Set default behavior to automatically normalize line endings to LF
+* text=auto eol=lf
+
+# Explicitly declare files that must always use LF
+*.ts text eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.css text eol=lf
+*.html text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
+# Explicitly denote binary files that should never be modified by Git line conversions
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary
+*.svg text
+*.mp4 binary


### PR DESCRIPTION
## Description
This PR introduces a root `.gitattributes` file to enforce automatic normalization of text files to Unix-style line endings (`LF`) across different operating systems. Inconsistent line formats (`LF` vs `CRLF`) between Windows and Unix/Linux contributors often lead to Git tracking noisy, accidental line modifications in file diffs. Setting this standard configuration ensures cross-platform consistency and clean, predictable Git commit histories.

## Related Issue
Closes #1270

## Type of Contribution
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: atharv96k
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue