### PR TITLE
fix: associate trim validation errors with form fields

### DIFF
--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -265,6 +265,7 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
           {invalidStart && (
             <p
               id="trim-start-error"
+              role="alert"
               className="font-heading animate-fade-in mt-1.5 flex items-center gap-1 text-[10px] text-red-500"
             >
               <AlertCircle size={10} className="shrink-0" />
@@ -302,6 +303,7 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
           {invalidEnd && (
             <p
               id="trim-end-error"
+              role="alert"
               className="font-heading animate-fade-in mt-1.5 flex items-center gap-1 text-[10px] text-red-500"
             >
               <AlertCircle size={10} className="shrink-0" />


### PR DESCRIPTION
## Description

Improved accessibility of trim validation fields by properly associating validation errors with their corresponding form inputs.

### Changes Made

* Added `role="alert"` to trim validation error messages
* Verified `aria-describedby` links inputs to their error messages
* Verified `aria-invalid` is set on invalid inputs
* Ensured screen readers can announce validation errors correctly

### Accessibility Improvements

* Error messages are programmatically associated with form fields
* Invalid fields expose their state through `aria-invalid`
* Validation errors are announced using `role="alert"`

## Related Issue

Fixes #172

## Type of Contribution

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor
* [x] GSSoC contribution

## Participant Info

* GitHub username: srinidhi-2006-bit
* Contribution level (Beginner)

## Screen Recording

**Recording / Loom link:**  

https://github.com/user-attachments/assets/feb098a2-35bc-4879-9ab5-905490352bbe

## Checklist

* [x] I have read the contribution guidelines
* [x] My changes follow the project structure
* [x] I have tested my changes in Chrome, Firefox, and Safari
* [x] `bun run lint` passes (no ESLint errors)
* [x] `bunx tsc --noEmit` passes (no TypeScript errors)
* [x] New interactive elements have `aria-label` / accessible names
* [x] No `console.log` statements left in
* [x] This PR is related to a valid issue
* [x] **Screen recording attached above** (required for UI/feature/design changes)
