### PR TITLE
fix: keep custom ratio field inside panel

### DIFF
--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -273,8 +273,8 @@ export default function PresetSelector({ recipe, onChange }: Props) {
       </div>
 
       {recipe.preset === "custom" && (
-        <div className="mt-2 flex items-center gap-4 rounded-lg border border-[var(--border)] bg-[var(--surface)] p-4 shadow-sm animate-fade-in">
-          <div className="flex-1">
+        <div className="mt-2 flex flex-col gap-4 rounded-lg border border-[var(--border)] bg-[var(--surface)] p-4 shadow-sm animate-fade-in sm:flex-row sm:items-end">
+          <div className="flex-1 min-w-0">
             <label
               htmlFor="custom-width"
               className="mb-1.5 block text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)]"
@@ -294,13 +294,13 @@ export default function PresetSelector({ recipe, onChange }: Props) {
             />
           </div>
 
-          <div className="flex h-full flex-col items-center justify-center">
+          <div className="flex h-full items-center justify-center self-stretch sm:self-auto">
             <span className="font-heading text-sm font-medium text-[var(--muted)]">
               ×
             </span>
           </div>
 
-          <div className="flex-1">
+          <div className="flex-1 min-w-0">
             <label
               htmlFor="custom-height"
               className="mb-1.5 block text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)]"
@@ -320,11 +320,11 @@ export default function PresetSelector({ recipe, onChange }: Props) {
             />
           </div>
 
-          <div className="hidden h-full flex-col justify-end sm:flex">
+          <div className="hidden h-full min-w-0 flex-col justify-end sm:flex">
             <span className="mb-1.5 block text-center text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)]">
               Ratio
             </span>
-            <div className="flex h-[38px] items-center rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 text-xs font-medium text-film-700">
+            <div className="flex min-h-[38px] max-w-[12rem] items-center rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2 text-xs font-medium leading-snug text-film-700 break-words">
               {getOrientationLabel(
                 recipe.customWidth || 0,
                 recipe.customHeight || 0,


### PR DESCRIPTION
## Summary\n- Stack the custom dimension inputs vertically on narrow screens\n- Keep the ratio label constrained so it no longer overflows the panel\n\nCloses #1399\n\n## Validation\n- \n- 