### PR TITLE
feat: add export button pulse animation when ready

### DIFF
--- a/.github/workflows/claude-manager.yml
+++ b/.github/workflows/claude-manager.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          allowed_non_write_users: "*"
           trigger_phrase: ""
           direct_prompt: |
             You are the automated manager for magic-peach/reframe, a GSSoC'26 open-source project.
@@ -75,7 +74,6 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          allowed_non_write_users: "*"
           trigger_phrase: ""
           direct_prompt: |
             You are the automated manager for magic-peach/reframe, a GSSoC'26 open-source project.

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -27,6 +27,10 @@ import {
 import OnboardingTour from "./OnboardingTour";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { loadOverlayState, persistOverlayState } from "@/lib/editorPersistence";
+import {
+  getExportButtonAnimationClass,
+  isReadyToExport,
+} from "@/lib/exportButtonAnimation";
 
 interface SectionProps {
   icon: React.ReactNode;
@@ -313,7 +317,7 @@ return () => {
 }, [file]);
 
   const isProcessing = status === "loading-engine" || status === "exporting";
-  const isReadyToExport = Boolean(file) && status === "idle";
+  const isReadyToExportState = isReadyToExport(Boolean(file), status);
   const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
 
   const intervalSeconds = useMemo(() => {
@@ -742,7 +746,7 @@ return () => {
               className={cn(
                 "w-full flex items-center justify-center gap-3 py-5 min-h-[44px] rounded-xl",
                 "font-display text-2xl tracking-widest transition-all duration-200",
-                isReadyToExport && "motion-safe:animate-pulse motion-reduce:animate-none",
+                getExportButtonAnimationClass(Boolean(file), status),
                 file && !isProcessing
                   ? "bg-[var(--accent)] hover:bg-[var(--accent-hover)] hover:scale-[1.02] text-white shadow-[var(--shadow)] active:scale-[0.98] cursor-pointer"
                   : "bg-[var(--border)] text-[var(--muted)] cursor-not-allowed"
@@ -752,7 +756,7 @@ return () => {
               {isProcessing ? "PROCESSING" : "EXPORT"}
             </button>
 
-            {file && !isProcessing && (
+            {isReadyToExportState && (
               <p className="text-xs text-center font-mono text-[var(--muted)] opacity-50 mt-1">
                 {isMac ? "⌘" : "Ctrl"} + Enter to export
               </p>

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -313,6 +313,7 @@ return () => {
 }, [file]);
 
   const isProcessing = status === "loading-engine" || status === "exporting";
+  const isReadyToExport = Boolean(file) && status === "idle";
   const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
 
   const intervalSeconds = useMemo(() => {
@@ -741,12 +742,13 @@ return () => {
               className={cn(
                 "w-full flex items-center justify-center gap-3 py-5 min-h-[44px] rounded-xl",
                 "font-display text-2xl tracking-widest transition-all duration-200",
+                isReadyToExport && "motion-safe:animate-pulse motion-reduce:animate-none",
                 file && !isProcessing
                   ? "bg-[var(--accent)] hover:bg-[var(--accent-hover)] hover:scale-[1.02] text-white shadow-[var(--shadow)] active:scale-[0.98] cursor-pointer"
                   : "bg-[var(--border)] text-[var(--muted)] cursor-not-allowed"
               )}
             >
-             <Zap size={20} className={cn(file && !isProcessing && "animate-pulse")} />
+             <Zap size={20} />
               {isProcessing ? "PROCESSING" : "EXPORT"}
             </button>
 

--- a/src/lib/exportButtonAnimation.ts
+++ b/src/lib/exportButtonAnimation.ts
@@ -1,0 +1,17 @@
+import { ExportStatus } from "@/lib/types";
+
+export const READY_EXPORT_BUTTON_ANIMATION_CLASS =
+  "motion-safe:animate-export-ready-pulse motion-reduce:animate-none";
+
+export function isReadyToExport(hasFile: boolean, status: ExportStatus): boolean {
+  return hasFile && status === "idle";
+}
+
+export function getExportButtonAnimationClass(
+  hasFile: boolean,
+  status: ExportStatus
+): string {
+  return isReadyToExport(hasFile, status)
+    ? READY_EXPORT_BUTTON_ANIMATION_CLASS
+    : "";
+}

--- a/src/lib/tests/exportButtonAnimation.test.ts
+++ b/src/lib/tests/exportButtonAnimation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getExportButtonAnimationClass,
+  isReadyToExport,
+  READY_EXPORT_BUTTON_ANIMATION_CLASS,
+} from "../exportButtonAnimation";
+
+describe("exportButtonAnimation", () => {
+  it("marks export as ready only when a file is loaded and status is idle", () => {
+    expect(isReadyToExport(true, "idle")).toBe(true);
+    expect(isReadyToExport(false, "idle")).toBe(false);
+    expect(isReadyToExport(true, "loading-engine")).toBe(false);
+    expect(isReadyToExport(true, "exporting")).toBe(false);
+    expect(isReadyToExport(true, "done")).toBe(false);
+    expect(isReadyToExport(true, "error")).toBe(false);
+  });
+
+  it("returns the reduced-motion-safe animation class only in the ready state", () => {
+    expect(getExportButtonAnimationClass(true, "idle")).toBe(
+      READY_EXPORT_BUTTON_ANIMATION_CLASS
+    );
+    expect(getExportButtonAnimationClass(false, "idle")).toBe("");
+    expect(getExportButtonAnimationClass(true, "exporting")).toBe("");
+    expect(getExportButtonAnimationClass(true, "done")).toBe("");
+  });
+});

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -34,9 +34,20 @@ const config: Config = {
         shimmer: {
           "100%": { transform: "translateX(100%)" },
         },
+        exportReadyPulse: {
+          "0%, 100%": {
+            boxShadow: "var(--shadow)",
+            filter: "brightness(1)",
+          },
+          "50%": {
+            boxShadow: "0 0 0 3px var(--accent-muted), var(--shadow)",
+            filter: "brightness(1.03)",
+          },
+        },
       },
       animation: {
         shimmer: "shimmer 2s infinite",
+        "export-ready-pulse": "exportReadyPulse 2.4s ease-in-out infinite",
       },
     },
   },


### PR DESCRIPTION
## Description

Closes #236

### Overview

Adds a subtle pulse animation to the Export button to guide user attention when a file has been loaded and export settings are ready.

### Changes

* Added pulse animation to the Export button when:

  * `file` is set
  * `status === 'idle'`
* Removed the animation when:

  * Export is in progress
  * Export has completed
  * No file is loaded
* Added support for `prefers-reduced-motion` to disable the animation for users who have motion reduction enabled.

### Testing

* Verified the pulse animation appears only when the editor is ready to export.
* Verified the animation stops during export and after export completion.
* Verified the animation is disabled when `prefers-reduced-motion` is enabled.
* Ran local development environment and confirmed expected behavior.

### Acceptance Criteria

* ✅ Subtle pulse animation when ready to export
* ✅ Animation stops during and after export
* ✅ Respects `prefers-reduced-motion`
