### PR TITLE
fix: enforce real 8K dimension limits

### DIFF
--- a/src/lib/tests/video-validation.test.ts
+++ b/src/lib/tests/video-validation.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import {
+  getDownscaledDimensions,
+  MAX_4K_HEIGHT,
+  MAX_4K_WIDTH,
+  MAX_8K_HEIGHT,
+  MAX_8K_WIDTH,
+  validateDimensions,
+} from "@/utils/video-validation";
+
+describe("video-validation", () => {
+  it("treats standard 4K and under as safe", () => {
+    expect(validateDimensions(3840, 2160)).toBe("safe");
+    expect(validateDimensions(1920, 1080)).toBe("safe");
+  });
+
+  it("warns on dimensions that exceed 4K but stay within 8K", () => {
+    expect(validateDimensions(MAX_4K_WIDTH + 1, 2160)).toBe("warning");
+    expect(validateDimensions(3840, MAX_4K_HEIGHT + 1)).toBe("warning");
+  });
+
+  it("blocks dimensions that exceed the 8K width or height cap", () => {
+    expect(validateDimensions(MAX_8K_WIDTH + 1, 2160)).toBe("blocked");
+    expect(validateDimensions(3840, MAX_8K_HEIGHT + 1)).toBe("blocked");
+    expect(validateDimensions(9000, 3000)).toBe("blocked");
+    expect(validateDimensions(3000, 9000)).toBe("blocked");
+  });
+
+  it("downscales blocked videos to fit within 4K bounds", () => {
+    const downscaled = getDownscaledDimensions(9000, 4000);
+
+    expect(downscaled.width).toBeLessThanOrEqual(MAX_4K_WIDTH);
+    expect(downscaled.height).toBeLessThanOrEqual(MAX_4K_HEIGHT);
+    expect(downscaled.width % 2).toBe(0);
+    expect(downscaled.height % 2).toBe(0);
+  });
+
+  it("exposes pixel caps derived from real 4K and 8K frame dimensions", () => {
+    expect(MAX_4K_WIDTH * MAX_4K_HEIGHT).toBe(3840 * 2160);
+    expect(MAX_8K_WIDTH * MAX_8K_HEIGHT).toBe(7680 * 4320);
+  });
+});

--- a/src/utils/video-validation.ts
+++ b/src/utils/video-validation.ts
@@ -1,26 +1,36 @@
 // src/utils/video-validation.ts
 
-export const MAX_4K_PIXELS = 3840 * 2160; 
-export const MAX_8K_PIXELS = 7680 * 7680; 
+export const MAX_4K_WIDTH = 3840
+export const MAX_4K_HEIGHT = 2160
+export const MAX_4K_PIXELS = MAX_4K_WIDTH * MAX_4K_HEIGHT
+
+export const MAX_8K_WIDTH = 7680
+export const MAX_8K_HEIGHT = 4320
+export const MAX_8K_PIXELS = MAX_8K_WIDTH * MAX_8K_HEIGHT
 
 export type ValidationResult = 'safe' | 'warning' | 'blocked';
 
 export function validateDimensions(width: number, height: number): ValidationResult {
-  const pixels = width * height;
-  
-  if (pixels > MAX_8K_PIXELS) return 'blocked';
-  if (pixels > MAX_4K_PIXELS) return 'warning';
-  
-  return 'safe';
+  if (width > MAX_8K_WIDTH || height > MAX_8K_HEIGHT) return 'blocked'
+  if (width > MAX_4K_WIDTH || height > MAX_4K_HEIGHT) return 'warning'
+
+  return 'safe'
 }
 
 export function getDownscaledDimensions(width: number, height: number) {
-  const aspectRatio = width / height;
-  const newHeight = Math.sqrt(MAX_4K_PIXELS / aspectRatio);
-  const newWidth = newHeight * aspectRatio;
-  
+  if (width <= 0 || height <= 0) {
+    return {
+      width: 0,
+      height: 0,
+    }
+  }
+
+  const scale = Math.min(MAX_4K_WIDTH / width, MAX_4K_HEIGHT / height)
+  const newWidth = width * scale
+  const newHeight = height * scale
+
   return {
     width: Math.floor(newWidth / 2) * 2,
-    height: Math.floor(newHeight / 2) * 2
-  };
+    height: Math.floor(newHeight / 2) * 2,
+  }
 }


### PR DESCRIPTION
## Summary\n- Replace the square 8K pixel cap with real width/height limits\n- Block oversized landscape and portrait uploads that were slipping through validation\n- Downscale blocked inputs to fit within 4K bounds\n\nCloses #1470\n\n## Validation\n- \n- 
 RUN  v4.1.6 /Users/saurabhkumarbajpaiai/Documents/Codex/OpenCode/reframe


 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  22:53:35
   Duration  477ms (transform 15ms, setup 46ms, import 7ms, tests 1ms, environment 300ms)\n- 