### PR TITLE
fix: prevent onboarding tooltip from going off-screen

### DIFF
--- a/src/components/OnboardingTour.tsx
+++ b/src/components/OnboardingTour.tsx
@@ -76,16 +76,20 @@ function getTooltipStyle(
         top: sr.top - th - TOOLTIP_OFFSET,
         left: sr.left + sr.width / 2 - tw / 2,
       };
-    case "left":
-      return {
-        top: sr.top + sr.height / 2 - th / 2,
-        left: sr.left - tw - TOOLTIP_OFFSET,
-      };
-    case "right":
-      return {
-        top: sr.top + sr.height / 2 - th / 2,
-        left: sr.left + sr.width + TOOLTIP_OFFSET,
-      };
+   case "left":
+  return {
+    top: Math.max(16, sr.top + sr.height / 2 - th / 2),
+    left: Math.max(16, sr.left - tw - TOOLTIP_OFFSET),
+  };
+
+case "right":
+  return {
+    top: Math.max(16, sr.top + sr.height / 2 - th / 2),
+    left: Math.min(
+      window.innerWidth - tw - 16,
+      sr.left + sr.width + TOOLTIP_OFFSET,
+    ),
+  };
     case "bottom":
     default:
       return {
@@ -178,8 +182,7 @@ function Tooltip({
       className="fixed z-[9999] w-80 rounded-xl shadow-2xl border
         bg-[var(--surface)]
         border-[var(--border)]
-        text-[var(--text)]
-        transition-all duration-200"
+        text-[var(--text)]"
       style={{ ...style }}
       tabIndex={-1}
     >


### PR DESCRIPTION
## Description

Fixed the onboarding tour tooltip positioning issue where the tooltip could move outside the viewport during step transitions, causing content to become partially or completely unreadable.

### Changes Made

* Added viewport boundary checks for tooltip positioning.
* Prevented tooltips from rendering outside the visible screen area.
* Improved onboarding tour readability during step transitions.
* Ensured tooltip content remains accessible and visible throughout the onboarding flow.

## Related Issue

Fixes #1521

## Type of Contribution

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor
* [x] GSSoC contribution

## Participant Info

* GitHub username: Saylee12R
* Contribution level: Beginner

## Screen Recording

Recording / Loom link:


https://github.com/user-attachments/assets/bc75bca1-e9c9-4ad7-87c7-86b069ba8289

## Checklist

* [x] I have read the contribution guidelines
* [x] My changes follow the project structure
* [x] I have tested my changes locally
* [x] `npm run lint` passes (no ESLint errors)
* [x] This PR is related to a valid issue
* [x] Screen recording attached above
