### PR TITLE
fix: apply adjustment filters in preview

### DIFF
--- a/src/components/ComparisonPreview.tsx
+++ b/src/components/ComparisonPreview.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useRef, useState, useCallback, RefObject } from "react";
 import { EditRecipe } from "@/lib/types";
 import { getPresetById } from "@/lib/presets";
+import { buildPreviewAdjustmentFilter } from "@/lib/adjustmentFilters";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -193,6 +194,7 @@ export default function ComparisonPreview({ file, recipe, videoRef }: Props) {
           <video
             ref={rightVideoRef}
             className="w-full h-full object-contain"
+            style={recipe ? { filter: buildPreviewAdjustmentFilter(recipe) || undefined } : undefined}
             playsInline
             muted
             autoPlay

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useRef, useState, useCallback, RefObject } from "react";
 import { EditRecipe, TextOverlay, TimelineTrack, MultiTrackEditorState } from "@/lib/types";
 import { getPresetById } from "@/lib/presets";
+import { buildPreviewAdjustmentFilter } from "@/lib/adjustmentFilters";
 import { cn } from "@/lib/utils";
 import { Camera } from "lucide-react";
 import ComparisonPreview from "./ComparisonPreview";
@@ -276,6 +277,7 @@ export default function VideoPreview({
           ref={videoRef}
           controls
           className={cn("w-full h-full object-contain transition-opacity duration-300", isLoading ? "opacity-0" : "opacity-100")}
+          style={recipe ? { filter: buildPreviewAdjustmentFilter(recipe) || undefined } : undefined}
           onLoadedData={() => setIsLoading(false)}
           playsInline
           muted={!recipe?.keepAudio}

--- a/src/lib/adjustmentFilters.ts
+++ b/src/lib/adjustmentFilters.ts
@@ -1,0 +1,19 @@
+import { EditRecipe } from "./types";
+
+export function buildPreviewAdjustmentFilter(recipe: Pick<EditRecipe, "brightness" | "contrast" | "saturation">): string {
+  const parts: string[] = [];
+
+  if (recipe.brightness !== 0) {
+    parts.push(`brightness(${Math.max(0, 1 + recipe.brightness).toFixed(3)})`);
+  }
+
+  if (recipe.contrast !== 1) {
+    parts.push(`contrast(${Math.max(0, recipe.contrast).toFixed(3)})`);
+  }
+
+  if (recipe.saturation !== 1) {
+    parts.push(`saturate(${Math.max(0, recipe.saturation).toFixed(3)})`);
+  }
+
+  return parts.join(" ");
+}

--- a/src/lib/tests/adjustmentFilters.test.ts
+++ b/src/lib/tests/adjustmentFilters.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { buildPreviewAdjustmentFilter } from "../adjustmentFilters";
+
+describe("buildPreviewAdjustmentFilter", () => {
+  it("returns an empty string for neutral adjustments", () => {
+    expect(buildPreviewAdjustmentFilter({ brightness: 0, contrast: 1, saturation: 1 })).toBe("");
+  });
+
+  it("maps brightness, contrast, and saturation to CSS filters", () => {
+    expect(
+      buildPreviewAdjustmentFilter({ brightness: 0.5, contrast: 1.2, saturation: 1.5 })
+    ).toBe("brightness(1.500) contrast(1.200) saturate(1.500)");
+  });
+
+  it("clamps brightness and contrast to non-negative values", () => {
+    expect(
+      buildPreviewAdjustmentFilter({ brightness: -1, contrast: -2, saturation: 0.25 })
+    ).toBe("brightness(0.000) contrast(0.000) saturate(0.250)");
+  });
+});


### PR DESCRIPTION
## Summary\n- Apply the brightness, contrast, and saturation settings to the live preview video\n- Mirror the same adjustment values in comparison mode's reframed side\n- Keep the preview logic aligned with the export filter settings\n\nCloses #1364\n\n## Validation\n- \n- 
 RUN  v4.1.6 /Users/saurabhkumarbajpaiai/Documents/Codex/OpenCode/reframe


 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  23:09:24
   Duration  288ms (transform 11ms, setup 24ms, import 5ms, tests 1ms, environment 202ms)\n- 