### PR TITLE
fix: clamp onboarding tooltip within viewport bounds and fix button accessibility

### DIFF
--- a/src/components/OnboardingTour.tsx
+++ b/src/components/OnboardingTour.tsx
@@ -70,29 +70,37 @@ function getTooltipStyle(
     height: rect.height + PADDING * 2,
   };
 
+  const MARGIN = 8;
+  const vw = typeof window !== "undefined" ? window.innerWidth : 1024;
+  const vh = typeof window !== "undefined" ? window.innerHeight : 768;
+
+  let top = 0;
+  let left = 0;
+
   switch (position) {
     case "top":
-      return {
-        top: sr.top - th - TOOLTIP_OFFSET,
-        left: sr.left + sr.width / 2 - tw / 2,
-      };
+      top = sr.top - th - TOOLTIP_OFFSET;
+      left = sr.left + sr.width / 2 - tw / 2;
+      break;
     case "left":
-      return {
-        top: sr.top + sr.height / 2 - th / 2,
-        left: sr.left - tw - TOOLTIP_OFFSET,
-      };
+      top = sr.top + sr.height / 2 - th / 2;
+      left = sr.left - tw - TOOLTIP_OFFSET;
+      break;
     case "right":
-      return {
-        top: sr.top + sr.height / 2 - th / 2,
-        left: sr.left + sr.width + TOOLTIP_OFFSET,
-      };
+      top = sr.top + sr.height / 2 - th / 2;
+      left = sr.left + sr.width + TOOLTIP_OFFSET;
+      break;
     case "bottom":
     default:
-      return {
-        top: sr.top + sr.height + TOOLTIP_OFFSET,
-        left: sr.left + sr.width / 2 - tw / 2,
-      };
+      top = sr.top + sr.height + TOOLTIP_OFFSET;
+      left = sr.left + sr.width / 2 - tw / 2;
+      break;
   }
+
+  top = Math.max(MARGIN, Math.min(top, vh - th - MARGIN));
+  left = Math.max(MARGIN, Math.min(left, vw - tw - MARGIN));
+
+  return { top, left };
 }
 
 interface SpotlightProps {
@@ -204,12 +212,15 @@ function Tooltip({
 
         <div className="flex items-center justify-between gap-3">
           <button
+            type="button"
             onClick={onSkip}
+            aria-label="Skip onboarding tour"
             className="text-xs text-[var(--muted)] hover:text-[var(--text)] transition-colors underline underline-offset-2"
           >
             Skip tour
           </button>
           <button
+            type="button"
             onClick={onNext}
             ref={(el) => {
               el?.focus();
@@ -314,8 +325,7 @@ export default function OnboardingTour() {
             else dismiss();
           }
         })
-        .catch((error) => {
-          console.error("Failed to measure tour target:", error);
+        .catch(() => {
           dismiss();
         });
     };


### PR DESCRIPTION
## What does this PR do?
Fixes the onboarding tooltip escaping the viewport by adding 
viewport clamping to `getTooltipStyle`. Also removes a 
`console.error` violation and adds missing `type="button"` 
and `aria-label` attributes to the Skip and Next buttons.

## Related issue
Closes #922

## Changes made
- `src/components/OnboardingTour.tsx`:
  - Added viewport clamping to `getTooltipStyle` — tooltip now 
    stays within viewport bounds on all screen sizes
  - Removed `console.error` from catch block per CONTRIBUTING.md
  - Added `type="button"` to Skip and Next buttons
  - Added `aria-label="Skip onboarding tour"` to Skip button

## How to test
1. Open the editor at localhost:3000
2. Clear site data to trigger onboarding
3. Resize browser to mobile width (360px)
4. Confirm tooltip stays within screen bounds on all steps
5. Confirm Skip and Next buttons work with keyboard

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue