### PR TITLE
fix(preview): resolve coordinate mismatch by positioning text overlays relative to active video rect (#1498)

### DIFF
--- a/src/components/DraggableTextOverlays.tsx
+++ b/src/components/DraggableTextOverlays.tsx
@@ -9,6 +9,8 @@ interface DraggableTextOverlaysProps {
   recipe?: EditRecipe;
   containerWidth: number;
   containerHeight: number;
+  videoLeft?: number;
+  videoTop?: number;
   selectedTextId: string | null;
   onUpdateText: (id: string, updates: Partial<TextOverlay>) => void;
   onSelectText: (id: string | null) => void;
@@ -22,6 +24,8 @@ export default function DraggableTextOverlays({
   recipe,
   containerWidth,
   containerHeight,
+  videoLeft = 0,
+  videoTop = 0,
   selectedTextId,
   onUpdateText,
   onSelectText,
@@ -216,8 +220,13 @@ export default function DraggableTextOverlays({
   return (
     <div
       ref={containerRef}
-      className="absolute inset-0 pointer-events-none"
-      style={{ width: containerWidth, height: containerHeight }}
+      className="absolute pointer-events-none"
+      style={{
+        left: `${videoLeft}px`,
+        top: `${videoTop}px`,
+        width: containerWidth,
+        height: containerHeight,
+      }}
     >
       {textOverlays.map((overlay) => {
         const { left, top } = getTextPixelPosition(

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -36,8 +36,41 @@ export default function VideoPreview({
     width: 0,
     height: 0,
   });
+  const [activeVideoRect, setActiveVideoRect] = useState({
+    width: 0,
+    height: 0,
+    left: 0,
+    top: 0,
+  });
   const previewContainerRef = useRef<HTMLDivElement>(null);
   const onLoadedRef = useRef<(() => void) | null>(null);
+
+  const updateActiveVideoRect = useCallback(() => {
+    const video = videoRef.current;
+    if (!video || video.videoWidth === 0 || video.videoHeight === 0 || containerDimensions.width === 0) {
+      return;
+    }
+
+    const videoRatio = video.videoWidth / video.videoHeight;
+    const containerRatio = containerDimensions.width / containerDimensions.height;
+
+    let width = 0;
+    let height = 0;
+    let left = 0;
+    let top = 0;
+
+    if (videoRatio > containerRatio) {
+      width = containerDimensions.width;
+      height = containerDimensions.width / videoRatio;
+      top = (containerDimensions.height - height) / 2;
+    } else {
+      height = containerDimensions.height;
+      width = containerDimensions.height * videoRatio;
+      left = (containerDimensions.width - width) / 2;
+    }
+
+    setActiveVideoRect({ width, height, left, top });
+  }, [containerDimensions, videoRef]);
 
   const handleGrabFrame = useCallback(() => {
     const video = videoRef.current;
@@ -143,6 +176,10 @@ export default function VideoPreview({
     window.addEventListener("resize", updateDimensions);
     return () => window.removeEventListener("resize", updateDimensions);
   }, []);
+
+  useEffect(() => {
+    updateActiveVideoRect();
+  }, [containerDimensions, isLoading, updateActiveVideoRect]);
 
   const overlay = (() => {
     if (!recipe || !showOverlay) return null;
@@ -286,11 +323,13 @@ export default function VideoPreview({
         )}
 
         {/* Draggable Text Overlays */}
-        {recipe && !isLoading && containerDimensions.width > 0 && (
+        {recipe && !isLoading && activeVideoRect.width > 0 && (
           <DraggableTextOverlays
             recipe={recipe}
-            containerWidth={containerDimensions.width}
-            containerHeight={containerDimensions.height}
+            containerWidth={activeVideoRect.width}
+            containerHeight={activeVideoRect.height}
+            videoLeft={activeVideoRect.left}
+            videoTop={activeVideoRect.top}
             selectedTextId={selectedTextId ?? null}
             onSelectText={onSelectText || (() => {})}
             onUpdateText={onUpdateText || (() => {})}


### PR DESCRIPTION
### Summary
This PR resolves a visual alignment bug where text overlays in exported videos are significantly shifted, misplaced, or cropped out compared to their position in the preview editor (#1498).

### Changes
* Calculated the visual boundaries of the active video frame (handling `object-contain` scaling relative to the player aspect ratio inside `VideoPreview.tsx`) to exclude letterbox/pillarbox padding regions.
* Positioned and scaled the `DraggableTextOverlays` context to fit exactly onto the visual video boundary.
* Passed the active video dimensions as `containerWidth` and `containerHeight` parameters to correct the drag percentage calculations.

### Verification
* Uploading non-16:9 vertical (9:16) or standard (4:3) videos and dragging text overlays now preserves the exact relative coordinate positions on screen and aligns precisely with the exported output coordinates.