### PR TITLE
fix(preview): prevent memory leak and CPU overhead in thumbnail generator by aborting video stream and adding timeout fallback 

### DIFF
--- a/src/components/ThumbnailStrip.tsx
+++ b/src/components/ThumbnailStrip.tsx
@@ -45,6 +45,10 @@ export default function ThumbnailStrip({
 
   const cancelThumbnailRun = useCallback(() => {
     lastRunIdRef.current += 1;
+    if (offscreenVideoRef.current) {
+      offscreenVideoRef.current.src = "";
+      offscreenVideoRef.current.load();
+    }
   }, []);
 
   const generateThumbnails = useCallback(async () => {
@@ -97,8 +101,15 @@ export default function ThumbnailStrip({
 
         const time = times[i] ?? 0;
         await new Promise<void>((resolve) => {
-          const onSeeked = async () => {
+          let timeoutId: number | undefined;
+
+          const cleanup = () => {
             video.removeEventListener("seeked", onSeeked);
+            if (timeoutId) window.clearTimeout(timeoutId);
+          };
+
+          const onSeeked = async () => {
+            cleanup();
 
             if (lastRunIdRef.current !== runId) {
               resolve();
@@ -127,6 +138,13 @@ export default function ThumbnailStrip({
             setProgress(Math.round(((i + 1) / times.length) * 100));
             resolve();
           };
+
+          // Setup timeout fallback (2 seconds max per seek to prevent hang)
+          timeoutId = window.setTimeout(() => {
+            cleanup();
+            resolve();
+          }, 2000);
+
           video.addEventListener("seeked", onSeeked);
           video.currentTime = time;
         });


### PR DESCRIPTION
### Summary
This PR prevents memory leaks and background CPU overhead in the offscreen thumbnail generator caused by stalled seek operations when new videos are uploaded or components unmount (#1500).

### Changes
* Updated `cancelThumbnailRun` in `ThumbnailStrip.tsx` to immediately set the source of the offscreen video element to `""` and invoke `load()`. This halts active media loading/decoding instantly and clears occupied hardware/software decoder slots.
* Added a 2-second timeout fallback inside the offscreen canvas seek promise within `generateThumbnails`. If a seek stalls, the promise resolves and allows the loop to exit and clean up rather than hanging indefinitely.

### Verification
* Uploading new videos rapidly in succession or unmounting the component during thumbnail generation now aborts active seeks immediately, resolving memory footprint creep and background thread usage.