### PR TITLE
feat: add workflow progress stepper

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -303,7 +303,7 @@ export default function VideoEditor() {
 
   useEffect(() => {
     if (status === "done" && downloadRef.current) {
-      
+
       const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
       downloadRef.current.scrollIntoView({
         behavior: prefersReducedMotion ? "instant" : "smooth",
@@ -327,6 +327,16 @@ return () => {
 }, [file]);
 
   const isProcessing = status === "loading-engine" || status === "exporting";
+  const currentStep =
+  !file
+    ? 0
+    : status === "idle"
+    ? 1
+    : status === "loading-engine" || status === "exporting"
+    ? 2
+    : status === "done"
+    ? 3
+    : 1;
   const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
 
   const intervalSeconds = useMemo(() => {
@@ -412,7 +422,7 @@ return () => {
       <span className="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-[var(--accent)] inline-block animate-pulse" />
       No login. No ads. 100% private.
     </div>
-  </div>  
+  </div>
   <div
     className="flex flex-wrap justify-center text-center items-center gap-2 text-sm font-heading font-semibold uppercase tracking-widest text-[var(--muted)] pb-1"
     style={{ justifyContent: 'center', textAlign: 'center', margin: '0', width: 'auto' }}
@@ -421,6 +431,29 @@ return () => {
     No login. No ads. 100% private - your video never leaves your device.
   </div>
     </header>
+    <div className="mb-8">
+  <div className="flex items-center justify-center gap-4 flex-wrap">
+    {["Upload", "Configure", "Export", "Download"].map((step, index) => (
+      <div
+        key={step}
+        aria-current={currentStep === index ? "step" : undefined}
+        className={cn(
+          "flex items-center gap-2 px-4 py-2 rounded-lg border text-sm font-medium",
+          currentStep === index
+            ? "border-film-500 bg-film-50"
+            : index < currentStep
+            ? "border-green-500 bg-green-50"
+            : "border-[var(--border)] bg-[var(--surface)]"
+        )}
+      >
+        <span>
+          {index < currentStep ? "✓" : index === currentStep ? "●" : "○"}
+        </span>
+        <span>{step}</span>
+      </div>
+    ))}
+  </div>
+</div>
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-5">
 
           <div className="space-y-4 min-w-0">


### PR DESCRIPTION
## Description

Added a workflow progress stepper to guide users through the video editing process.

The stepper visually indicates the current stage and completed stages of the workflow:

**Upload → Configure → Export → Download**

### Related Issue

Closes #98

## Type of Contribution

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [ ] Refactor
* [x] GSSoC contribution

## Participant Info

* GitHub username: srinidhi-2006-bit
* Contribution level (Beginner)

## Screen Recording

**Recording / Loom link:** Add your Loom or screen recording link here.

## Checklist

* [x] I have read the contribution guidelines
* [x] My changes follow the project structure
* [ ] I have tested my changes in Chrome, Firefox, and Safari
* [ ] `bun run lint` passes (no ESLint errors)
* [ ] `bunx tsc --noEmit` passes (no TypeScript errors)
* [x] New interactive elements have `aria-label` / accessible names
* [x] No `console.log` statements left in
* [x] This PR is related to a valid issue
* [ ] **Screen recording attached above** (required for UI/feature/design changes)

### Changes Made

* Added workflow progress stepper below the header section
* Added active step highlighting
* Added completed step indicators (✓)
* Added accessibility support using `aria-current="step"`
* Automatically updates based on editor state:

  * Upload
  * Configure
  * Export
  * Download
