### PR TITLE
fix(a11y): announce ffmpeg loading state

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -363,6 +363,26 @@ return () => {
     };
   }, [videoSrc]);
 
+  const exportStatusAnnouncement = useMemo(() => {
+    if (status === "loading-engine") {
+      return "Loading video processing engine, please wait.";
+    }
+
+    if (status === "exporting") {
+      return `Export started. Exporting video: ${progress}%`;
+    }
+
+    if (status === "done") {
+      return "Export complete! Video ready to download.";
+    }
+
+    if (status === "error") {
+      return `Export failed: ${error}`;
+    }
+
+    return "";
+  }, [error, progress, status]);
+
   return (
     <div className="min-h-screen relative flex flex-col" style={{ background: "var(--bg)" }}>
       <ExportOverlay
@@ -373,10 +393,8 @@ return () => {
       />
       <OnboardingTour />
 
-      <div aria-live="polite" aria-atomic="true" className="sr-only">
-        {status === "exporting" && `Exporting video: ${progress}%`}
-        {status === "done" && "Export complete! Video ready to download."}
-        {status === "error" && `Export failed: ${error}`}
+      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+        {exportStatusAnnouncement}
       </div>
 
       <div className="max-w-6xl mx-auto px-4 py-8 pb-6 flex-1 w-full">


### PR DESCRIPTION
## Summary
- announce the FFmpeg engine loading state through the existing screen-reader live region
- announce the transition into export processing with a polite status update
- preserve the existing completion, progress, and error announcements in one computed status string

## Why
Screen-reader users could see export progress once processing started, but the app stayed silent while the FFmpeg engine was loading. That made the UI feel frozen before the export began.

Fixes #168

## Verification
- npm run lint (passes; existing VideoEditor hook dependency warning remains)
- npx tsc --noEmit
- npm run build (passes; same existing hook dependency warning)
- git diff --check
