### PR TITLE
fix: add MIME type magic byte validation to prevent spoofed file uploads (#137)

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -6,6 +6,7 @@ import LottiePlayer from "./LottiePlayer";
 import uploadAnim from "@/lib/lottie/upload.json";
 import { cn, formatBytes, formatDuration } from "@/lib/utils";
 import { MAX_FILE_SIZE, WARNING_FILE_SIZE } from "@/lib/types";
+import { validateVideoMagicBytes } from "@/utils/video-validation";
 
 interface Props {
   onFileSelect: (file: File) => void;
@@ -83,38 +84,53 @@ export default function FileUpload({
   }, []);
 
   // ── File validation ───────────────────────────────────
-  const handleFile = useCallback((file: File) => {
+  const handleFile = useCallback(async (file: File) => {
     setError("");
     setWarning("");
 
-    if (!file.type.startsWith("video/")) {
-      setError("Please drop a valid video file (MP4, MOV, AVI, WebM, etc.)");
-      return;
-    }
+    try {
+      if (!file.type.startsWith("video/")) {
+        setError("Please drop a valid video file (MP4, MOV, AVI, WebM, etc.)");
+        return;
+      }
 
-    if (file.size > 500 * 1024 * 1024) {
-      setError("File size exceeds 500MB limit. Please select a smaller video.");
-      return;
-    }
+      // Magic-byte check: verify the actual file header, not just its extension
+      // or the browser-supplied MIME type (which is derived from the extension
+      // and can be spoofed by renaming any file to *.mp4).
+      const isRealVideo = await validateVideoMagicBytes(file);
+      if (!isRealVideo) {
+        setError(
+          "File does not appear to be a valid video. Please upload an MP4, WebM, AVI, MOV, or other supported format."
+        );
+        return;
+      }
 
-    if (file.size > MAX_FILE_SIZE) {
-      setError(
-        `File too large (${formatBytes(file.size)}). Maximum allowed size is 2GB.`
-      );
-      return;
-    }
+      if (file.size > 500 * 1024 * 1024) {
+        setError("File size exceeds 500MB limit. Please select a smaller video.");
+        return;
+      }
 
-    if (file.size > WARNING_FILE_SIZE) {
-      const estimatedMinutes = Math.max(
-        1,
-        Math.round(file.size / (100 * 1024 * 1024))
-      );
-      setWarning(
-        `Large file detected (${formatBytes(file.size)}). Processing may take ~${estimatedMinutes} minutes.`
-      );
-    }
+      if (file.size > MAX_FILE_SIZE) {
+        setError(
+          `File too large (${formatBytes(file.size)}). Maximum allowed size is 2GB.`
+        );
+        return;
+      }
 
-    onFileSelect(file);
+      if (file.size > WARNING_FILE_SIZE) {
+        const estimatedMinutes = Math.max(
+          1,
+          Math.round(file.size / (100 * 1024 * 1024))
+        );
+        setWarning(
+          `Large file detected (${formatBytes(file.size)}). Processing may take ~${estimatedMinutes} minutes.`
+        );
+      }
+
+      onFileSelect(file);
+    } catch {
+      setError("Could not read the file. Please try again with a different file.");
+    }
   }, [onFileSelect]);
 
   // ── Drop zone (inner) handler ─────────────────────────

--- a/src/utils/video-validation.ts
+++ b/src/utils/video-validation.ts
@@ -1,5 +1,78 @@
 // src/utils/video-validation.ts
 
+/**
+ * Magic byte signatures for supported video formats.
+ *
+ * Each entry defines a byte pattern and the offset at which it appears in the
+ * file header.  Reading only the first 12 bytes is enough to cover all formats
+ * listed below.
+ *
+ * References:
+ *   MP4 / MOV  – "ftyp" box at byte offset 4  (ISO 14496-12)
+ *   WebM       – EBML magic bytes at offset 0  (RFC 8794 / Matroska spec)
+ *   AVI        – RIFF container at offset 0    (Microsoft RIFF spec)
+ *   MKV        – same EBML header as WebM
+ *   OGG        – "OggS" capture pattern        (RFC 3533)
+ *   FLV        – "FLV" signature at offset 0   (Adobe spec)
+ *   MPEG-TS    – 0x47 sync byte at offset 0    (ISO 13818-1)
+ *   MPEG (PS)  – pack-start-code at offset 0
+ *   3GPP       – "ftyp3g" at byte offset 4
+ */
+interface MagicSignature {
+  /** Human-readable format name used in error messages. */
+  label: string;
+  /** Byte values to match.  `null` means "skip / wildcard". */
+  bytes: (number | null)[];
+  /** Byte offset at which the pattern starts. */
+  offset: number;
+}
+
+const VIDEO_SIGNATURES: MagicSignature[] = [
+  // MP4 / MOV / M4V – "ftyp" box descriptor at byte 4
+  { label: "MP4/MOV", bytes: [0x66, 0x74, 0x79, 0x70], offset: 4 },
+
+  // WebM / MKV – EBML magic: 0x1A 0x45 0xDF 0xA3
+  { label: "WebM/MKV", bytes: [0x1a, 0x45, 0xdf, 0xa3], offset: 0 },
+
+  // AVI – RIFF header: "RIFF"
+  { label: "AVI", bytes: [0x52, 0x49, 0x46, 0x46], offset: 0 },
+
+  // OGG – "OggS"
+  { label: "OGG", bytes: [0x4f, 0x67, 0x67, 0x53], offset: 0 },
+
+  // FLV – "FLV\x01"
+  { label: "FLV", bytes: [0x46, 0x4c, 0x56, 0x01], offset: 0 },
+
+  // MPEG-2 Transport Stream – sync byte 0x47
+  { label: "MPEG-TS", bytes: [0x47], offset: 0 },
+
+  // MPEG-1/2 Program Stream – pack start code 0x00 0x00 0x01 0xBA
+  { label: "MPEG-PS", bytes: [0x00, 0x00, 0x01, 0xba], offset: 0 },
+
+  // 3GPP – "ftyp3g" at offset 4
+  { label: "3GPP", bytes: [0x66, 0x74, 0x79, 0x70, 0x33, 0x67], offset: 4 },
+];
+
+/** Number of bytes required to test all signatures. */
+const MAGIC_BYTES_LENGTH = 12;
+
+/**
+ * Reads the first {@link MAGIC_BYTES_LENGTH} bytes of `file` and checks them
+ * against known video magic-byte signatures.
+ *
+ * @returns `true` when the file header matches at least one video format.
+ */
+export async function validateVideoMagicBytes(file: File): Promise<boolean> {
+  const buffer = await file.slice(0, MAGIC_BYTES_LENGTH).arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+
+  return VIDEO_SIGNATURES.some(({ bytes: pattern, offset }) =>
+    pattern.every(
+      (expected, i) => expected === null || bytes[offset + i] === expected
+    )
+  );
+}
+
 export const MAX_4K_PIXELS = 3840 * 2160; 
 export const MAX_8K_PIXELS = 7680 * 7680; 
 


### PR DESCRIPTION
Closes #137

## What changed
- Added `validateVideoMagicBytes()` in `src/utils/video-validation.ts` that reads the first 12 bytes of the uploaded file and checks them against known video format magic byte signatures
- Updated `handleFile` in `src/components/FileUpload.tsx` to be async and call the magic byte check before processing
- Added try/catch so file read failures show a friendly error message
- Validation runs before the file is passed to FFmpeg

## Formats supported
- MP4 / MOV — `ftyp` box at byte offset 4
- WebM / MKV — EBML magic bytes `0x1A 0x45 0xDF 0xA3`
- AVI — `RIFF` header
- OGG — `OggS` signature
- FLV — `FLV\x01` signature
- MPEG-TS — sync byte `0x47`
- MPEG-PS — pack start code
- 3GPP — `ftyp3g` at byte offset 4

## Testing
- Renamed a `.txt` file to `.mp4` → correctly rejected with error message
- Uploaded a real `.mp4` video → loaded and processed normally