### PR TITLE
fix: add dismissible large file warning banner for files over 500MB

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -226,11 +226,19 @@ export default function VideoEditor() {
 
   const [copied, setCopied] = useState(false);
   const [shareCopied, setShareCopied] = useState(false);
+  // State for dismissing the large file warning
+  const [largeFileWarningDismissed, setLargeFileWarningDismissed] = useState(false);
   const initialOverlayState = useRef({
     overlayPosition,
     overlaySize,
     overlayOpacity,
   });
+
+  // Reset warning dismissal when a new file is selected
+  useEffect(() => {
+    setLargeFileWarningDismissed(false);
+  }, [file]);
+
   useEffect(() => {
     if (!file) return;
 
@@ -446,11 +454,29 @@ return () => {
               )}
             </div>
 
-            {file && file.size > 100 * 1024 * 1024 && (
-              <p className="text-[var(--warning)] text-sm">
-                ⚠️ Large file - processing may take several minutes
-              </p>
+            {/* ── Large file warning banner (shown for files > 500MB, dismissible) ── */}
+            {file && file.size > 500 * 1024 * 1024 && !largeFileWarningDismissed && (
+              <div
+                role="alert"
+                className="flex items-start gap-3 p-4 bg-yellow-50 border border-yellow-300 rounded-xl text-yellow-800 text-sm animate-fade-in"
+              >
+                <AlertTriangle size={16} className="shrink-0 mt-0.5 text-yellow-500" />
+                <p className="flex-1">
+                  ⚠️ Large file detected ({(file.size / (1024 * 1024)).toFixed(0)} MB).
+                  Export may be slow or fail due to browser memory limits.
+                  For best results, use files under 500MB.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setLargeFileWarningDismissed(true)}
+                  className="ml-auto text-yellow-700 hover:text-yellow-900 font-bold text-base leading-none shrink-0"
+                  aria-label="Dismiss large file warning"
+                >
+                  ✕
+                </button>
+              </div>
             )}
+
             {file && (
               <div className={cn(
                 "grid grid-cols-1 gap-4",


### PR DESCRIPTION
## Description
When a user uploads a video file larger than 500MB, the app would silently
hang or crash the browser tab during export with no feedback. This PR adds
a visible, dismissible warning banner that appears immediately after a large
file is selected, informing the user of the risk before they attempt export.

Changes made:
- Replaced the old basic 100MB plain text warning in `VideoEditor.tsx` with
  a proper yellow alert banner triggered at 500MB
- Banner displays the exact file size in MB
- Banner is dismissible via a ✕ button
- Warning resets automatically when a new file is selected
- Uses `AlertTriangle` from `lucide-react` (already in project, zero new dependencies)

## Related Issue
Fixes #(Closes #1563)

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: AKIB2005
- Contribution level (Beginner/Intermediate/Advanced): Beginner

## Screen Recording
**Recording / Loom link:** *(record yourself uploading a 500MB+ file and showing the banner appears, then dismissing it)*

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [ ] `bun run lint` passes (no ESLint errors)
- [ ] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [ ] **Screen recording attached above** (required for UI/feature/design changes)