### PR TITLE
fix: prevent waveform OOM on large files

### DIFF
--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -25,7 +25,11 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
     recipe.trimStart.toString()
   );
 
-  const { waveform, isLoading: waveformLoading } = useAudioWaveform(file);
+  const {
+    waveform,
+    isLoading: waveformLoading,
+    waveformError,
+  } = useAudioWaveform(file);
   const hasAudio = waveform.length > 0;
 
   useEffect(() => {
@@ -315,6 +319,11 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
         <p className="text-sm text-[var(--muted)] font-heading mt-1">
           Clip: {formatDuration(clipLength)} of{" "}
           {formatDuration(duration)}
+        </p>
+      )}
+      {waveformError && (
+        <p className="text-[10px] text-[var(--muted)] font-heading">
+          {waveformError}
         </p>
       )}
       {recipe.trimEnd !== null &&

--- a/src/hooks/__tests__/useAudioWaveform.test.tsx
+++ b/src/hooks/__tests__/useAudioWaveform.test.tsx
@@ -1,0 +1,26 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  MAX_WAVEFORM_FILE_SIZE_BYTES,
+  useAudioWaveform,
+} from "../useAudioWaveform";
+
+describe("useAudioWaveform", () => {
+  it("skips waveform decoding for files that are too large", async () => {
+    const file = new File(["video"], "large-video.mp4", { type: "video/mp4" });
+    Object.defineProperty(file, "size", {
+      value: MAX_WAVEFORM_FILE_SIZE_BYTES + 1,
+    });
+    const arrayBufferSpy = vi.spyOn(file, "arrayBuffer");
+
+    const { result } = renderHook(() => useAudioWaveform(file));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.waveformError).toMatch(/larger than 50 MB/i);
+    });
+
+    expect(result.current.waveform).toEqual([]);
+    expect(arrayBufferSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useAudioWaveform.ts
+++ b/src/hooks/useAudioWaveform.ts
@@ -3,6 +3,9 @@
 import { useEffect, useState } from "react";
 
 const DEFAULT_BAR_COUNT = 96;
+export const MAX_WAVEFORM_FILE_SIZE_BYTES = 50 * 1024 * 1024;
+const LARGE_FILE_WAVEFORM_MESSAGE =
+  "Waveform preview is disabled for files larger than 50 MB.";
 
 type BrowserWindow = Window &
   typeof globalThis & {
@@ -33,6 +36,7 @@ export function useAudioWaveform(
 ) {
   const [waveform, setWaveform] = useState<number[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [waveformError, setWaveformError] = useState<string | null>(null);
 
   useEffect(() => {
     let isCancelled = false;
@@ -41,6 +45,14 @@ export function useAudioWaveform(
     async function extractWaveform() {
       if (!file) {
         setWaveform([]);
+        setWaveformError(null);
+        setIsLoading(false);
+        return;
+      }
+
+      if (file.size > MAX_WAVEFORM_FILE_SIZE_BYTES) {
+        setWaveform([]);
+        setWaveformError(LARGE_FILE_WAVEFORM_MESSAGE);
         setIsLoading(false);
         return;
       }
@@ -50,11 +62,13 @@ export function useAudioWaveform(
 
       if (!AudioContextCtor) {
         setWaveform([]);
+        setWaveformError(null);
         setIsLoading(false);
         return;
       }
 
       setIsLoading(true);
+      setWaveformError(null);
 
       try {
         audioContext = new AudioContextCtor();
@@ -70,6 +84,7 @@ export function useAudioWaveform(
       } catch {
         if (!isCancelled) {
           setWaveform([]);
+          setWaveformError("Unable to generate waveform preview for this file.");
         }
       } finally {
         await audioContext?.close();
@@ -86,5 +101,5 @@ export function useAudioWaveform(
     };
   }, [barCount, file]);
 
-  return { waveform, isLoading };
+  return { waveform, isLoading, waveformError };
 }


### PR DESCRIPTION
Fixes #1501

## Description
This PR prevents large files from being fully loaded into memory during waveform generation by adding a pre-decode file-size guard before `file.arrayBuffer()` is called.

When waveform generation is skipped or fails, the editor now shows a graceful fallback message instead of risking a browser freeze or crash. Normal waveform generation for smaller files is preserved.

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: anirudhu-ui
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Screen Recording
**Recording / Loom link:** https://drive.google.com/file/d/1KLARUl0HzdjFo67TPYD9cvigZdtvbSun/view?usp=sharing

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [ ] I have tested my changes in Chrome, Firefox, and Safari
- [ ] `bun run lint` passes (no ESLint errors)
- [ ] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run build`

Note: Bun is not installed in my local environment, so I verified with the equivalent npm/npx commands. The PR is kept as draft until the required browser checks are added.