### PR TITLE
Fix editor footer spacing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import Footer from "@/components/Footer";
 
 export default function Home() {
   return (
-    <>
+    <div className="min-h-screen flex flex-col bg-[var(--bg)]">
       <a
         href="https://github.com/magic-peach/reframe"
         target="_blank"
@@ -14,11 +14,11 @@ export default function Home() {
         ⭐ Star on GitHub
       </a>
 
-      <main id="main-content" tabIndex={-1}>
+      <main id="main-content" tabIndex={-1} className="flex-1">
         <VideoEditor />
       </main>
 
       <Footer />
-    </>
+    </div>
   );
 }

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -350,7 +350,7 @@ return () => {
   }, [videoSrc]);
 
   return (
-    <div className="min-h-screen relative flex flex-col" style={{ background: "var(--bg)" }}>
+    <div className="relative flex flex-col" style={{ background: "var(--bg)" }}>
       <ExportOverlay
         status={status}
         progress={progress}


### PR DESCRIPTION
## Summary
- move the full-height page shell to the home page wrapper
- let the video editor size to its own content instead of reserving an extra viewport before the footer
- keep the footer naturally pinned after the main content on short pages

Closes #509

## Testing
- git diff --check

Note: full dependency-based checks were not run locally because this clone has no node_modules and the local disk has insufficient free space for a dependency install.