### PR TITLE
feat(ffmpeg): add service worker caching for FFmpeg WASM assets

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,47 @@
+const CACHE_NAME = "ffmpeg-wasm-v1";
+
+const FFMPEG_URLS = [
+  "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd/ffmpeg-core.js",
+  "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd/ffmpeg-core.wasm",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(FFMPEG_URLS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key !== CACHE_NAME)
+          .map((key) => caches.delete(key))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener("fetch", (event) => {
+  const url = event.request.url;
+
+  if (FFMPEG_URLS.some((asset) => url.startsWith(asset))) {
+    event.respondWith(
+      caches.match(event.request).then((cached) => {
+        return (
+          cached ||
+          fetch(event.request).then((response) => {
+            const cloned = response.clone();
+            caches.open(CACHE_NAME).then((cache) => {
+              cache.put(event.request, cloned);
+            });
+            return response;
+          })
+        );
+      })
+    );
+  }
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from "@/components/ThemeProvider";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import ScrollToTop from "@/components/ScrollToTop";
 import BrandLogo from "@/components/BrandLogo";
+import Script from "next/script";
 
 export const metadata: Metadata = {
   title: "Reframe — Resize, trim, and export videos in your browser",
@@ -64,6 +65,19 @@ export default function RootLayout({
 })();`,
           }}
         />
+
+        <Script id="sw-register" strategy="afterInteractive">
+          {`
+          if ('serviceWorker' in navigator) {
+          window.addEventListener('load', () => {
+          navigator.serviceWorker
+          .register('/sw.js')
+          .catch((err) => console.error('SW registration failed:', err));
+          });
+          }
+        `}
+        </Script>
+
         <link rel="preconnect" href="https://cdn.jsdelivr.net" />
         <link rel="dns-prefetch" href="https://cdn.jsdelivr.net" />
       </head>


### PR DESCRIPTION
## Description
Implemented service worker caching for FFmpeg WASM assets.

### Changes made:
- Added `public/sw.js` service worker
- Cached FFmpeg WASM assets using Cache API
- Registered service worker in `src/app/layout.tsx`
- Added cache versioning and cleanup of old caches on activation

### Benefits:
- FFmpeg WASM files are cached after first download
- Subsequent loads use cached assets
- Reduced repeated network downloads of large FFmpeg WASM files
- Improved performance and loading experience

## Closes #181

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: deepsikha-dash
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Screen Recording
N/A

**Recording / Loom link:** ## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [ ] **Screen recording attached above** (required for UI/feature/design changes)