### PR TITLE
feat: add export duration calculator helper for sequential audio clips (#1394)

### DIFF
--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -312,11 +312,17 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
       </div>
 
       {duration > 0 && (
-        <p className="text-sm text-[var(--muted)] font-heading mt-1">
-          Clip: {formatDuration(clipLength)} of{" "}
-          {formatDuration(duration)}
-        </p>
+        <div className="flex flex-wrap justify-between items-center mt-1 gap-2">
+          <p className="text-sm text-[var(--muted)] font-heading">
+            Clip: {formatDuration(clipLength)} of{" "}
+            {formatDuration(duration)}
+          </p>
+          <p className="text-sm font-semibold font-heading text-film-600 bg-film-50 px-2 py-0.5 rounded border border-film-100 animate-fade-in" aria-live="polite">
+            Expected Export Duration: {((clipLength) / recipe.speed).toFixed(1)}s
+          </p>
+        </div>
       )}
+
       {recipe.trimEnd !== null &&
         recipe.trimEnd - recipe.trimStart < MIN_CLIP_DURATION && (
           <p className="text-[10px] text-[var(--error)] font-heading">


### PR DESCRIPTION
## Description
Added a live dynamic expected export duration calculator on the main timeline panel. This automatically computes `clipLength / speed` based on the user's active trim and speed configurations, displaying the final expected output duration in real-time.

## Related Issue
Closes #1394

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: knoxiboy
- Contribution level (Beginner/Intermediate/Advanced): Beginner

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
