### PR TITLE
fix: resolve WAVE accessibility issues

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,7 +10,7 @@
   --surface: #f1f5f9;
   --border: #cbd5e1;
   --text: #0f172a;
-  --muted: #64748b;
+  --muted: #475569;
   --accent: #3b82f6;
   --accent-hover: #1d4ed8;
   --accent-muted: rgba(59, 130, 246, 0.12);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,9 +13,9 @@ export default function Home() {
         ⭐ Star on GitHub
       </a>
 
-      <main id="main-content" tabIndex={-1}>
+      <div>
         <VideoEditor />
-      </main>
+      </div>
 
       <Footer />
     </>

--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -171,10 +171,14 @@ export default function PresetSelector({ recipe, onChange }: Props) {
       </div>
 
       <div className="relative">
+        <label htmlFor="preset-search" className="sr-only">
+          Search output formats
+        </label>
         <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
           <Search size={14} className="text-[var(--muted)]" />
         </div>
         <input
+          id="preset-search"
           type="text"
           placeholder="Search formats..."
           value={search}

--- a/src/components/TextControls.tsx
+++ b/src/components/TextControls.tsx
@@ -208,7 +208,7 @@ export default function TextControls({
           </div>
 
           {/* Font Weight */}
-          <div>
+          <fieldset>
             <legend className="text-xs text-[var(--muted)] font-medium mb-1 block">
               Weight
             </legend>
@@ -233,7 +233,7 @@ export default function TextControls({
                 </button>
               ))}
             </div>
-          </div>
+          </fieldset>
         </div>
       )}
     </div>

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -569,7 +569,7 @@ return () => {
                             type="button"
                             onClick={() => updateRecipe({ brightness: 0 })}
                             className="text-film-500 hover:underline"
-                            aria-label="reset brightness"
+                            aria-label="Reset brightness adjustment"
                           >
                             Reset
                           </button>
@@ -594,7 +594,7 @@ return () => {
                             type="button"
                             onClick={() => updateRecipe({ contrast: 1 })}
                             className="text-film-500 hover:underline"
-                            aria-label="reset-contrast"
+                            aria-label="Reset contrast adjustment"
                           >
                             Reset
                           </button>
@@ -619,7 +619,7 @@ return () => {
                             type="button"
                             onClick={() => updateRecipe({ saturation: 1 })}
                             className="text-film-500 hover:underline"
-                            aria-label="reset-saturation"
+                            aria-label="Reset saturation adjustment"
                           >
                             Reset
                           </button>


### PR DESCRIPTION
## Summary
- removes the duplicate/nested `main-content` landmark by keeping the root layout as the single main landmark
- adds a programmatic label for the preset search input
- wraps text weight choices in a valid `fieldset`/`legend` group
- gives adjustment reset buttons clearer accessible names
- darkens the light-mode muted token to reduce small-text contrast alerts

## Why
These changes address concrete WAVE-style accessibility findings: duplicate landmarks/IDs, unlabeled controls, invalid grouping semantics, unclear control names, and low-contrast muted text in light mode.

Closes #178

## Verification
- `git diff --check`
- `npx tsc --noEmit`
- `npm run lint` passes with the existing `react-hooks/exhaustive-deps` warning in `src/components/VideoEditor.tsx:276`
- `npm run build`

## Test note
- `npm test -- --run` is currently blocked by existing test harness issues unrelated to this patch: Vitest cannot resolve the `@/utils/fontLoader` alias in FFmpeg-related tests, and `ThemeToggle.test.tsx` runs without a localStorage shim.
