### PR TITLE
test(gssoc): configure and expand getPresetById unit tests (#232)

### DIFF
--- a/src/lib/exportEstimate.test.ts
+++ b/src/lib/exportEstimate.test.ts
@@ -1,3 +1,4 @@
+import { describe, test, expect } from "vitest";
 import { estimateExportSize, formatEstimatedSize } from "./exportEstimate";
 import { EditRecipe } from "./types";
 

--- a/src/lib/tests/presets.test.ts
+++ b/src/lib/tests/presets.test.ts
@@ -21,4 +21,10 @@ describe('getPresetById', () => {
       expect(p.platform).toBeTruthy();
     });
   });
+
+  it('returns custom preset correctly', () => {
+    const preset = getPresetById('custom');
+    expect(preset?.id).toBe('custom');
+    expect(preset?.label).toBe('Custom');
+  });
 });


### PR DESCRIPTION
### Description
This Pull Request resolves GSSoC'26 issue **#232 (Unit test for getPresetById)**:
- Resolves the crashing Vitest test suite environment by explicitly importing environment functions (`describe`, `test`, `expect`) inside `src/lib/exportEstimate.test.ts`.
- Expands the unit test coverage inside `src/lib/tests/presets.test.ts` by introducing a dedicated test case that verifies the correct identification, lookup, and properties of the `custom` preset config on the `getPresetById` utility function.

---

### Verification
- **Tests**: Ran all unit tests with `npm test -- --run`. All 54 tests now execute and pass perfectly.