### PR TITLE
fix: revoke export blob urls on cleanup

### DIFF
--- a/src/components/DownloadResult.tsx
+++ b/src/components/DownloadResult.tsx
@@ -50,6 +50,15 @@ export default function DownloadResult({ result, onReset, soundOnCompletion, onT
       });
     }
   }, [soundOnCompletion]);
+
+  useEffect(() => {
+    const blobUrl = result.blobUrl;
+
+    return () => {
+      URL.revokeObjectURL(blobUrl);
+    };
+  }, [result.blobUrl]);
+
   const handleReset = () => {
     if (window.confirm("This will clear the current video and all settings. Continue?")) {
       onReset();


### PR DESCRIPTION
## Summary\n- Revoke export blob URLs when the download result component unmounts or the export result changes\n- Prevent object URLs from accumulating across repeated exports\n\nCloses #1490\n\n## Validation\n- \n- 