### PR TITLE
fix: remove duplicate main landmarks and id='main-content' across pages

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -6,7 +6,7 @@ export const metadata: Metadata = {
 };
 export default function ContactPage() {
   return (
-    <main className="min-h-screen bg-[var(--bg)] text-[var(--text)] p-8">
+    <div className="min-h-screen bg-[var(--bg)] text-[var(--text)] p-8">
       <div className="mb-8">
         <Link 
           href="/" 
@@ -46,6 +46,6 @@ export default function ContactPage() {
           <p className="text-[var(--muted)] mt-1">For questions, ideas, and general help.</p>
         </div>
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,9 +13,7 @@ export default function Home() {
         ⭐ Star on GitHub
       </a>
 
-      <main id="main-content" tabIndex={-1}>
-        <VideoEditor />
-      </main>
+      <VideoEditor />
 
       <Footer />
     </>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
 export default function PrivacyPage() {
   return (
     <>
-      <main className="min-h-screen bg-[var(--bg)] text-[var(--text)] pt-24 pb-20">
+      <div className="min-h-screen bg-[var(--bg)] text-[var(--text)] pt-24 pb-20">
 
         {/* Back link - top left below header */}
         <div className="px-6 mb-6">
@@ -84,7 +84,7 @@ export default function PrivacyPage() {
             </div>
           </div>
         </div>
-      </main>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Description

Fixes duplicate `id="main-content"` values and nested `<main>` landmark elements that caused invalid HTML and accessibility issues for screen readers and keyboard users.

### Root Cause

`layout.tsx` already renders a single:

```html
<main id="main-content">
```

that wraps all page content.

However, `page.tsx`, `privacy/page.tsx`, and `contact/page.tsx` were also rendering their own `<main>` elements, resulting in:

- Duplicate `id="main-content"` on the homepage
- Nested `<main>` landmarks across pages
- Invalid HTML structure
- Accessibility issues for screen readers and keyboard navigation

### Changes Made

- `src/app/layout.tsx` — No changes required; remains the single source of truth for `<main id="main-content">`
- `src/app/page.tsx` — Removed the duplicate `<main id="main-content">` wrapper around `<VideoEditor />`
- `src/app/privacy/page.tsx` — Replaced `<main>` with `<div>`
- `src/app/contact/page.tsx` — Replaced `<main>` with `<div>`

### Result

- Only one `id="main-content"` exists per page
- Only one `<main>` landmark exists per page
- Skip-link navigation works correctly
- Improved accessibility and valid HTML structure

## Related Issue

Closes #1264 

---

## Type of Contribution

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] GSSoC contribution

---

## Participant Info

**GitHub Username:** mayurigade-hub

**Contribution Level:** Intermediate

---

## Screen Recording

Not required. This is a structural accessibility fix with no visual UI changes.

Verification can be done through browser DevTools by confirming:

- Only one `id="main-content"` exists
- Only one `<main>` landmark exists per page

---

## Checklist

- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome
- [x] `bun run lint` passes
- [x] `bunx tsc --noEmit` passes
- [x] New interactive elements have accessible names where applicable
- [x] No `console.log` statements remain
- [x] This PR is related to a valid issue