### PR TITLE
fix: preserve ffmpeg log listener reference

### DIFF
--- a/src/lib/ffmpeg.worker.ts
+++ b/src/lib/ffmpeg.worker.ts
@@ -486,7 +486,7 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
     }
 
     let missingAudioDetected = false;
-    const logListener = ({ message }: { message: string }) => {
+    logListener = ({ message }: { message: string }) => {
       const msg = message.toLowerCase();
       if (
         msg.includes("matches no streams") ||


### PR DESCRIPTION
## Summary\n- Reuse the existing log listener reference in ffmpeg.worker.ts\n- Keep registration and cleanup aligned so the listener can be removed correctly\n\nCloses #1460\n\n## Validation\n- \n- 