### PR TITLE
chore: remove redundant jsdoc comments

### DIFF
--- a/src/components/DraggableTextOverlays.tsx
+++ b/src/components/DraggableTextOverlays.tsx
@@ -14,10 +14,6 @@ interface DraggableTextOverlaysProps {
   onSelectText: (id: string | null) => void;
 }
 
-/**
- * Renders draggable text overlays on the video preview.
- * Users can click and drag text to reposition it on the canvas.
- */
 export default function DraggableTextOverlays({
   recipe,
   containerWidth,
@@ -34,18 +30,11 @@ export default function DraggableTextOverlays({
   const containerRef = useRef<HTMLDivElement>(null);
   const editInputRef = useRef<HTMLDivElement>(null);
 
-  /**
-   * Memoize text overlays to prevent unnecessary dependency changes.
-   * Always ensures textOverlays is an array, even if recipe is malformed.
-   */
   const textOverlays = useMemo(() => {
     const overlays = recipe?.textOverlays;
     return Array.isArray(overlays) ? overlays : [];
   }, [recipe?.textOverlays]);
 
-  /**
-   * Handles the start of a drag operation.
-   */
   const handleMouseDown = useCallback(
     (e: React.MouseEvent<HTMLDivElement>, overlayId: string) => {
       e.preventDefault();
@@ -73,9 +62,6 @@ export default function DraggableTextOverlays({
     [textOverlays, containerWidth, containerHeight, onSelectText]
   );
 
-  /**
-   * Handles double-click to enter edit mode.
-   */
   const handleDoubleClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>, overlayId: string) => {
       e.preventDefault();
@@ -90,9 +76,6 @@ export default function DraggableTextOverlays({
     [textOverlays]
   );
 
-  /**
-   * Saves the edited text and exits edit mode.
-   */
   const handleSaveEdit = useCallback(
     (overlayId: string) => {
       if (editText.trim()) {
@@ -104,9 +87,6 @@ export default function DraggableTextOverlays({
     [editText, onUpdateText]
   );
 
-  /**
-   * Handles keyboard events in edit mode.
-   */
   const handleEditKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>, overlayId: string) => {
       if (e.key === "Enter" && !e.shiftKey) {
@@ -121,9 +101,6 @@ export default function DraggableTextOverlays({
     [handleSaveEdit]
   );
 
-  /**
-   * Handles dragging of text overlays.
-   */
   useEffect(() => {
     if (!draggingId || !containerRef.current) return;
 
@@ -155,12 +132,6 @@ export default function DraggableTextOverlays({
     };
   }, [draggingId, dragOffset, containerWidth, containerHeight, onUpdateText]);
 
-  /**
-   * Ensure custom fonts are loaded when overlays render.
-   * This prevents fallback font flashing and ensures preview accuracy.
-   * Runs whenever overlays change to keep fonts fresh.
-   * Also triggers re-render to ensure font changes are visible immediately.
-   */
   useEffect(() => {
     const loadFonts = async () => {
       // Collect unique fonts from all overlays
@@ -192,9 +163,6 @@ export default function DraggableTextOverlays({
     }
   }, [textOverlays]);
 
-  /**
-   * Focus edit input when entering edit mode.
-   */
   useEffect(() => {
     if (editingId && editInputRef.current) {
       // Set the initial text content

--- a/src/components/TextControls.tsx
+++ b/src/components/TextControls.tsx
@@ -15,10 +15,6 @@ interface TextControlsProps {
   onSelectText: (id: string | null) => void;
 }
 
-/**
- * Controls for managing text overlays on the video.
- * Allows users to add, remove, and select text overlays.
- */
 export default function TextControls({
   recipe,
   onChange,
@@ -27,10 +23,6 @@ export default function TextControls({
 }: TextControlsProps) {
   const { customFonts, addFonts, removeFont, getErrors } = useFontManager();
 
-  /**
-   * Memoize text overlays to prevent unnecessary dependency changes.
-   * Always ensures textOverlays is an array, even if recipe is malformed.
-   */
   const textOverlays = useMemo(
     (): TextOverlay[] => {
       const overlays = recipe?.textOverlays;
@@ -39,9 +31,6 @@ export default function TextControls({
     [recipe?.textOverlays]
   );
 
-  /**
-   * Adds a new text overlay to the recipe.
-   */
   const handleAddText = () => {
     const newOverlay = createDefaultTextOverlay();
     const updatedOverlays = [...textOverlays, newOverlay];
@@ -49,9 +38,6 @@ export default function TextControls({
     onSelectText(newOverlay.id);
   };
 
-  /**
-   * Removes a text overlay from the recipe.
-   */
   const handleRemoveText = (id: string) => {
     const updatedOverlays = textOverlays.filter((overlay) => overlay.id !== id);
     onChange({ textOverlays: updatedOverlays });
@@ -60,9 +46,6 @@ export default function TextControls({
     }
   };
 
-  /**
-   * Updates a text overlay property.
-   */
   const handleUpdateText = (id: string, updates: Partial<TextOverlay>) => {
     const updatedOverlays = textOverlays.map((overlay) =>
       overlay.id === id ? { ...overlay, ...updates } : overlay
@@ -70,9 +53,6 @@ export default function TextControls({
     onChange({ textOverlays: updatedOverlays });
   };
 
-  /**
-   * Get the currently selected overlay.
-   */
   const selectedOverlay = useMemo(
     (): TextOverlay | undefined =>
       textOverlays.find((o) => o.id === selectedTextId),


### PR DESCRIPTION
Closes #1088

Removes the redundant JSDoc comments from `TextControls.tsx` and `DraggableTextOverlays.tsx` so the code follows the repository's self-documenting style guidance.

Validation:
- `git diff --check`