### PR TITLE
fix: prevent infinite export when looping background music

### DIFF
--- a/src/lib/ffmpeg.worker.ts
+++ b/src/lib/ffmpeg.worker.ts
@@ -312,7 +312,9 @@ interface PositionCoords {
     const outputDuration = sourceDuration / recipe.speed;
     args.push("-t", outputDuration.toFixed(6));
   }
-
+  if (hasMusicTrack) {
+    args.push("-shortest");
+  }
   args.push(outputName);
   return args;
 }


### PR DESCRIPTION
## Description

Added FFmpeg `-shortest` flag when a background music track is present.

This ensures exports terminate when the video stream ends, preventing excessively long or potentially infinite exports when:

* the source video has no audio track
* loop music is enabled
* the background music duration exceeds the video duration

## Related Issue

Fixes #1493

## Type of Contribution

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor
* [x] GSSoC contribution

## Participant Info

* GitHub username: Saylee12R
* Contribution level: Beginner

## Screen Recording

N/A (logic-only bug fix, no UI changes)

## Checklist

* [x] I have read the contribution guidelines
* [x] My changes follow the project structure
* [x] `bun run lint` passes (no ESLint errors)
* [x] `bunx tsc --noEmit` passes (no TypeScript errors)
* [x] No `console.log` statements left in
* [x] This PR is related to a valid issue
