### PR TITLE
docs: add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to Reframe will be documented in this file.
+
+## [Unreleased]
+
+### Added
+- Root changelog to track future releases.
+
+### Changed
+- No release changes yet.
+
+### Fixed
+- No fixes have been recorded in this release window yet.
+
+---
+
+## Guidance
+
+- Follow semantic versioning where practical.
+- Keep entries short, factual, and grouped by release date or tag.
+- Prefer bullet points for user-facing changes, bug fixes, and breaking changes.


### PR DESCRIPTION
Closes #1273

Adds a root `CHANGELOG.md` with a standard unreleased section and brief guidance so the project has a central place for future release notes.

Validation:
- `git diff --check`