### PR TITLE
fix: Improve Error Handling for Unsupported Video Formats

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -5,7 +5,8 @@ import { Film, FolderOpen } from "lucide-react";
 import LottiePlayer from "./LottiePlayer";
 import uploadAnim from "@/lib/lottie/upload.json";
 import { cn, formatBytes, formatDuration } from "@/lib/utils";
-import { MAX_FILE_SIZE, WARNING_FILE_SIZE } from "@/lib/types";
+import { WARNING_FILE_SIZE } from "@/lib/types";
+import { validateVideoFileBasics } from "@/utils/videoImportValidation";
 
 interface Props {
   onFileSelect: (file: File | null) => void;
@@ -87,15 +88,9 @@ export default function FileUpload({
     setError("");
     setWarning("");
 
-    if (!file.type.startsWith("video/")) {
-      setError("Please drop a valid video file (MP4, MOV, AVI, WebM, etc.)");
-      return;
-    }
-
-    if (file.size > MAX_FILE_SIZE) {
-      setError(
-        `File too large (${formatBytes(file.size)}). Maximum allowed size is 2GB.`
-      );
+    const validation = validateVideoFileBasics(file);
+    if (!validation.valid) {
+      setError(validation.error ?? "Please drop a supported video file.");
       return;
     }
 

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -1,12 +1,18 @@
 "use client";
 
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
-import { EditRecipe, ExportResult, ExportStatus, MAX_FILE_SIZE, OverlayPosition, TimelineTrack, MultiTrackEditorState } from "@/lib/types";
+import { EditRecipe, ExportResult, ExportStatus, OverlayPosition, TimelineTrack, MultiTrackEditorState } from "@/lib/types";
 import { DEFAULT_RECIPE, SPEED_STEPS } from "@/lib/constants";
 import { getPresetById } from "@/lib/presets";
 import { loadFFmpeg, exportVideo, terminateFFmpeg, FFmpegLoadError } from "@/lib/ffmpeg";
 import { suggestPreset } from "@/lib/presetSuggestion";
 import { validateDimensions, getDownscaledDimensions } from "@/utils/video-validation";
+import {
+  getMetadataImportErrorMessage,
+  getUnsupportedVideoMessage,
+  validateVideoFileBasics,
+  verifyVideoSignature,
+} from "@/utils/videoImportValidation";
 import {
   createMultiTrackState,
   addTrackToTimeline,
@@ -52,31 +58,6 @@ export function extractMetadata(file: File): Promise<{ width: number; height: nu
       reject(new Error("Failed to load video metadata"));
     };
     video.src = url;
-  });
-}
-
-function verifyMagicBytes(file: File): Promise<boolean> {
-  return new Promise((resolve) => {
-    const reader = new FileReader();
-    reader.onloadend = (e) => {
-      if (!e.target?.result) {
-        resolve(false);
-        return;
-      }
-      const arr = new Uint8Array(e.target.result as ArrayBuffer);
-      const hex = Array.from(arr).map(b => b.toString(16).padStart(2, "0")).join("").toUpperCase();
-      const ascii = String.fromCharCode(...arr);
-
-      // WebM / MKV
-      if (hex.startsWith("1A45DFA3")) resolve(true);
-      // AVI
-      else if (hex.startsWith("52494646")) resolve(true);
-      // MP4 / MOV (checks for 'ftyp' in first 12 bytes)
-      else if (ascii.substring(0, 12).includes("ftyp")) resolve(true);
-      else resolve(false);
-    };
-    reader.onerror = () => resolve(false);
-    reader.readAsArrayBuffer(file.slice(0, 12));
   });
 }
 
@@ -356,54 +337,50 @@ export function useVideoEditor() {
       return;
     }
 
-    if (!selectedFile.type.startsWith("video/")) {
-      setFileError("Please upload a video file only.");
+    const basicValidation = validateVideoFileBasics(selectedFile);
+    if (!basicValidation.valid) {
+      const message = basicValidation.error ?? getUnsupportedVideoMessage("This file cannot be imported.");
+      console.error("[Reframe] Video import rejected:", {
+        name: selectedFile.name,
+        type: selectedFile.type || "unknown",
+        size: selectedFile.size,
+        reason: message,
+      });
+      setFileError(message);
+      setError(message);
+      setStatus("error");
       return;
     }
 
     setFileError("");
 
-    // LAYER 0: Size check
-    if (selectedFile.size > MAX_FILE_SIZE) {
-      setError(`Validation Failed: File too large. Maximum size is 2GB.`);
-      setStatus("error");
-      return;
-    }
-
-    const validExtensions = ['.mp4', '.mov', '.avi', '.webm', '.mkv'];
-    const filename = selectedFile.name.toLowerCase();
-    const hasValidExtension = validExtensions.some(ext => filename.endsWith(ext));
-    if (!hasValidExtension) {
-      setError(`Layer 1 Validation Failed: Invalid file extension. Expected one of: ${validExtensions.join(', ')}`);
-      setStatus("error");
-      return;
-    }
-
-    if (!selectedFile.type.startsWith("video/")) {
-      setError(`Layer 2 Validation Failed: Invalid MIME type. Expected video/*, got ${selectedFile.type || 'unknown'}`);
-      setStatus("error");
-      return;
-    }
-
     // Run validation and metadata extraction in background
     (async () => {
       try {
-        const isVideo = await verifyMagicBytes(selectedFile);
+        const isVideo = await verifyVideoSignature(selectedFile);
         if (!isVideo) {
-          setError("Layer 3 Validation Failed: Invalid file content. The file's magic bytes do not match known video formats.");
+          const message = getUnsupportedVideoMessage(
+            "This file does not appear to be a valid or supported video."
+          );
+          console.error("[Reframe] Video import rejected: unrecognized file signature", {
+            name: selectedFile.name,
+            type: selectedFile.type || "unknown",
+            size: selectedFile.size,
+          });
+          setFileError(message);
+          setError(message);
           setStatus("error");
           return;
         }
 
         const { width, height, duration: dur } = await extractMetadata(selectedFile);
 
-        // Layer 5: Resolution check
         const dimensionCheck = validateDimensions(width, height);
         if (dimensionCheck === "blocked") {
           const suggested = getDownscaledDimensions(width, height);
           setError(
-            `Layer 5 Validation Failed: Resolution too high (${width}×${height}). ` +
-            `Maximum supported is 8K. Suggested safe size: ${suggested.width}×${suggested.height}.`
+            `Resolution too high (${width}x${height}). ` +
+            `Maximum supported is 8K. Suggested safe size: ${suggested.width}x${suggested.height}.`
           );
           setStatus("error");
           return;
@@ -428,7 +405,10 @@ export function useVideoEditor() {
           };
         });
       } catch (err) {
-        setError(`Layer 4 Validation Failed: ${err instanceof Error ? err.message : "Unknown error"}`);
+        const message = getMetadataImportErrorMessage(err);
+        console.error("[Reframe] Video import metadata failed:", err);
+        setFileError(message);
+        setError(message);
         setStatus("error");
       }
     })();

--- a/src/lib/tests/videoImportValidation.test.ts
+++ b/src/lib/tests/videoImportValidation.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  getMetadataImportErrorMessage,
+  isRecognizedVideoSignature,
+  validateVideoFileBasics,
+} from "@/utils/videoImportValidation";
+
+describe("validateVideoFileBasics", () => {
+  it("accepts supported video files", () => {
+    const file = new File(["video"], "clip.mp4", { type: "video/mp4" });
+
+    expect(validateVideoFileBasics(file)).toEqual({ valid: true });
+  });
+
+  it("accepts supported extensions when the browser does not provide a MIME type", () => {
+    const file = new File(["video"], "clip.mov", { type: "" });
+
+    expect(validateVideoFileBasics(file)).toEqual({ valid: true });
+  });
+
+  it("rejects unsupported extensions with supported format guidance", () => {
+    const file = new File(["video"], "clip.txt", { type: "video/mp4" });
+    const result = validateVideoFileBasics(file);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("not supported");
+    expect(result.error).toContain("MP4, WebM, MOV, AVI, and MKV");
+  });
+
+  it("rejects non-video MIME types with a user-friendly message", () => {
+    const file = new File(["video"], "clip.mp4", { type: "text/plain" });
+    const result = validateVideoFileBasics(file);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("not a video");
+    expect(result.error).toContain("MP4, WebM, MOV, AVI, and MKV");
+  });
+
+  it("rejects empty files before metadata extraction", () => {
+    const file = new File([], "clip.mp4", { type: "video/mp4" });
+    const result = validateVideoFileBasics(file);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("empty");
+  });
+});
+
+describe("isRecognizedVideoSignature", () => {
+  it("recognizes MP4 and MOV ftyp signatures", () => {
+    expect(isRecognizedVideoSignature(new Uint8Array([0, 0, 0, 24, 102, 116, 121, 112]))).toBe(true);
+  });
+
+  it("recognizes WebM and MKV EBML signatures", () => {
+    expect(isRecognizedVideoSignature(new Uint8Array([0x1a, 0x45, 0xdf, 0xa3]))).toBe(true);
+  });
+
+  it("rejects unknown signatures", () => {
+    expect(isRecognizedVideoSignature(new Uint8Array([0xde, 0xad, 0xbe, 0xef]))).toBe(false);
+  });
+});
+
+describe("getMetadataImportErrorMessage", () => {
+  it("explains corrupted or unsupported metadata failures", () => {
+    const message = getMetadataImportErrorMessage(new Error("Failed to load video metadata"));
+
+    expect(message).toContain("metadata");
+    expect(message).toContain("corrupted");
+    expect(message).toContain("unsupported codec");
+  });
+});

--- a/src/utils/videoImportValidation.ts
+++ b/src/utils/videoImportValidation.ts
@@ -1,0 +1,89 @@
+import { MAX_FILE_SIZE } from "@/lib/types";
+
+export const SUPPORTED_VIDEO_FORMATS = "MP4, WebM, MOV, AVI, and MKV";
+
+const SUPPORTED_VIDEO_EXTENSIONS = [".mp4", ".webm", ".mov", ".avi", ".mkv"];
+
+export interface VideoValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+export function getUnsupportedVideoMessage(reason: string): string {
+  return `${reason} Please choose a supported video file (${SUPPORTED_VIDEO_FORMATS}).`;
+}
+
+export function validateVideoFileBasics(file: File): VideoValidationResult {
+  if (file.size === 0) {
+    return {
+      valid: false,
+      error: getUnsupportedVideoMessage("This file is empty."),
+    };
+  }
+
+  if (file.size > MAX_FILE_SIZE) {
+    return {
+      valid: false,
+      error: "File too large. Maximum size is 2GB.",
+    };
+  }
+
+  const filename = file.name.toLowerCase();
+  const hasSupportedExtension = SUPPORTED_VIDEO_EXTENSIONS.some((extension) =>
+    filename.endsWith(extension)
+  );
+
+  if (!hasSupportedExtension) {
+    return {
+      valid: false,
+      error: getUnsupportedVideoMessage("This file type is not supported."),
+    };
+  }
+
+  if (file.type && !file.type.startsWith("video/")) {
+    return {
+      valid: false,
+      error: getUnsupportedVideoMessage(`The selected file is ${file.type}, not a video.`),
+    };
+  }
+
+  return { valid: true };
+}
+
+export function isRecognizedVideoSignature(bytes: Uint8Array): boolean {
+  const hex = Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+    .toUpperCase();
+  const ascii = String.fromCharCode(...bytes);
+
+  return (
+    hex.startsWith("1A45DFA3") ||
+    hex.startsWith("52494646") ||
+    ascii.substring(0, 12).includes("ftyp")
+  );
+}
+
+export function verifyVideoSignature(file: File): Promise<boolean> {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onloadend = (event) => {
+      if (!event.target?.result) {
+        resolve(false);
+        return;
+      }
+
+      resolve(isRecognizedVideoSignature(new Uint8Array(event.target.result as ArrayBuffer)));
+    };
+    reader.onerror = () => resolve(false);
+    reader.readAsArrayBuffer(file.slice(0, 12));
+  });
+}
+
+export function getMetadataImportErrorMessage(error: unknown): string {
+  const detail = error instanceof Error ? error.message : "Unknown metadata error";
+
+  return getUnsupportedVideoMessage(
+    `Reframe could not read this video's metadata. The file may be corrupted or use an unsupported codec.`
+  ) + ` (${detail})`;
+}


### PR DESCRIPTION
## Description
Improves video import error handling for unsupported, invalid, empty, or corrupted video files.

This PR adds shared import validation for supported video formats, clearer user-facing error messages, and browser console diagnostics for debugging. It also prevents failed imports from leaving the editor in an inconsistent state and adds unit tests for unsupported import scenarios.

## Related Issue
Closes #1605

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: Shriraj888
- Contribution level (Beginner/Intermediate/Advanced): Intermediate

## Screen Recording
> **How to record:** run `bun run dev` → open http://localhost:3000 → demonstrate the full working flow of your change, including any edge cases.
>
> - **macOS**: `Cmd + Shift + 5` → Record Selected Portion, or use QuickTime Player
> - **Windows**: `Win + G` → Xbox Game Bar → Capture
> - **Linux**: OBS Studio, GNOME Screenshot tool, or `kazam`
> - **Any OS**: [Loom](https://loom.com) (free screen recorder, great for sharing)

**Recording / Loom link:** 

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [ ] `bun run lint` passes (no ESLint errors)
- [ ] `bunx tsc --noEmit` passes (no TypeScript errors)
- [x] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [x] **Screen recording attached above** (required for UI/feature/design changes)