### PR TITLE
fix: accept generic mime video uploads

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -6,6 +6,7 @@ import LottiePlayer from "./LottiePlayer";
 import uploadAnim from "@/lib/lottie/upload.json";
 import { cn, formatBytes, formatDuration } from "@/lib/utils";
 import { MAX_FILE_SIZE, WARNING_FILE_SIZE } from "@/lib/types";
+import { isAcceptableVideoCandidate } from "@/lib/fileValidation";
 
 interface Props {
   onFileSelect: (file: File | null) => void;
@@ -87,7 +88,7 @@ export default function FileUpload({
     setError("");
     setWarning("");
 
-    if (!file.type.startsWith("video/")) {
+    if (!isAcceptableVideoCandidate(file)) {
       setError("Please drop a valid video file (MP4, MOV, AVI, WebM, etc.)");
       return;
     }

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -24,6 +24,7 @@ import {
   RECIPE_STORAGE_KEY,
   LEGACY_SETTINGS_KEY,
 } from "@/lib/editorPersistence";
+import { SUPPORTED_VIDEO_EXTENSIONS, hasSupportedVideoExtension } from "@/lib/fileValidation";
 
 const DEFAULT_TITLE = "Reframe — Resize, trim, and export videos in your browser";
 
@@ -356,11 +357,6 @@ export function useVideoEditor() {
       return;
     }
 
-    if (!selectedFile.type.startsWith("video/")) {
-      setFileError("Please upload a video file only.");
-      return;
-    }
-
     setFileError("");
 
     // LAYER 0: Size check
@@ -370,17 +366,8 @@ export function useVideoEditor() {
       return;
     }
 
-    const validExtensions = ['.mp4', '.mov', '.avi', '.webm', '.mkv'];
-    const filename = selectedFile.name.toLowerCase();
-    const hasValidExtension = validExtensions.some(ext => filename.endsWith(ext));
-    if (!hasValidExtension) {
-      setError(`Layer 1 Validation Failed: Invalid file extension. Expected one of: ${validExtensions.join(', ')}`);
-      setStatus("error");
-      return;
-    }
-
-    if (!selectedFile.type.startsWith("video/")) {
-      setError(`Layer 2 Validation Failed: Invalid MIME type. Expected video/*, got ${selectedFile.type || 'unknown'}`);
+    if (!hasSupportedVideoExtension(selectedFile.name)) {
+      setError(`Layer 1 Validation Failed: Invalid file extension. Expected one of: ${SUPPORTED_VIDEO_EXTENSIONS.join(', ')}`);
       setStatus("error");
       return;
     }

--- a/src/lib/fileValidation.ts
+++ b/src/lib/fileValidation.ts
@@ -1,0 +1,15 @@
+export const SUPPORTED_VIDEO_EXTENSIONS = [".mp4", ".mov", ".avi", ".webm", ".mkv"];
+
+export function hasSupportedVideoExtension(filename: string): boolean {
+  const lower = filename.toLowerCase();
+  return SUPPORTED_VIDEO_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+export function isAcceptableVideoCandidate(file: File): boolean {
+  const mimeType = file.type.toLowerCase();
+
+  if (mimeType.startsWith("video/")) return true;
+  if (mimeType === "" || mimeType === "application/octet-stream") return true;
+
+  return hasSupportedVideoExtension(file.name);
+}

--- a/src/lib/tests/fileValidation.test.ts
+++ b/src/lib/tests/fileValidation.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { hasSupportedVideoExtension, isAcceptableVideoCandidate } from "../fileValidation";
+
+describe("fileValidation", () => {
+  it("accepts generic MIME files when the extension is supported", () => {
+    const file = new File(["video"], "clip.mp4", { type: "application/octet-stream" });
+    expect(isAcceptableVideoCandidate(file)).toBe(true);
+  });
+
+  it("accepts empty MIME files when the extension is supported", () => {
+    const file = new File(["video"], "clip.webm", { type: "" });
+    expect(isAcceptableVideoCandidate(file)).toBe(true);
+  });
+
+  it("rejects unsupported extensions when the mime type is not video", () => {
+    const file = new File(["video"], "clip.txt", { type: "text/plain" });
+    expect(isAcceptableVideoCandidate(file)).toBe(false);
+  });
+
+  it("detects supported extensions", () => {
+    expect(hasSupportedVideoExtension("movie.MKV")).toBe(true);
+    expect(hasSupportedVideoExtension("picture.png")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary\n- Allow video uploads with empty or generic MIME types when the extension is supported\n- Keep magic-byte validation and metadata extraction as the real source of truth\n- Share the same upload acceptance logic between the file picker and the editor\n\nCloses #1475\n\n## Validation\n- \n- 
 RUN  v4.1.6 /Users/saurabhkumarbajpaiai/Documents/Codex/OpenCode/reframe


 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  23:02:06
   Duration  271ms (transform 10ms, setup 23ms, import 5ms, tests 1ms, environment 187ms)\n- 