### PR TITLE
fix: correct main heading hierarchy

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -82,7 +82,7 @@ export default function RootLayout({
             >
               <div className="flex items-center gap-2">
                 <BrandLogo size={24} />
-                <h1 className="text-lg font-semibold">Reframe</h1>
+                <span className="text-lg font-semibold">Reframe</span>
               </div>
               <ThemeToggle />
             </header>

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -42,9 +42,9 @@ function Section({ icon, title, children, delay = 0 }: SectionProps) {
     >
       <div className="flex items-center gap-2">
         <span className="text-film-500 opacity-80">{icon}</span>
-        <h3 className="text-sm font-heading font-bold uppercase tracking-widest text-[var(--muted)]">
+        <h2 className="text-sm font-heading font-bold uppercase tracking-widest text-[var(--muted)]">
           {title}
-        </h3>
+        </h2>
         <div className="flex-1 h-px bg-[var(--border)]" />
       </div>
       {children}


### PR DESCRIPTION
Closes #69

## Summary
- keep the sticky header brand text visually unchanged without rendering a second page-level `h1`
- promote reusable editor section labels from `h3` to `h2` so the main page follows `h1 -> h2` order
- verified the app shell, home page, and video editor now expose one `h1` and no skipped heading level in the targeted files

## Validation
- `npx tsc --noEmit --pretty false`
- `npm run lint -- --file src/app/layout.tsx --file src/app/page.tsx --file src/components/VideoEditor.tsx`
- `npm run build`
- `git diff --check`

Note: dependency install required `npm install --legacy-peer-deps` because the repo currently has a React 19 / @testing-library/react 14 peer dependency conflict under plain `npm install`. No dependency or lockfile changes are included.