### PR TITLE
fix: update Vercel deployment instructions to remove incorrect Output…

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Reframe uses static export (`output: 'export'`) and can be deployed easily on Ve
 4. Configure:
    - Framework Preset: Next.js
    - Build Command: `bun run build`
-   - Output Directory: `out`
+   - Output Directory: leave blank (Vercel auto-detects `out` for static exports)
 5. Click **Deploy**
 
 Vercel will automatically build and host the static output.
@@ -214,7 +214,7 @@ The quickest way to get Reframe live:
 3. Vercel auto-detects Next.js settings:
    - **Framework Preset:** Next.js
    - **Build Command:** `bun run build`
-   - **Output Directory:** `out`
+   - **Output Directory:** leave blank (Vercel auto-detects `out` for static exports)
 4. Click **Deploy** — your site will be live in ~2 minutes
 
 **Option 2 — Vercel CLI**


### PR DESCRIPTION
## Summary
Fixes incorrect Vercel deployment instructions in README.md that caused `routes-manifest.json couldn't be found` errors.
Closes #1238

---
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / code cleanup

---
## Changes Made
- Updated both Vercel deployment sections in README.md
- Removed hardcoded `out` as Output Directory
- Added note that Vercel auto-detects the output directory for Next.js static exports

---
## How to Test
1. Follow the updated README deployment instructions
2. Deploy to Vercel without setting Output Directory manually
3. Vercel should auto-detect `out` and deploy successfully

---
## Checklist
- [x] Linked issue in summary
- [x] Self-reviewed the diff
- [x] No TypeScript errors