### PR TITLE
docs(gssoc): remove duplicate Contributors section in README (#234)

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,15 +417,7 @@ Reframe is an **official project in GirlScript Summer of Code (GSSoC) 2026**! We
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide including development setup, code style, and PR checklist.
 
----
 
-## Contributors
-
-Thank you to everyone who has contributed to Reframe! 🎉
-
-[![Contributors](https://contrib.rocks/image?repo=magic-peach/reframe)](https://github.com/magic-peach/reframe/graphs/contributors)
-
----
 
 ## Privacy
 


### PR DESCRIPTION
### Description
This Pull Request resolves GSSoC'26 issue **#234 (Contributors Consolidation)**:
- Consolidates the two duplicate Contributors blocks present in the main `README.md` into a single, beautifully organized Contributors footer.
- Cleans up trailing horizontal rule markdown layouts to improve the visual formatting of the document.

---

### Verification
- **Formatting**: Verified that exactly one Contributors graph and footer section remains at the bottom of the `README.md` file.