### PR TITLE
feat: add interactive export frame preview

### DIFF
--- a/src/components/FramingControl.tsx
+++ b/src/components/FramingControl.tsx
@@ -10,39 +10,95 @@ interface Props {
 }
 
 export default function FramingControl({ recipe, onChange }: Props) {
+  const framePositionX = recipe.framePositionX ?? 50;
+  const framePositionY = recipe.framePositionY ?? 50;
+
   return (
-    <div className="flex gap-2">
-      {(["fit", "fill"] as const).map((mode) => {
-        const Icon = mode === "fit" ? Maximize2 : Crop;
-        const active = recipe.framing === mode;
-        return (
-          <button
-            type="button"
-            key={mode}
-            title={mode === "fit" ? "Fit: Adds black bars (letterbox) to fill empty space" : "Fill: Crops the video to fill the entire frame"}
-            onClick={() => onChange({ framing: mode })}
-            className={cn(
-              "flex-1 min-h-[44px] min-w-[44px] flex flex-col items-center justify-center gap-2 py-4 rounded-lg border transition-all duration-150 hover:scale-[1.02] active:scale-[0.98]",
-              active
-                ? "border-film-500 bg-film-50 text-film-700"
-                : "border-[var(--border)] text-[var(--muted)] hover:border-film-300 bg-[var(--surface)]"
-            )}
-          >
-            <Icon size={18} aria-hidden="true" />
-            <span className="sr-only">
-              Set framing to {mode === "fit" ? "fit within frame" : "fill frame by cropping"}
+    <div className="space-y-3">
+      <div className="flex gap-2">
+        {(["fit", "fill"] as const).map((mode) => {
+          const Icon = mode === "fit" ? Maximize2 : Crop;
+          const active = recipe.framing === mode;
+          return (
+            <button
+              type="button"
+              key={mode}
+              title={mode === "fit" ? "Fit: Adds black bars (letterbox) to fill empty space" : "Fill: Crops the video to fill the entire frame"}
+              onClick={() => onChange({ framing: mode })}
+              className={cn(
+                "flex-1 min-h-[44px] min-w-[44px] flex flex-col items-center justify-center gap-2 py-4 rounded-lg border transition-all duration-150 hover:scale-[1.02] active:scale-[0.98]",
+                active
+                  ? "border-film-500 bg-film-50 text-film-700"
+                  : "border-[var(--border)] text-[var(--muted)] hover:border-film-300 bg-[var(--surface)]"
+              )}
+            >
+              <Icon size={18} aria-hidden="true" />
+              <span className="sr-only">
+                Set framing to {mode === "fit" ? "fit within frame" : "fill frame by cropping"}
+              </span>
+              <div className="text-center">
+                <p className="text-xs font-heading font-semibold uppercase tracking-wider">
+                  {mode === "fit" ? "Fit" : "Fill"}
+                </p>
+                <p className="text-[10px] text-[var(--muted)] mt-0.5">
+                  {mode === "fit" ? "Letterbox / pillarbox" : "Crop to frame"}
+                </p>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {recipe.framing === "fill" && (
+        <div className="rounded-lg border border-[var(--border)] bg-[var(--surface)] p-3 space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-[10px] font-heading font-bold uppercase tracking-wider text-[var(--muted)]">
+              Crop position
+            </p>
+            <button
+              type="button"
+              onClick={() => onChange({ framePositionX: 50, framePositionY: 50 })}
+              className="text-[10px] font-heading font-bold uppercase tracking-wider text-film-500 hover:underline"
+            >
+              Center
+            </button>
+          </div>
+
+          <label className="block space-y-1">
+            <span className="flex items-center justify-between text-xs text-[var(--muted)]">
+              <span>Horizontal</span>
+              <span>{framePositionX}%</span>
             </span>
-            <div className="text-center">
-              <p className="text-xs font-heading font-semibold uppercase tracking-wider">
-                {mode === "fit" ? "Fit" : "Fill"}
-              </p>
-              <p className="text-[10px] text-[var(--muted)] mt-0.5">
-                {mode === "fit" ? "Letterbox / pillarbox" : "Crop to frame"}
-              </p>
-            </div>
-          </button>
-        );
-      })}
+            <input
+              type="range"
+              min={0}
+              max={100}
+              step={1}
+              value={framePositionX}
+              onChange={(event) => onChange({ framePositionX: Number(event.target.value) })}
+              className="w-full accent-film-500"
+              aria-label="Horizontal crop position"
+            />
+          </label>
+
+          <label className="block space-y-1">
+            <span className="flex items-center justify-between text-xs text-[var(--muted)]">
+              <span>Vertical</span>
+              <span>{framePositionY}%</span>
+            </span>
+            <input
+              type="range"
+              min={0}
+              max={100}
+              step={1}
+              value={framePositionY}
+              onChange={(event) => onChange({ framePositionY: Number(event.target.value) })}
+              className="w-full accent-film-500"
+              aria-label="Vertical crop position"
+            />
+          </label>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -36,7 +36,8 @@ export default function VideoPreview({
     width: 0,
     height: 0,
   });
-  const previewContainerRef = useRef<HTMLDivElement>(null);
+  const previewShellRef = useRef<HTMLDivElement>(null);
+  const outputFrameRef = useRef<HTMLDivElement>(null);
   const onLoadedRef = useRef<(() => void) | null>(null);
 
   const handleGrabFrame = useCallback(() => {
@@ -126,12 +127,12 @@ export default function VideoPreview({
   }, [recipe, videoRef]);
 
   /**
-   * Track preview container dimensions for text overlay positioning.
+   * Track output frame dimensions for overlay positioning.
    */
   useEffect(() => {
     const updateDimensions = () => {
-      if (previewContainerRef.current) {
-        const rect = previewContainerRef.current.getBoundingClientRect();
+      if (outputFrameRef.current) {
+        const rect = outputFrameRef.current.getBoundingClientRect();
         setContainerDimensions({
           width: rect.width,
           height: rect.height,
@@ -140,53 +141,41 @@ export default function VideoPreview({
     };
 
     updateDimensions();
+    const observer = typeof ResizeObserver !== "undefined"
+      ? new ResizeObserver(updateDimensions)
+      : null;
+    if (observer && outputFrameRef.current) {
+      observer.observe(outputFrameRef.current);
+    }
     window.addEventListener("resize", updateDimensions);
-    return () => window.removeEventListener("resize", updateDimensions);
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", updateDimensions);
+    };
   }, []);
 
-  const overlay = (() => {
-    if (!recipe || !showOverlay) return null;
-
+  const outputFrame = (() => {
+    const fallback = { width: 16, height: 9 };
+    if (!recipe) return fallback;
     const preset = recipe.preset === "custom"
       ? { width: recipe.customWidth, height: recipe.customHeight }
       : getPresetById(recipe.preset);
 
-    if (!preset) return null;
-
-    // Preview container is 16:9
-    const containerW = 16;
-    const containerH = 9;
-    const containerRatio = containerW / containerH;   // 1.777…
-    const outputRatio = preset.width / preset.height;
-
-    if (recipe.framing === "fit") {
-      // Letterbox: the output video fits entirely inside 16:9, padded with bars.
-      if (outputRatio > containerRatio) {
-        // Wider output → pillarbox bars on top & bottom
-        const contentH = (containerRatio / outputRatio) * 100;
-        const barH = (100 - contentH) / 2;
-        return { mode: "fit", barTop: `${barH}%`, barBottom: `${barH}%`, barLeft: "0", barRight: "0" };
-      } else {
-        // Taller output → letterbox bars on left & right
-        const contentW = (outputRatio / containerRatio) * 100;
-        const barW = (100 - contentW) / 2;
-        return { mode: "fit", barTop: "0", barBottom: "0", barLeft: `${barW}%`, barRight: `${barW}%` };
-      }
-    } else {
-      // Fill / crop: the output fills the entire 16:9 preview — show a box representing what survives the crop.
-      if (outputRatio < containerRatio) {
-        // Output is taller → crops top & bottom
-        const visibleH = (outputRatio / containerRatio) * 100;
-        const cropH = (100 - visibleH) / 2;
-        return { mode: "fill", barTop: `${cropH}%`, barBottom: `${cropH}%`, barLeft: "0", barRight: "0" };
-      } else {
-        // Output is wider → crops left & right
-        const visibleW = (containerRatio / outputRatio) * 100;
-        const cropW = (100 - visibleW) / 2;
-        return { mode: "fill", barTop: "0", barBottom: "0", barLeft: `${cropW}%`, barRight: `${cropW}%` };
-      }
-    }
+    return preset ?? fallback;
   })();
+
+  const outputRatio = outputFrame.width / outputFrame.height;
+  const previewRatio = 16 / 9;
+  const frameStyle: React.CSSProperties = {
+    aspectRatio: `${outputFrame.width} / ${outputFrame.height}`,
+    width: outputRatio >= previewRatio ? "100%" : "auto",
+    height: outputRatio >= previewRatio ? "auto" : "100%",
+    maxWidth: "100%",
+    maxHeight: "100%",
+  };
+  const objectPosition = recipe
+    ? `${recipe.framePositionX ?? 50}% ${recipe.framePositionY ?? 50}%`
+    : "50% 50%";
 
   if (!file) return null;
 
@@ -216,86 +205,69 @@ export default function VideoPreview({
   return (
     <>
       <div
-        ref={previewContainerRef}
+        ref={previewShellRef}
         role="group"
-        className="relative w-full rounded-lg overflow-hidden bg-[var(--bg)] aspect-video focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+        className="relative flex w-full items-center justify-center rounded-lg overflow-hidden bg-[var(--bg)] aspect-video p-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
         tabIndex={0}
         onKeyDown={handleKeyDown}
         aria-label="Video preview (press Space to play/pause)"
       >
-        {isLoading && (
-          <div
-            className="absolute inset-0 animate-pulse bg-[var(--surface)] rounded-xl transition-opacity duration-300"
-            aria-label="Loading video preview"
-          />
-        )}
-        {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-        <video
-          ref={videoRef}
-          controls
-          className={cn("w-full h-full object-contain transition-opacity duration-300", isLoading ? "opacity-0" : "opacity-100")}
-          onLoadedData={() => setIsLoading(false)}
-          playsInline
-          muted={!recipe?.keepAudio}
+        <div
+          ref={outputFrameRef}
+          className="relative overflow-hidden rounded-md bg-black shadow-[0_0_0_1px_var(--border)]"
+          style={frameStyle}
+          aria-label={`${outputFrame.width} by ${outputFrame.height} export frame`}
         >
-          <track kind="captions" />
-        </video>
+          {isLoading && (
+            <div
+              className="absolute inset-0 animate-pulse bg-[var(--surface)] rounded-xl transition-opacity duration-300"
+              aria-label="Loading video preview"
+            />
+          )}
+          {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+          <video
+            ref={videoRef}
+            controls
+            className={cn("w-full h-full transition-opacity duration-300", isLoading ? "opacity-0" : "opacity-100")}
+            style={{
+              objectFit: recipe?.framing === "fill" ? "cover" : "contain",
+              objectPosition,
+            }}
+            onLoadedData={() => setIsLoading(false)}
+            playsInline
+            muted={!recipe?.keepAudio}
+          >
+            <track kind="captions" />
+          </video>
 
-        {/* Letterbox / Crop overlay */}
-        {overlay && (
-          <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
-            {overlay.mode === "fit" ? (
-              // Letterbox: semi-transparent bars outside the content area
-              <>
-                <div className="absolute left-0 right-0 top-0 bg-[color-mix(in_srgb,var(--bg)_60%,transparent)]" style={{ height: overlay.barTop }} />
-                <div className="absolute left-0 right-0 bottom-0 bg-[color-mix(in_srgb,var(--bg)_60%,transparent)]" style={{ height: overlay.barBottom }} />
-                <div className="absolute top-0 bottom-0 left-0 bg-[color-mix(in_srgb,var(--bg)_60%,transparent)]" style={{ width: overlay.barLeft }} />
-                <div className="absolute top-0 bottom-0 right-0 bg-[color-mix(in_srgb,var(--bg)_60%,transparent)]" style={{ width: overlay.barRight }} />
-              </>
-            ) : (
-              // Fill/crop: dashed border around the surviving area, dimmed outside
-              <>
-                <div className="absolute left-0 right-0 top-0 bg-[var(--error-bg)]" style={{ height: overlay.barTop }} />
-                <div className="absolute left-0 right-0 bottom-0 bg-[var(--error-bg)]" style={{ height: overlay.barBottom }} />
-                <div className="absolute top-0 bottom-0 left-0 bg-[var(--error-bg)]" style={{ width: overlay.barLeft }} />
-                <div className="absolute top-0 bottom-0 right-0 bg-[var(--error-bg)]" style={{ width: overlay.barRight }} />
-                <div
-                  className="absolute border-2 border-dashed border-film-400"
-                  style={{
-                    top: overlay.barTop,
-                    bottom: overlay.barBottom,
-                    left: overlay.barLeft,
-                    right: overlay.barRight,
-                  }}
-                />
-              </>
-            )}
-          </div>
-        )}
+          {showOverlay && (
+            <div className="absolute inset-0 pointer-events-none ring-2 ring-film-400" aria-hidden="true">
+              <div className="absolute left-2 top-2 rounded bg-black/70 px-2 py-1 text-[10px] font-heading font-bold uppercase tracking-wider text-white">
+                {recipe?.framing === "fill" ? "Live crop frame" : "Live letterbox frame"}
+              </div>
+            </div>
+          )}
 
-        {/* 3x3 Grid Overlay */}
-        {showGridOverlay && (
-          <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
-            {/* Vertical lines */}
-            <div className="absolute top-0 bottom-0 left-1/3 border-l-2 border-dotted border-black" />
-            <div className="absolute top-0 bottom-0 right-1/3 border-l-2 border-dotted border-black" />
-            {/* Horizontal lines */}
-            <div className="absolute left-0 right-0 top-1/3 border-t-2 border-dotted border-black" />
-            <div className="absolute left-0 right-0 bottom-1/3 border-t-2 border-dotted border-black" />
-          </div>
-        )}
+          {showGridOverlay && (
+            <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
+              <div className="absolute top-0 bottom-0 left-1/3 border-l-2 border-dotted border-white/65" />
+              <div className="absolute top-0 bottom-0 right-1/3 border-l-2 border-dotted border-white/65" />
+              <div className="absolute left-0 right-0 top-1/3 border-t-2 border-dotted border-white/65" />
+              <div className="absolute left-0 right-0 bottom-1/3 border-t-2 border-dotted border-white/65" />
+            </div>
+          )}
 
-        {/* Draggable Text Overlays */}
-        {recipe && !isLoading && containerDimensions.width > 0 && (
-          <DraggableTextOverlays
-            recipe={recipe}
-            containerWidth={containerDimensions.width}
-            containerHeight={containerDimensions.height}
-            selectedTextId={selectedTextId ?? null}
-            onSelectText={onSelectText || (() => {})}
-            onUpdateText={onUpdateText || (() => {})}
-          />
-        )}
+          {recipe && !isLoading && containerDimensions.width > 0 && (
+            <DraggableTextOverlays
+              recipe={recipe}
+              containerWidth={containerDimensions.width}
+              containerHeight={containerDimensions.height}
+              selectedTextId={selectedTextId ?? null}
+              onSelectText={onSelectText || (() => {})}
+              onUpdateText={onUpdateText || (() => {})}
+            />
+          )}
+        </div>
 
         {/* Toggle button */}
         {recipe && !isLoading && (

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -208,6 +208,9 @@ export function useVideoEditor() {
         return typeof val === "number" && !isNaN(val) && val >= 16 && val <= 7680;
       case "framing":
         return val === "fit" || val === "fill";
+      case "framePositionX":
+      case "framePositionY":
+        return typeof val === "number" && !isNaN(val) && val >= 0 && val <= 100;
       case "trimStart":
         return typeof val === "number" && !isNaN(val) && val >= 0;
       case "trimEnd":

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -8,6 +8,8 @@ export const DEFAULT_RECIPE: EditRecipe = {
   customWidth: 1920,
   customHeight: 1080,
   framing: "fit",
+  framePositionX: 50,
+  framePositionY: 50,
   trimStart: 0,
   trimEnd: null,
   rotate: 0,

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -351,9 +351,11 @@ export function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: n
       `pad=${targetW}:${targetH}:(ow-iw)/2:(oh-ih)/2:color=black`
     );
   } else {
+    const cropX = ((recipe.framePositionX ?? 50) / 100).toFixed(4);
+    const cropY = ((recipe.framePositionY ?? 50) / 100).toFixed(4);
     filters.push(
       `scale=${targetW}:${targetH}:force_original_aspect_ratio=increase`,
-      `crop=${targetW}:${targetH}`
+      `crop=${targetW}:${targetH}:(iw-ow)*${cropX}:(ih-oh)*${cropY}`
     );
   }
 

--- a/src/lib/ffmpeg.worker.ts
+++ b/src/lib/ffmpeg.worker.ts
@@ -105,9 +105,11 @@ function buildVideoFilter(recipe: EditRecipe, targetW: number, targetH: number):
       `pad=${targetW}:${targetH}:(ow-iw)/2:(oh-ih)/2:color=black`
     );
   } else {
+    const cropX = ((recipe.framePositionX ?? 50) / 100).toFixed(4);
+    const cropY = ((recipe.framePositionY ?? 50) / 100).toFixed(4);
     filters.push(
       `scale=${targetW}:${targetH}:force_original_aspect_ratio=increase`,
-      `crop=${targetW}:${targetH}`
+      `crop=${targetW}:${targetH}:(iw-ow)*${cropX}:(ih-oh)*${cropY}`
     );
   }
 

--- a/src/lib/tests/videoFilter.test.ts
+++ b/src/lib/tests/videoFilter.test.ts
@@ -61,7 +61,17 @@ describe("buildVideoFilter", () => {
   it("should use fill framing with scale and crop", () => {
     const result = buildVideoFilter(base({ framing: "fill" }), 1280, 720);
     expect(result).toContain("force_original_aspect_ratio=increase");
-    expect(result).toContain("crop=1280:720");
+    expect(result).toContain("crop=1280:720:(iw-ow)*0.5000:(ih-oh)*0.5000");
+  });
+
+  it("should pass crop position to fill framing", () => {
+    const result = buildVideoFilter(
+      base({ framing: "fill", framePositionX: 25, framePositionY: 75 }),
+      1280,
+      720
+    );
+
+    expect(result).toContain("crop=1280:720:(iw-ow)*0.2500:(ih-oh)*0.7500");
   });
 
   it("should include deshake when stabilization is true", () => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,6 +20,8 @@ export interface EditRecipe {
   customWidth: number;
   customHeight: number;
   framing: "fit" | "fill";
+  framePositionX: number;
+  framePositionY: number;
   trimStart: number;
   trimEnd: number | null;
   rotate: 0 | 90 | 180 | 270;
@@ -90,6 +92,10 @@ export function isValidRecipe(value: unknown): value is EditRecipe {
   if (typeof v.customWidth !== "number" || !isFinite(v.customWidth)) return false;
   if (typeof v.customHeight !== "number" || !isFinite(v.customHeight)) return false;
   if (v.framing !== "fit" && v.framing !== "fill") return false;
+  if (typeof v.framePositionX !== "number" || !isFinite(v.framePositionX)) return false;
+  if (typeof v.framePositionY !== "number" || !isFinite(v.framePositionY)) return false;
+  if (v.framePositionX < 0 || v.framePositionX > 100) return false;
+  if (v.framePositionY < 0 || v.framePositionY > 100) return false;
   if (typeof v.trimStart !== "number" || !isFinite(v.trimStart)) return false;
   if (!(v.trimEnd === null || (typeof v.trimEnd === "number" && isFinite(v.trimEnd)))) return false;
   if (![0, 90, 180, 270].includes(v.rotate)) return false;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vitest/config'
+import { fileURLToPath, URL } from 'node:url'
 
 export default defineConfig({
   oxc: {
     jsx: {
       runtime: 'automatic',
+    },
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
   test: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,41 @@
 // Vitest setup: polyfills and global mocks
 import '@testing-library/jest-dom/vitest'
 
+function createMemoryStorage(): Storage {
+  let store: Record<string, string> = {};
+
+  return {
+    get length() {
+      return Object.keys(store).length;
+    },
+    clear: () => {
+      store = {};
+    },
+    getItem: (key: string) => store[key] ?? null,
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+  };
+}
+
+if (!globalThis.localStorage) {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: createMemoryStorage(),
+  });
+}
+
+if (!window.localStorage) {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: globalThis.localStorage,
+  });
+}
+
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   value: (query: string) => ({


### PR DESCRIPTION
## Description
Fixes #391

Adds a live export-frame preview so the editor shows the selected output aspect ratio before export instead of only drawing crop guide bars over a 16:9 player. Fill mode now supports horizontal and vertical crop-position sliders, and those values are passed into the FFmpeg crop expression so preview and export stay aligned.

Also fixes the local Vitest harness so the existing at-sign import alias and localStorage-dependent tests run reliably.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Manual smoke: started the app locally on http://localhost:3017 and generated a 2-second MP4 sample for visual follow-up testing
- [x] npm exec vitest -- run src/lib/tests/videoFilter.test.ts -- 17 passed
- [x] npm test -- --run -- 78 passed
- [x] npx tsc --noEmit --pretty false
- [x] npx next lint -- no warnings/errors
- [x] npm run build
- [x] git diff --check

## Checklist:
- [x] My code follows the Coding Guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have NOT added useless AI-generated comments.
- [x] I have NOT deleted existing unrelated comments.
- [x] I have NOT modified files unrelated to this task.
- [x] My changes generate no new warnings in lint/build.
- [x] I have linked the issue I am working on.

## Screenshots (if applicable)
No static screenshot attached yet; the local app is running and ready for visual proof if requested.