### PR TITLE
fix(export): enable custom font rendering by serializing and writing font files to ffmpeg virtual filesystem (#1499)

### DIFF
--- a/src/components/TextControls.tsx
+++ b/src/components/TextControls.tsx
@@ -6,13 +6,17 @@ import { Trash2, Plus } from "lucide-react";
 import { useMemo } from "react";
 import BaseButton from "./ui/BaseButton";
 import FontSelector from "./FontSelector";
-import { useFontManager } from "@/hooks/useFontManager";
+import { CustomFont } from "@/hooks/useFontManager";
 
 interface TextControlsProps {
   recipe: EditRecipe;
   onChange: (patch: Partial<EditRecipe>) => void;
   selectedTextId: string | null;
   onSelectText: (id: string | null) => void;
+  customFonts: CustomFont[];
+  onAddFonts: (files: File[]) => Promise<{ success: number; errors: string[] }>;
+  onRemoveFont: (name: string) => void;
+  getFontErrors: () => string[];
 }
 
 /**
@@ -24,8 +28,11 @@ export default function TextControls({
   onChange,
   selectedTextId,
   onSelectText,
+  customFonts,
+  onAddFonts,
+  onRemoveFont,
+  getFontErrors,
 }: TextControlsProps) {
-  const { customFonts, addFonts, removeFont, getErrors } = useFontManager();
 
   /**
    * Memoize text overlays to prevent unnecessary dependency changes.
@@ -148,9 +155,9 @@ export default function TextControls({
               handleUpdateText(selectedTextId!, { fontFamily: fontName })
             }
             customFonts={customFonts}
-            onAddFonts={addFonts}
-            onRemoveFont={removeFont}
-            errors={getErrors()}
+            onAddFonts={onAddFonts}
+            onRemoveFont={onRemoveFont}
+            errors={getFontErrors()}
           />
 
           {/* Font Size Slider */}

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -210,6 +210,10 @@ export default function VideoEditor() {
     recommendedPreset,
     currentTime,
     toggleSound,
+    customFonts,
+    addFonts,
+    removeFont,
+    getFontErrors,
   } = useVideoEditor();
 
   useKeyboardShortcuts({
@@ -511,6 +515,10 @@ return () => {
                       onChange={updateRecipe}
                       selectedTextId={selectedTextId}
                       onSelectText={setSelectedTextId}
+                      customFonts={customFonts}
+                      onAddFonts={addFonts}
+                      onRemoveFont={removeFont}
+                      getFontErrors={getFontErrors}
                     />
                   </AccordionSection>
                   <details className="group">

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -7,6 +7,7 @@ import { getPresetById } from "@/lib/presets";
 import { loadFFmpeg, exportVideo, terminateFFmpeg, FFmpegLoadError } from "@/lib/ffmpeg";
 import { suggestPreset } from "@/lib/presetSuggestion";
 import { validateDimensions, getDownscaledDimensions } from "@/utils/video-validation";
+import { useFontManager } from "@/hooks/useFontManager";
 
 const DEFAULT_TITLE = "Reframe — Resize, trim, and export videos in your browser";
   const STORAGE_KEY = "reframe:recipe";
@@ -188,7 +189,9 @@ export function useVideoEditor() {
   const [overlaySize, setOverlaySize] = useState(150);
   const [overlayOpacity, setOverlayOpacity] = useState(100);
   const [currentTime, setCurrentTime] = useState(0);
- const updateRecipe = useCallback((patch: Partial<EditRecipe>) => {
+  const { customFonts, addFonts, removeFont, getErrors: getFontErrors } = useFontManager();
+
+  const updateRecipe = useCallback((patch: Partial<EditRecipe>) => {
   setRecipe((prev) => {
     const next = { ...prev, ...patch };
     // GIF has no audio — force keepAudio off
@@ -494,7 +497,8 @@ export function useVideoEditor() {
           position: overlayPosition,
           size: overlaySize,
           opacity: overlayOpacity,
-        }
+        },
+        customFonts
       );
       if (exportCancelledRef.current) return;
 
@@ -729,5 +733,9 @@ export function useVideoEditor() {
     recommendedPreset,
     currentTime,
     toggleSound,
+    customFonts,
+    addFonts,
+    removeFont,
+    getFontErrors,
   };
 }

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -213,7 +213,8 @@ export async function exportVideo(
   onProgress: (percent: number) => void,
   signal?: AbortSignal,
   musicOptions?: BackgroundMusicOptions,
-  overlayOptions?: ImageOverlayOptions
+  overlayOptions?: ImageOverlayOptions,
+  customFonts?: Array<{ name: string; file: File }>
 ): Promise<ExportResult> {
   await loadFFmpeg(signal, onProgress);
 
@@ -245,6 +246,44 @@ export async function exportVideo(
       }
     : undefined;
 
+  // Process custom fonts
+  const fontFilesPayload: SerializedFile[] = [];
+  const transfers: Transferable[] = [arrayBuffer];
+  if (musicFilePayload) transfers.push(musicFilePayload.data);
+  if (overlayFilePayload) transfers.push(overlayFilePayload.data);
+
+  const updatedOverlays = (recipe.textOverlays || []).map((overlay) => {
+    if (!overlay.fontFamily) return overlay;
+    const customFont = customFonts?.find((f) => f.name === overlay.fontFamily);
+    if (!customFont) return overlay;
+
+    const ext = customFont.file.name.split(".").pop() ?? "ttf";
+    const virtualFontPath = `font_${customFont.name}.${ext}`;
+    return {
+      ...overlay,
+      fontPath: virtualFontPath,
+    };
+  });
+
+  const updatedRecipe = {
+    ...recipe,
+    textOverlays: updatedOverlays,
+  };
+
+  if (customFonts) {
+    for (const font of customFonts) {
+      const ext = font.file.name.split(".").pop() ?? "ttf";
+      const virtualFontPath = `font_${font.name}.${ext}`;
+      const fontBuffer = await font.file.arrayBuffer();
+      fontFilesPayload.push({
+        name: virtualFontPath,
+        type: font.file.type || "application/x-font-truetype",
+        data: fontBuffer,
+      });
+      transfers.push(fontBuffer);
+    }
+  }
+
   const sanitizedMusicOptions = musicOptions
     ? { ...musicOptions, file: null }
     : undefined;
@@ -270,22 +309,19 @@ export async function exportVideo(
   };
   signal?.addEventListener("abort", onAbort, { once: true });
 
-  const transfers: Transferable[] = [arrayBuffer];
-  if (musicFilePayload) transfers.push(musicFilePayload.data);
-  if (overlayFilePayload) transfers.push(overlayFilePayload.data);
-
   ffmpegWorker.postMessage(
     {
       type: "export",
       id: sessionId,
       file: filePayload,
-      recipe,
+      recipe: updatedRecipe,
       videoDuration: await getVideoDuration(file),
       musicFile: musicFilePayload,
       musicOptions: sanitizedMusicOptions,
       overlayFile: overlayFilePayload,
       overlayOptions: sanitizedOverlayOptions,
-    } as WorkerExportRequest,
+      fontFiles: fontFilesPayload,
+    } as any,
     transfers
   );
 

--- a/src/lib/ffmpeg.worker.ts
+++ b/src/lib/ffmpeg.worker.ts
@@ -27,6 +27,7 @@ type ExportRequest = {
   musicOptions?: BackgroundMusicOptions;
   overlayFile?: SerializedFile;
   overlayOptions?: ImageOverlayOptions;
+  fontFiles?: SerializedFile[];
 };
 
 type LoadRequest = { type: "load" };
@@ -427,6 +428,16 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
     await ffmpeg.writeFile(overlayInputName, serializeFileBuffer(request.overlayFile!), {
       signal: activeExportAbortController?.signal,
     });
+  }
+
+  // Write custom font files
+  if (request.fontFiles) {
+    for (const fontFile of request.fontFiles) {
+      cleanupFiles.add(fontFile.name);
+      await ffmpeg.writeFile(fontFile.name, serializeFileBuffer(fontFile), {
+        signal: activeExportAbortController?.signal,
+      });
+    }
   }
 
   const videoDuration = request.videoDuration;

--- a/src/lib/text-overlay.ts
+++ b/src/lib/text-overlay.ts
@@ -91,16 +91,15 @@ export function buildTextFilter(
   // Build the drawtext filter with font support
   let filter = `drawtext=text='${escapedText}':x=${pixelX}:y=${pixelY}:fontsize=${overlay.fontSize}:fontcolor=${overlay.color}:fontweight=${fontWeightParam}`;
 
-  // Add font family if specified
-  if (overlay.fontFamily) {
-    // Sanitize font name for FFmpeg
-    const safeFontName = overlay.fontFamily.replace(/[^a-zA-Z0-9-]/g, "");
-    filter += `:fontfile='${safeFontName}'`;
-  }
-
-  // Add custom font file path if available
+  // Add custom font file path if available. Otherwise, use fallback font family if built-in.
   if (fontFileParam) {
     filter += `:${fontFileParam}`;
+  } else if (overlay.fontFamily) {
+    const builtInNames = ["Arial", "Inter", "Roboto", "Poppins", "Montserrat"];
+    if (builtInNames.includes(overlay.fontFamily)) {
+      const safeFontName = overlay.fontFamily.replace(/[^a-zA-Z0-9-]/g, "");
+      filter += `:fontfile='${safeFontName}'`;
+    }
   }
 
   return filter;


### PR DESCRIPTION
### Summary
This PR enables custom font file uploads to render correctly in exported videos by serializing and transferring font files to the FFmpeg.wasm worker filesystem at export time (#1499).

### Changes
* Lifted the `useFontManager` hook up from the local `TextControls.tsx` to `useVideoEditor.ts` to make custom font state globally accessible to the export pipeline.
* Updated `exportVideo` in `ffmpeg.ts` to accept the uploaded `customFonts` array, serialize font files to ArrayBuffer payloads, map overlay virtual file paths, and transfer them to the worker thread.
* Updated `ffmpeg.worker.ts` to write these binary font files to the virtual filesystem before executing the FFmpeg filter graph and added them to `cleanupFiles` for automatic cleanup after execution.
* Corrected `buildTextFilter` in `text-overlay.ts` to only output one valid `:fontfile` argument in the filter string when a custom font is used, preventing filter graph syntax errors.

### Verification
* Uploading custom TTF/OTF fonts in the editor, styling text overlays with them, and exporting now successfully renders text with the custom font instead of falling back to default styling or failing exports.