### PR TITLE
fix: add clear red border validation feedback to trim inputs #221

### DIFF
--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -57,39 +57,40 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
     }
   }, [xToSeconds, duration, recipe.trimStart, recipe.trimEnd, onChange]);
 
- useEffect(() => {
-  const onMove = (e: MouseEvent | TouchEvent) => {
-    let clientX: number;
+  useEffect(() => {
+    const onMove = (e: MouseEvent | TouchEvent) => {
+      let clientX: number;
 
-    if ("touches" in e) {
-      const touch = e.touches[0];
+      if ("touches" in e) {
+        const touch = e.touches[0];
 
-      if (!touch) return;
+        if (!touch) return;
 
-      clientX = touch.clientX;
-    } else {
-      clientX = e.clientX;
-    }
+        clientX = touch.clientX;
+      } else {
+        clientX = e.clientX;
+      }
 
-    applyDrag(clientX);
-  };
+      applyDrag(clientX);
+    };
 
-  const onUp = () => {
-    dragging.current = null;
-  };
+    const onUp = () => {
+      dragging.current = null;
+    };
 
-  document.addEventListener("mousemove", onMove);
-  document.addEventListener("mouseup", onUp);
-  document.addEventListener("touchmove", onMove);
-  document.addEventListener("touchend", onUp);
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+    document.addEventListener("touchmove", onMove);
+    document.addEventListener("touchend", onUp);
 
-  return () => {
-    document.removeEventListener("mousemove", onMove);
-    document.removeEventListener("mouseup", onUp);
-    document.removeEventListener("touchmove", onMove);
-    document.removeEventListener("touchend", onUp);
-  };
-}, [applyDrag]);
+    return () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+      document.removeEventListener("touchmove", onMove);
+      document.removeEventListener("touchend", onUp);
+    };
+  }, [applyDrag]);
+
   const handleStart = (val: string) => {
     setStartInput(val);
 
@@ -173,7 +174,7 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
   };
 
   const inputClass =
-    "w-full text-sm px-3 py-2 border border-[var(--border)] rounded-md bg-[var(--bg)] font-heading focus:outline-none focus:ring-2 focus:ring-film-400 text-[var(--text)] transition-shadow [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none";
+    "w-full text-sm px-3 py-2 border rounded-md bg-[var(--bg)] font-heading focus:outline-none focus:ring-2 focus:ring-film-400 text-[var(--text)] transition-shadow [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none";
 
   return (
     <div id="trim-control" className="space-y-3">
@@ -257,9 +258,10 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
             aria-label="Trim start time in seconds"
             aria-invalid={invalidStart}
             aria-describedby={invalidStart ? "trim-start-error" : undefined}
-            className={`${inputClass} ${
-              invalidStart ? "border-[var(--error)]" : "border-[var(--border)]"
-            }`}
+            className={`${inputClass} ${invalidStart
+                ? "border-red-500 focus:ring-red-500 focus:border-red-500"
+                : "border-[var(--border)]"
+              }`}
             placeholder="0"
           />
           {invalidStart && (
@@ -294,9 +296,10 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
             aria-label="Trim end time in seconds"
             aria-invalid={invalidEnd}
             aria-describedby={invalidEnd ? "trim-end-error" : undefined}
-            className={`${inputClass} ${
-              invalidEnd ? "border-[var(--error)]" : "border-[var(--border)]"
-            }`}
+            className={`${inputClass} ${invalidEnd
+                ? "border-red-500 focus:ring-red-500 focus:border-red-500"
+                : "border-[var(--border)]"
+              }`}
             placeholder={duration > 0 ? `${duration.toFixed(1)}` : "full length"}
           />
           {invalidEnd && (
@@ -322,9 +325,7 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
           <p className="text-[10px] text-[var(--error)] font-heading">
             Clip must be at least 0.1 seconds long.
           </p>
-      )}
+        )}
     </div>
   );
 }
-
-


### PR DESCRIPTION
### Description
Replaced the template literal conditional style logic for the 'trim-start' and 'trim-end' input components to directly apply high-visibility Tailwind red color classes on invalid validation states.

Closes #221
## Related Issue
## Type of Contribution
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] GSSoC contribution

## Participant Info
- GitHub username: 
- Contribution level (Beginner/Intermediate/Advanced): 

## Screen Recording
> **How to record:** run `bun run dev` → open http://localhost:3000 → demonstrate the full working flow of your change, including any edge cases.
>
> - **macOS**: `Cmd + Shift + 5` → Record Selected Portion, or use QuickTime Player
> - **Windows**: `Win + G` → Xbox Game Bar → Capture
> - **Linux**: OBS Studio, GNOME Screenshot tool, or `kazam`
> - **Any OS**: [Loom](https://loom.com) (free screen recorder, great for sharing)

**Recording / Loom link:** ## Checklist
- [ ] I have read the contribution guidelines
- [ ] My changes follow the project structure
- [ ] I have tested my changes in Chrome, Firefox, and Safari
- [ ] `bun run lint` passes (no ESLint errors)
- [ ] `bunx tsc --noEmit` passes (no TypeScript errors)
- [ ] New interactive elements have `aria-label` / accessible names
- [ ] No `console.log` statements left in
- [ ] This PR is related to a valid issue
- [ ] **Screen recording attached above** (required for UI/feature/design changes)