### PR TITLE
fix: darken --muted in light mode to meet WCAG AA contrast (#1037)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,7 +10,7 @@
   --surface: #f1f5f9;
   --border: #cbd5e1;
   --text: #0f172a;
-  --muted: #64748b;
+  --muted: #475569;
   --accent: #3b82f6;
   --accent-hover: #1d4ed8;
   --accent-muted: rgba(59, 130, 246, 0.12);


### PR DESCRIPTION
Closes #1037

Changes \--muted\ in light mode from \#64748b\ to \#475569\ to raise the contrast ratio against white backgrounds from 4.37:1 to 6.8:1, satisfying WCAG AA (4.5:1 minimum) for normal-sized text and improving legibility of secondary text and inactive UI controls.