### PR TITLE
fix: resolve log listener cleanup issue in ffmpeg.worker.ts

### DIFF
--- a/src/lib/ffmpeg.worker.ts
+++ b/src/lib/ffmpeg.worker.ts
@@ -486,7 +486,7 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
     }
 
     let missingAudioDetected = false;
-    const logListener = ({ message }: { message: string }) => {
+    logListener = ({ message }: { message: string }) => {
       const msg = message.toLowerCase();
       if (
         msg.includes("matches no streams") ||


### PR DESCRIPTION
## Description

Fixed a log listener cleanup issue in `src/lib/ffmpeg.worker.ts`.

The non-GIF export flow declared a new `logListener` variable that shadowed the outer variable used during cleanup. This prevented the same listener reference from being used for both registration and cleanup.

### Changes Made

```diff
- const logListener = ({ message }: { message: string }) => {
+ logListener = ({ message }: { message: string }) => {
```

This ensures the same listener reference is used for both `ffmpeg.on("log", ...)` and `ffmpeg.off("log", ...)`.

## Related Issue

Closes #1460 

## Type of Contribution

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [x] Refactor
* [x] GSSoC contribution

## Participant Info

* GitHub username: riya-chauhan12
* Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Screen Recording

N/A – Internal logic fix with no visible UI changes.

**Recording / Loom link:** N/A

## Checklist

* [x] I have read the contribution guidelines
* [x] My changes follow the project structure
* [x] bun run lint passes (no ESLint errors)
* [x] bunx tsc --noEmit passes (no TypeScript errors)
* [ ] New interactive elements have aria-label / accessible names
* [x] No console.log statements left in
* [x] This PR is related to a valid issue
