### PR TITLE
Fix btoa emoji crash

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useMemo } from "react";
-import { useVideoEditor } from "@/hooks/useVideoEditor";
+import { useVideoEditor, encodeRecipe } from "@/hooks/useVideoEditor";
 import { TextOverlay } from "@/lib/types";
 import FileUpload from "./FileUpload";
 import VideoPreview from "./VideoPreview";
@@ -291,7 +291,7 @@ export default function VideoEditor() {
 
   const handleCopyLink = () => {
     if (typeof window === "undefined") return;
-    const encoded = btoa(JSON.stringify(recipe));
+    const encoded = encodeRecipe(recipe);
     const url = new URL(window.location.href);
     url.searchParams.set("settings", encoded);
     history.replaceState(null, "", url.toString());

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -118,13 +118,13 @@ function validateRecipe(recipe: EditRecipe, duration: number ): string | null {
   );
 }
 
-function encodeRecipe(recipe: EditRecipe): string {
-  return btoa(JSON.stringify(recipe));
+export function encodeRecipe(recipe: EditRecipe): string {
+  return btoa(unescape(encodeURIComponent(JSON.stringify(recipe))));
 }
 
 function decodeRecipe(encoded: string): Partial<EditRecipe> | null {
   try {
-    const decoded = JSON.parse(atob(encoded));
+    const decoded = JSON.parse(decodeURIComponent(escape(atob(encoded))));
     return decoded as Partial<EditRecipe>;
   } catch {
     return null;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config'
+import path from 'path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  },
   oxc: {
     jsx: {
       runtime: 'automatic',

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -14,3 +14,22 @@ Object.defineProperty(window, 'matchMedia', {
     dispatchEvent: () => false,
   }),
 })
+
+const localStorageMock = (function () {
+  let store: Record<string, string> = {};
+  return {
+    getItem(key: string) {
+      return store[key] || null;
+    },
+    setItem(key: string, value: string) {
+      store[key] = value.toString();
+    },
+    removeItem(key: string) {
+      delete store[key];
+    },
+    clear() {
+      store = {};
+    }
+  };
+})();
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });


### PR DESCRIPTION
Hey @magic-peach 
## Description
Fixes a fatal `DOMException` crash when clicking "Copy Link" after adding a text overlay 
containing emojis or non-ASCII characters. The native `btoa()` only accepts Latin1 characters, 
so emoji in the JSON string caused an immediate unhandled exception with no user feedback.

**Fix:** Wraps `JSON.stringify(recipe)` with `encodeURIComponent` + `unescape` before 
`btoa()`, and decodes symmetrically with `escape` + `decodeURIComponent` after `atob()`. 
Exports `encodeRecipe` from `useVideoEditor.ts` and uses it in `VideoEditor.tsx`'s 
`handleCopyLink`, replacing the crashing direct `btoa()` call.

## Related Issue
Closes #1469

## Type of Contribution
- [x] Bug fix
- [x] GSSoC contribution

## Participant Info
- GitHub username: divyansha12
- Contribution level: Intermediate

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
