### PR TITLE
fix: disable page scrolling during tutorial flow

### DIFF
--- a/src/components/OnboardingTour.tsx
+++ b/src/components/OnboardingTour.tsx
@@ -362,6 +362,16 @@ export default function OnboardingTour() {
     return () => window.removeEventListener("keydown", onKey);
   }, [visible, stepIndex, dismiss]);
 
+  // Lock body scroll when tour is active
+  useEffect(() => {
+    if (!visible) return;
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [visible]);
+
   if (!visible || !targetRect || !currentStep) return null;
 
   return createPortal(


### PR DESCRIPTION
This pull request introduces an improvement to the onboarding tour user experience by preventing background scrolling when the tour is active.

User experience enhancement:

* Added a `useEffect` hook to the `OnboardingTour` component to lock the body scroll (by setting `document.body.style.overflow` to `"hidden"`) while the tour is visible, and restore the original overflow style when the tour is dismissed.## Description
## Related Issue 
Closes #1481
## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: yashr5120

