### PR TITLE
fix: prevent footer overlap on tablet viewports

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -99,7 +99,7 @@ export default function Footer() {
             </h3>
 
             <form
-              className="flex items-center w-full sm:w-80 bg-[var(--surface)] border border-[var(--border)] rounded-lg px-3 focus-within:border-[var(--accent)] transition"
+              className="flex items-center w-full lg:w-80 bg-[var(--surface)] border border-[var(--border)] rounded-lg px-3 focus-within:border-[var(--accent)] transition"
               onSubmit={(e) => e.preventDefault()}
               aria-label="Newsletter signup"
             >


### PR DESCRIPTION
## Description

### Summary

Fixes footer layout overlap on tablet-sized and narrow viewport widths.

### Changes Made

* Updated the newsletter form width from `sm:w-80` to `lg:w-80`
* Allows the newsletter input to remain responsive on tablet and reduced viewport widths
* Prevents the Updates and Community sections from overlapping with the Navigation section
* Preserves the original desktop appearance by applying the fixed width only on large screens

### Result

The footer now maintains proper spacing and alignment across desktop, tablet, and narrow window sizes without content collisions.

## Related Issue

Fixes #1594

## Type of Contribution

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactor
* [x] GSSoC contribution

## Participant Info

* GitHub username: karthikvemula23
* Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Screenshots

### Before
<img width="2553" height="1439" alt="Screenshot 2026-06-21 171714" src="https://github.com/user-attachments/assets/555d94a1-267a-4837-ab20-b8bce6b46367" />


### After
<img width="2554" height="1434" alt="Screenshot 2026-06-21 171745" src="https://github.com/user-attachments/assets/f9077eae-c71b-476b-9720-8c0f98f9e1c0" />
## Checklist

* [x] I have read the contribution guidelines
* [x] My changes follow the project structure
* [x ] I have tested my changes in Edge, Chrome, Firefox, and Safari
* [ x] `bun run lint` passes (no ESLint errors)
* [x ] `bunx tsc --noEmit` passes (no TypeScript errors)
* [x] New interactive elements have `aria-label` / accessible names
* [x] No `console.log` statements left in
* [x] This PR is related to a valid issue
* [x] Screenshots attached above
