### PR TITLE
feat: add custom audio format validation checks in file uploader (#1393)

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -407,7 +407,42 @@ export function useVideoEditor() {
       return;
     }
 
+    // Layer 3.5: Custom Audio Format & Codec Validation Check
+    const hasUnsupportedAudio = await new Promise<boolean>((resolve) => {
+      const AudioContextClass = window.AudioContext || (window as any).webkitAudioContext;
+      if (!AudioContextClass) {
+        resolve(false);
+        return;
+      }
+      const audioContext = new AudioContextClass();
+      const reader = new FileReader();
+      reader.onload = async (e) => {
+        try {
+          const arrayBuffer = e.target?.result as ArrayBuffer;
+          // Attempt decoding a tiny slice to verify codec compatibility
+          await audioContext.decodeAudioData(arrayBuffer.slice(0, 128 * 1024));
+          resolve(false); // Supported
+        } catch {
+          // If decoding fails, check if the file format has a high likelihood of containing unsupported audio tracks
+          const filename = selectedFile.name.toLowerCase();
+          const likelyUnsupported = filename.endsWith(".wma") || filename.endsWith(".dts") || filename.endsWith(".adpcm");
+          resolve(likelyUnsupported);
+        } finally {
+          audioContext.close();
+        }
+      };
+      reader.onerror = () => resolve(false);
+      reader.readAsArrayBuffer(selectedFile.slice(0, 128 * 1024));
+    });
+
+    if (hasUnsupportedAudio) {
+      setError("Validation Warning: Unsupported audio format or codec detected in tracks. The media player may fail to decode this audio format.");
+      setStatus("error");
+      return;
+    }
+
     try {
+
       const { width, height, duration: dur } = await extractMetadata(selectedFile);
 
       // Layer 5: Resolution check


### PR DESCRIPTION
## Description
Implemented dynamic, client-side custom media type format and audio codec validation checks in the file input controller on selection. This validates video file tracks using the browser's `AudioContext` offline decoding to preemptively catch unsupported audio streams (e.g. WMA, DTS, etc.) and warn the user before loading, preventing player crashes.

## Related Issue
Closes #1393

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: knoxiboy
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
