### PR TITLE
fix: resolve export estimates from preset ids

### DIFF
--- a/src/lib/exportEstimate.test.ts
+++ b/src/lib/exportEstimate.test.ts
@@ -5,7 +5,7 @@ import { describe, test, expect } from "vitest";
 // Minimal recipe factory — only the fields estimateExportSize cares about
 function makeRecipe(overrides: Partial<EditRecipe> = {}): EditRecipe {
   return {
-    preset: "1080p",
+    preset: "landscape-16-9",
     customWidth: 1920,
     customHeight: 1080,
     quality: 23,       // default CRF
@@ -49,10 +49,33 @@ describe("estimateExportSize", () => {
     expect(long / short).toBeCloseTo(4, 0);
   });
 
-  test("higher resolution (4k) produces a larger estimate than 720p", () => {
-    const hd  = estimateExportSize(makeRecipe({ preset: "720p" }), 60);
-    const uhd = estimateExportSize(makeRecipe({ preset: "4k"   }), 60);
-    expect(uhd).toBeGreaterThan(hd);
+  test("larger preset dimensions produce a larger estimate", () => {
+    const hd = estimateExportSize(makeRecipe({ preset: "twitter-hd" }), 60);
+    const panoramic = estimateExportSize(makeRecipe({ preset: "instagram-panoramic" }), 60);
+    expect(panoramic).toBeGreaterThan(hd);
+  });
+
+  test("preset IDs resolve dimensions from the preset list instead of custom fallback", () => {
+    const presetHd = estimateExportSize(
+      makeRecipe({
+        preset: "twitter-hd",
+        customWidth: 1920,
+        customHeight: 1080,
+        format: "gif",
+      }),
+      10
+    );
+    const customLandscape = estimateExportSize(
+      makeRecipe({
+        preset: "custom",
+        customWidth: 1920,
+        customHeight: 1080,
+        format: "gif",
+      }),
+      10
+    );
+
+    expect(presetHd).toBeLessThan(customLandscape);
   });
 
   test("trim reduces effective duration and therefore file size", () => {

--- a/src/lib/exportEstimate.ts
+++ b/src/lib/exportEstimate.ts
@@ -1,23 +1,14 @@
 import { EditRecipe } from "./types";
+import { PRESETS } from "./presets";
 
 // ---------------------------------------------------------------------------
 // Preset dimension map
-// Keep in sync with src/lib/presets.ts. Width × height for every named preset.
+// Derived from src/lib/presets.ts so estimator IDs stay aligned with the UI.
 // ---------------------------------------------------------------------------
-const PRESET_DIMENSIONS: Record<string, { width: number; height: number }> = {
-  "1080p":       { width: 1920, height: 1080 },
-  "720p":        { width: 1280, height: 720  },
-  "480p":        { width: 854,  height: 480  },
-  "360p":        { width: 640,  height: 360  },
-  "4k":          { width: 3840, height: 2160 },
-  "2k":          { width: 2560, height: 1440 },
-  // Square / portrait presets
-  "square-1080": { width: 1080, height: 1080 },
-  "square-720":  { width: 720,  height: 720  },
-  "portrait-1080": { width: 1080, height: 1920 },
-  "portrait-720":  { width: 720,  height: 1280 },
-  // Fallback — if a preset name is unrecognised we fall through to customWidth/H
-};
+const PRESET_DIMENSIONS: Record<string, { width: number; height: number }> =
+  Object.fromEntries(
+    PRESETS.map(({ id, width, height }) => [id, { width, height }])
+  );
 
 /**
  * Resolve the actual output pixel dimensions for a recipe.


### PR DESCRIPTION
## Summary
- Derive export estimate preset dimensions from the canonical `PRESETS` list
- Replace legacy preset IDs in export estimate tests with current preset IDs
- Add regression coverage to ensure preset IDs do not fall back to custom dimensions

## Tests
- `npm test -- src\lib\exportEstimate.test.ts` could not run because `vitest` is not installed in this local clone

Closes #1464