### PR TITLE
test: cover export cancellation overlay

### DIFF
--- a/src/components/__tests__/ExportOverlay.test.tsx
+++ b/src/components/__tests__/ExportOverlay.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react'
+import { describe, afterEach, it, expect, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ExportOverlay from '../ExportOverlay'
+
+vi.mock('focus-trap-react', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('../LottiePlayer', () => ({
+  default: () => <div data-testid="export-spinner" />,
+}))
+
+vi.mock('../TipCarousel', () => ({
+  default: () => <div data-testid="export-tips" />,
+}))
+
+describe('ExportOverlay', () => {
+  afterEach(() => {
+    cleanup()
+    document.body.style.overflow = ''
+    vi.restoreAllMocks()
+  })
+
+  it('stays hidden while the editor is idle', () => {
+    render(<ExportOverlay status="idle" progress={0} />)
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /cancel export/i })).not.toBeInTheDocument()
+  })
+
+  it('shows engine loading progress without a cancel action', () => {
+    render(<ExportOverlay status="loading-engine" progress={42} />)
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /loading engine/i })).toBeInTheDocument()
+    expect(screen.getByRole('progressbar', { name: /engine download progress/i })).toHaveAttribute(
+      'aria-valuenow',
+      '42',
+    )
+    expect(screen.queryByRole('button', { name: /cancel export/i })).not.toBeInTheDocument()
+  })
+
+  it('calls onCancel when the cancel button is clicked during export', async () => {
+    const onCancel = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <ExportOverlay
+        status="exporting"
+        progress={65}
+        exportStartedAt={Date.now() - 3000}
+        onCancel={onCancel}
+      />,
+    )
+
+    expect(screen.getByRole('heading', { name: /exporting/i })).toBeInTheDocument()
+    expect(screen.getByRole('progressbar', { name: /export progress/i })).toHaveAttribute(
+      'aria-valuenow',
+      '65',
+    )
+
+    await user.click(screen.getByRole('button', { name: /cancel export/i }))
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onCancel when Escape is pressed while exporting', () => {
+    const onCancel = vi.fn()
+
+    render(
+      <ExportOverlay
+        status="exporting"
+        progress={10}
+        exportStartedAt={Date.now()}
+        onCancel={onCancel}
+      />,
+    )
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config'
+import { fileURLToPath } from 'node:url'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   oxc: {
     jsx: {
       runtime: 'automatic',

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,28 @@
 // Vitest setup: polyfills and global mocks
 import '@testing-library/jest-dom/vitest'
 
+const storage = new Map<string, string>()
+const localStorageMock: Storage = {
+  get length() {
+    return storage.size
+  },
+  clear: () => storage.clear(),
+  getItem: (key: string) => storage.get(key) ?? null,
+  key: (index: number) => Array.from(storage.keys())[index] ?? null,
+  removeItem: (key: string) => storage.delete(key),
+  setItem: (key: string, value: string) => storage.set(key, value),
+}
+
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: localStorageMock,
+})
+
+Object.defineProperty(window, 'localStorage', {
+  configurable: true,
+  value: localStorageMock,
+})
+
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   value: (query: string) => ({


### PR DESCRIPTION
## Summary
- add ExportOverlay regression coverage for idle, engine-loading, export progress, button cancellation, and Escape cancellation states
- configure Vitest to resolve the existing @/ alias used by app components
- provide an in-memory localStorage mock so the full jsdom test suite can run reliably

Closes #474

## Tests
- npm run test -- src/components/__tests__/ExportOverlay.test.tsx
- npm run test
- npx tsc --noEmit
- npm run build

Note: this PR only adds regression tests for the existing cancel export behavior, so no UI recording is attached.