### PR TITLE
docs: remove duplicate contributors section from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,22 +428,15 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide including development 
 
 ---
 
-## Contributors
-
-Thank you to everyone who has contributed to Reframe! 🎉
-
-[![Contributors](https://contrib.rocks/image?repo=magic-peach/reframe)](https://github.com/magic-peach/reframe/graphs/contributors)
-
----
-
 ## Privacy
 
 Reframe processes all videos **100% client-side**. Your video files are never uploaded to any server. You can even use Reframe offline (after first load). The source code is fully open for inspection.
+
 ---
 
 ## Contributors
 
-Thanks to all the amazing people who have contributed to Reframe!
+Thanks to all the amazing people who have contributed to Reframe! 🎉
 
 [![Contributors](https://contrib.rocks/image?repo=magic-peach/reframe)](https://github.com/magic-peach/reframe/graphs/contributors)
 


### PR DESCRIPTION
## Description
This PR fixes a structural issue in the README where the "Contributors" section was duplicated. The section appeared both before and immediately after the "Privacy" block. I removed the redundant section to clean up the document flow and maintain a single source of truth for contributor acknowledgments.

## Related Issue
Closes #None

## Type of Contribution
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor
- [ ] GSSoC contribution

## Participant Info
- GitHub username: Mohit-001-hash
- Contribution level (Beginner/Intermediate/Advanced): Beginner

## Screen Recording
> **How to record:** run `bun run dev` → open http://localhost:3000 → demonstrate the full working flow of your change, including any edge cases.
>
> - **macOS**: `Cmd + Shift + 5` → Record Selected Portion, or use QuickTime Player
> - **Windows**: `Win + G` → Xbox Game Bar → Capture
> - **Linux**: OBS Studio, GNOME Screenshot tool, or `kazam`
> - **Any OS**: [Loom](https://loom.com) (free screen recorder, great for sharing)

**Recording / Loom link:** N/A (Documentation formatting update only)

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [ ] I have tested my changes in Chrome, Firefox, and Safari
- [ ] `bun run lint` passes (no ESLint errors)
- [ ] `bunx tsc --noEmit` passes (no TypeScript errors)
- [ ] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [ ] **Screen recording attached above** (required for UI/feature/design changes)