### PR TITLE
perf: implement lazy loading and bundle splitting (resolves #1382)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,13 +4,50 @@ const nextConfig: NextConfig = {
   output: "export",
   experimental: {
     scrollRestoration: true,
+    /**
+     * Tree-shake lucide-react so only the icons actually used in the
+     * source are included in the production bundle, instead of the
+     * full icon library (~2 MB uncompressed).
+     */
+    optimizePackageImports: ["lucide-react"],
   },
   // Required for ffmpeg.wasm to load WASM files correctly
   // Without this, Next.js might try to process .wasm files and break them
   webpack: (config) => {
     config.resolve.fallback = { fs: false };
+
+    /**
+     * Split large third-party dependencies into separate chunks so the
+     * browser can cache them independently and users only re-download
+     * what actually changed between versions.
+     */
+    config.optimization = {
+      ...config.optimization,
+      splitChunks: {
+        chunks: "all",
+        cacheGroups: {
+          // Keep ffmpeg.wasm in its own chunk — it is very large and
+          // changes infrequently, so long-term caching is valuable.
+          ffmpeg: {
+            test: /[\\/]node_modules[\\/]@ffmpeg[\\/]/,
+            name: "ffmpeg",
+            chunks: "all",
+            priority: 30,
+            enforce: true,
+          },
+          // Group all other heavy vendor code together.
+          vendor: {
+            test: /[\\/]node_modules[\\/]/,
+            name: "vendors",
+            chunks: "all",
+            priority: 10,
+          },
+        },
+      },
+    };
+
     return config;
   },
 };
 
-export default nextConfig;
+export default nextConfig;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,33 @@
-import VideoEditor from "@/components/VideoEditor";
-import Footer from "@/components/Footer";
+"use client";
+
+import dynamic from "next/dynamic";
+import { Suspense } from "react";
+
+/**
+ * Lazy-load VideoEditor (the heaviest component ~32 KB).
+ * `ssr: false` is required because VideoEditor uses browser-only APIs
+ * (e.g. URL.createObjectURL, navigator, ffmpeg.wasm).
+ */
+const VideoEditor = dynamic(() => import("@/components/VideoEditor"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <div className="flex flex-col items-center gap-3 text-[var(--muted)]">
+        <span className="h-8 w-8 animate-spin rounded-full border-2 border-current border-t-transparent" aria-hidden="true" />
+        <p className="text-xs font-mono uppercase tracking-widest opacity-60">Loading editor…</p>
+      </div>
+    </div>
+  ),
+});
+
+/**
+ * Footer lives below the fold — load it lazily so it never blocks
+ * the critical rendering path.
+ */
+const Footer = dynamic(() => import("@/components/Footer"), {
+  ssr: false,
+  loading: () => null,
+});
 
 export default function Home() {
   return (
@@ -14,10 +42,15 @@ export default function Home() {
       </a>
 
       <main id="main-content" tabIndex={-1}>
-        <VideoEditor />
+        <Suspense fallback={null}>
+          <VideoEditor />
+        </Suspense>
       </main>
 
-      <Footer />
+      <Suspense fallback={null}>
+        <Footer />
+      </Suspense>
     </>
   );
 }
+

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useState, useRef, useEffect, useMemo } from "react";
+import dynamic from "next/dynamic";
 import { useVideoEditor } from "@/hooks/useVideoEditor";
 import { TextOverlay } from "@/lib/types";
 import FileUpload from "./FileUpload";
 import VideoPreview from "./VideoPreview";
-import ThumbnailStrip from "./ThumbnailStrip";
 import PresetSelector from "./PresetSelector";
 import FramingControl from "./FramingControl";
 import TrimControl from "./TrimControl";
@@ -16,15 +16,32 @@ import FormatSelector from "./FormatSelector";
 import ExportSettings from "./ExportSettings";
 import ExportOverlay from "./ExportOverlay";
 import DownloadResult from "./DownloadResult";
-import ImageOverlay from "./ImageOverlay"
+import ImageOverlay from "./ImageOverlay";
 import { getPresetById } from "@/lib/presets";
+
+/**
+ * ThumbnailStrip is only rendered after a file is uploaded.
+ * Lazy-load it to keep the initial JS bundle smaller.
+ */
+const ThumbnailStrip = dynamic(() => import("./ThumbnailStrip"), {
+  ssr: false,
+  loading: () => <div className="h-12 w-full animate-pulse rounded bg-[var(--border)]" />,
+});
+
+/**
+ * OnboardingTour is shown only once on first visit — defer it entirely
+ * so it never blocks the initial render.
+ */
+const OnboardingTour = dynamic(() => import("./OnboardingTour"), {
+  ssr: false,
+  loading: () => null,
+});
 
 import { cn } from "@/lib/utils";
 import {
   Layers, Crop, Scissors, RotateCw, Volume2, Type,
   SlidersHorizontal, Zap, AlertTriangle, Github, Copy
 } from "lucide-react";
-import OnboardingTour from "./OnboardingTour";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 
 interface SectionProps {


### PR DESCRIPTION
Closes #1382

## Summary

Implements a comprehensive lazy loading and bundle splitting strategy to reduce initial page load time and Time to Interactive (TTI).

## Changes

### `src/app/page.tsx`
- Replaced eager import of `VideoEditor` (32 KB) with `next/dynamic` + `ssr: false`
  - Shows an animated spinner while the editor chunk loads
- Replaced eager import of `Footer` with `next/dynamic` + `ssr: false`
  - Footer is below the fold and never needs to block first paint

### `src/components/VideoEditor.tsx`
- Replaced eager import of `ThumbnailStrip` (13 KB) with `next/dynamic`
  - Only rendered after a file is uploaded — never needed at first paint
  - Shows an animated skeleton placeholder while loading
- Replaced eager import of `OnboardingTour` (11 KB) with `next/dynamic`
  - Only shown once on first visit — deferred completely to after hydration
- `LottiePlayer` was already using dynamic `import()` ✅

### `next.config.ts`
- Added `optimizePackageImports: ["lucide-react"]` — tree-shakes unused icons
- Added webpack `splitChunks` config with dedicated `ffmpeg` and `vendor` cache groups for long-term browser caching

## Impact

| Metric | Before | After |
|---|---|---|
| Initial JS sent to browser | Entire editor + all components | Only shell + async chunks |
| VideoEditor chunk | Eagerly loaded | Deferred until after first paint |
| ThumbnailStrip + OnboardingTour | Always loaded | Only loaded when needed |
| lucide-react | Full library | Tree-shaken to used icons only |
| ffmpeg.wasm | Part of main bundle | Separate cached chunk |
