### PR TITLE
fix: prevent non-file drags from showing upload overlay

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -14,6 +14,11 @@ interface Props {
   duration: number;
 }
 
+function isFileDrag(e: DragEvent) {
+  const types = e.dataTransfer?.types;
+  return Boolean(types && Array.prototype.includes.call(types, "Files"));
+}
+
 export default function FileUpload({
   onFileSelect,
   currentFile,
@@ -44,22 +49,30 @@ export default function FileUpload({
   // Uses a counter so nested dragenter/dragleave don't flicker
   useEffect(() => {
     const onDragEnter = (e: DragEvent) => {
+      if (!isFileDrag(e)) return;
+
       e.preventDefault();
       dragCounterRef.current += 1;
       if (dragCounterRef.current === 1) setPageDragging(true);
     };
 
     const onDragLeave = (e: DragEvent) => {
+      if (!isFileDrag(e)) return;
+
       e.preventDefault();
-      dragCounterRef.current -= 1;
+      dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
       if (dragCounterRef.current === 0) setPageDragging(false);
     };
 
     const onDragOver = (e: DragEvent) => {
+      if (!isFileDrag(e)) return;
+
       e.preventDefault(); // required to allow drop
     };
 
     const onDrop = (e: DragEvent) => {
+      if (!isFileDrag(e)) return;
+
       e.preventDefault();
       dragCounterRef.current = 0;
       setPageDragging(false);

--- a/src/components/__tests__/FileUpload.test.tsx
+++ b/src/components/__tests__/FileUpload.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { fireEvent } from '@testing-library/dom'
+import FileUpload from '../FileUpload'
+
+function createDocumentDragEvent(type: string, dataTransferTypes: string[]) {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+
+  Object.defineProperty(event, 'dataTransfer', {
+    value: {
+      types: dataTransferTypes,
+      files: [],
+    },
+  })
+
+  return event
+}
+
+describe('FileUpload page drag overlay', () => {
+  const currentFile = new File(['video'], 'sample.mp4', { type: 'video/mp4' })
+
+  it('ignores document drag events that are not file drags', () => {
+    render(
+      <FileUpload
+        onFileSelect={vi.fn()}
+        currentFile={currentFile}
+        fileError=""
+        duration={10}
+      />
+    )
+
+    fireEvent(document, createDocumentDragEvent('dragenter', ['text/plain']))
+
+    expect(screen.queryByText('Drop your video anywhere')).not.toBeInTheDocument()
+  })
+
+  it('shows the page overlay for document file drags', () => {
+    render(
+      <FileUpload
+        onFileSelect={vi.fn()}
+        currentFile={currentFile}
+        fileError=""
+        duration={10}
+      />
+    )
+
+    fireEvent(document, createDocumentDragEvent('dragenter', ['Files']))
+
+    expect(screen.getByText('Drop your video anywhere')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the page-level upload overlay so it only responds to real file drags. This prevents normal in-app drag interactions, like dragging the Brightness slider, from being treated as a video upload attempt.

## Root cause

The document-level drag handlers in `FileUpload.tsx` were calling `preventDefault()` and showing the overlay for every drag event. That meant non-file drag events from UI controls could activate the global "Drop your video anywhere" overlay.

## Changes

- Added a small `isFileDrag` guard based on `dataTransfer.types`.
- Applied the guard to the global `dragenter`, `dragleave`, `dragover`, and `drop` handlers.
- Kept external file drag-and-drop behavior intact.
- Added regression coverage for file and non-file document drag events.

## Verification

- `npm test -- --run src/components/__tests__/FileUpload.test.tsx`
- `npm test -- --run`
- `npm run lint`
- `npm run build`

Fixes #1515