### PR TITLE
fix: use real preset dimensions in export estimates

### DIFF
--- a/src/lib/exportEstimate.test.ts
+++ b/src/lib/exportEstimate.test.ts
@@ -49,10 +49,15 @@ describe("estimateExportSize", () => {
     expect(long / short).toBeCloseTo(4, 0);
   });
 
-  test("higher resolution (4k) produces a larger estimate than 720p", () => {
-    const hd  = estimateExportSize(makeRecipe({ preset: "720p" }), 60);
-    const uhd = estimateExportSize(makeRecipe({ preset: "4k"   }), 60);
-    expect(uhd).toBeGreaterThan(hd);
+  test("real named presets use their own dimensions instead of falling back to 1080p", () => {
+    const base = estimateExportSize(makeRecipe({ preset: "1080p" }), 60);
+    const instagram = estimateExportSize(makeRecipe({ preset: "instagram-4-5" }), 60);
+    const twitter = estimateExportSize(makeRecipe({ preset: "twitter-hd" }), 60);
+    const ultrawide = estimateExportSize(makeRecipe({ preset: "ultrawide-21-9" }), 60);
+
+    expect(instagram).not.toBeCloseTo(base, 5);
+    expect(twitter).not.toBeCloseTo(base, 5);
+    expect(ultrawide).toBeGreaterThan(base);
   });
 
   test("trim reduces effective duration and therefore file size", () => {

--- a/src/lib/exportEstimate.ts
+++ b/src/lib/exportEstimate.ts
@@ -1,23 +1,5 @@
 import { EditRecipe } from "./types";
-
-// ---------------------------------------------------------------------------
-// Preset dimension map
-// Keep in sync with src/lib/presets.ts. Width × height for every named preset.
-// ---------------------------------------------------------------------------
-const PRESET_DIMENSIONS: Record<string, { width: number; height: number }> = {
-  "1080p":       { width: 1920, height: 1080 },
-  "720p":        { width: 1280, height: 720  },
-  "480p":        { width: 854,  height: 480  },
-  "360p":        { width: 640,  height: 360  },
-  "4k":          { width: 3840, height: 2160 },
-  "2k":          { width: 2560, height: 1440 },
-  // Square / portrait presets
-  "square-1080": { width: 1080, height: 1080 },
-  "square-720":  { width: 720,  height: 720  },
-  "portrait-1080": { width: 1080, height: 1920 },
-  "portrait-720":  { width: 720,  height: 1280 },
-  // Fallback — if a preset name is unrecognised we fall through to customWidth/H
-};
+import { getPresetById } from "./presets";
 
 /**
  * Resolve the actual output pixel dimensions for a recipe.
@@ -26,12 +8,12 @@ const PRESET_DIMENSIONS: Record<string, { width: number; height: number }> = {
  */
 function getOutputDimensions(recipe: EditRecipe): { width: number; height: number } {
   if (recipe.preset !== "custom") {
-    const dims = PRESET_DIMENSIONS[recipe.preset];
-    if (dims) return dims;
+    const preset = getPresetById(recipe.preset);
+    if (preset) return { width: preset.width, height: preset.height };
   }
-  return { 
-    width: recipe.customWidth || 1920, 
-    height: recipe.customHeight || 1080 
+  return {
+    width: recipe.customWidth || 1920,
+    height: recipe.customHeight || 1080,
   };
 }
 


### PR DESCRIPTION
## Summary\n- Resolve export estimate dimensions from the real preset registry instead of a hard-coded subset\n- Make the estimator reflect presets like Instagram 4:5, Twitter HD, and ultrawide outputs\n\nCloses #1472\n\n## Validation\n- \n- 
 RUN  v4.1.6 /Users/saurabhkumarbajpaiai/Documents/Codex/OpenCode/reframe


 Test Files  1 passed (1)
      Tests  14 passed (14)
   Start at  22:59:19
   Duration  284ms (transform 16ms, setup 24ms, import 11ms, tests 2ms, environment 190ms)\n- 