### PR TITLE
fix: critical process termination leak on FFmpeg export timeout (#1396)

### DIFF
--- a/src/lib/ffmpeg.worker.ts
+++ b/src/lib/ffmpeg.worker.ts
@@ -376,6 +376,27 @@ async function removeFile(path: string) {
   }
 }
 
+async function execWithTimeout(args: string[], timeoutMs = 300000): Promise<number> {
+  if (!ffmpeg) throw new Error("FFmpeg engine is not loaded.");
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      if (activeExportAbortController && !activeExportAbortController.signal.aborted) {
+        activeExportAbortController.abort();
+      }
+      reject(new Error("FFmpeg execution timed out. Process killed to prevent memory leak."));
+    }, timeoutMs);
+  });
+  try {
+    const execPromise = ffmpeg.exec(args, undefined, {
+      signal: activeExportAbortController?.signal,
+    });
+    return await Promise.race([execPromise, timeoutPromise]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 async function runExport(request: ExportRequest): Promise<ResultPayload> {
   if (!ffmpeg) throw new Error("FFmpeg engine is not loaded.");
   if (activeExportAbortController?.signal.aborted) {
@@ -455,17 +476,13 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
           })()
         : [];
 
-      const pass1Code = await ffmpeg.exec(
-        ["-i", inputName, "-vf", vfWithPalette, ...gifDurationArgs, "-y", paletteName],
-        undefined,
-        { signal: activeExportAbortController?.signal }
+      const pass1Code = await execWithTimeout(
+        ["-i", inputName, "-vf", vfWithPalette, ...gifDurationArgs, "-y", paletteName]
       );
       if (pass1Code !== 0) throw new Error("GIF palette generation failed");
 
-      const pass2Code = await ffmpeg.exec(
-        ["-i", inputName, "-i", paletteName, "-lavfi", vfWithPaletteUse, ...gifDurationArgs, "-y", outputName],
-        undefined,
-        { signal: activeExportAbortController?.signal }
+      const pass2Code = await execWithTimeout(
+        ["-i", inputName, "-i", paletteName, "-lavfi", vfWithPaletteUse, ...gifDurationArgs, "-y", outputName]
       );
       if (pass2Code !== 0) throw new Error("GIF export failed");
 
@@ -515,9 +532,7 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
       videoDuration
     );
 
-    let exitCode = await ffmpeg.exec(args, undefined, {
-      signal: activeExportAbortController?.signal,
-    });
+    let exitCode = await execWithTimeout(args);
 
     if (exitCode !== 0 && missingAudioDetected) {
       missingAudioDetected = false;
@@ -537,9 +552,7 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
         false,
         videoDuration
       );
-      exitCode = await ffmpeg.exec(args, undefined, {
-        signal: activeExportAbortController?.signal,
-      });
+      exitCode = await execWithTimeout(args);
     }
 
     if (exitCode !== 0) {
@@ -560,9 +573,7 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
         videoDuration
       );
 
-      const fallbackCode = await ffmpeg.exec(args, undefined, {
-        signal: activeExportAbortController?.signal,
-      });
+      const fallbackCode = await execWithTimeout(args);
       if (fallbackCode !== 0) throw new Error("Export failed");
 
       const data = await ffmpeg.readFile(fallbackOutputName, undefined, {


### PR DESCRIPTION
## Description
Wrapped FFmpeg subprocess compilation exec triggers inside a promise that races with a robust timeout (e.g. 5 minutes). If the execution times out or hangs, the process is cleanly killed immediately, and the `finally` handlers are securely triggered to purge all temporary file buffers from the worker FS. This prevents process leaks and potential storage exhaustion.

## Related Issue
Closes #1396

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: knoxiboy
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
