### PR TITLE
fix: use correct preset IDs in exportEstimate to match presets.ts

### DIFF
--- a/src/lib/exportEstimate.test.ts
+++ b/src/lib/exportEstimate.test.ts
@@ -5,7 +5,7 @@ import { describe, test, expect } from "vitest";
 // Minimal recipe factory — only the fields estimateExportSize cares about
 function makeRecipe(overrides: Partial<EditRecipe> = {}): EditRecipe {
   return {
-    preset: "1080p",
+    preset: "landscape-16-9",
     customWidth: 1920,
     customHeight: 1080,
     quality: 23,       // default CRF
@@ -49,9 +49,9 @@ describe("estimateExportSize", () => {
     expect(long / short).toBeCloseTo(4, 0);
   });
 
-  test("higher resolution (4k) produces a larger estimate than 720p", () => {
-    const hd  = estimateExportSize(makeRecipe({ preset: "720p" }), 60);
-    const uhd = estimateExportSize(makeRecipe({ preset: "4k"   }), 60);
+  test("higher resolution (dci-2k) produces a larger estimate than twitter-hd", () => {
+    const hd  = estimateExportSize(makeRecipe({ preset: "twitter-hd" }), 60);
+    const uhd = estimateExportSize(makeRecipe({ preset: "dci-2k"    }), 60);
     expect(uhd).toBeGreaterThan(hd);
   });
 

--- a/src/lib/exportEstimate.ts
+++ b/src/lib/exportEstimate.ts
@@ -5,17 +5,16 @@ import { EditRecipe } from "./types";
 // Keep in sync with src/lib/presets.ts. Width × height for every named preset.
 // ---------------------------------------------------------------------------
 const PRESET_DIMENSIONS: Record<string, { width: number; height: number }> = {
-  "1080p":       { width: 1920, height: 1080 },
-  "720p":        { width: 1280, height: 720  },
-  "480p":        { width: 854,  height: 480  },
-  "360p":        { width: 640,  height: 360  },
-  "4k":          { width: 3840, height: 2160 },
-  "2k":          { width: 2560, height: 1440 },
-  // Square / portrait presets
-  "square-1080": { width: 1080, height: 1080 },
-  "square-720":  { width: 720,  height: 720  },
-  "portrait-1080": { width: 1080, height: 1920 },
-  "portrait-720":  { width: 720,  height: 1280 },
+  "vertical-9-16":       { width: 1080, height: 1920 },
+  "instagram-4-5":       { width: 1080, height: 1350 },
+  "square-1-1":          { width: 1080, height: 1080 },
+  "landscape-16-9":      { width: 1920, height: 1080 },
+  "twitter-hd":          { width: 1280, height: 720  },
+  "ultrawide-21-9":      { width: 2560, height: 1080 },
+  "instagram-panoramic": { width: 5120, height: 1080 },
+  "portrait-3-4":        { width: 1080, height: 1440 },
+  "cinema-scope":        { width: 2048, height: 858  },
+  "dci-2k":              { width: 2048, height: 1080 },
   // Fallback — if a preset name is unrecognised we fall through to customWidth/H
 };
 


### PR DESCRIPTION
## Description

Fixed `PRESET_DIMENSIONS` in `exportEstimate.ts` to use the correct preset IDs from `presets.ts`. The old map used legacy IDs (1080p, 720p, 4k, etc.) that never matched, causing `getOutputDimensions()` to always fall through to the custom width/height fallback — making export size estimates wrong for every preset.

## Related Issue

Closes #1464

## Type of Contribution

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: vipul674
- Contribution level: Intermediate

## Checklist

- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
