### PR TITLE
fix: handle unicode in shared recipe links

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -20,6 +20,7 @@ import ImageOverlay from "./ImageOverlay"
 import { getPresetById } from "@/lib/presets";
 
 import { cn } from "@/lib/utils";
+import { encodeRecipe } from "@/lib/shareLink";
 import {
   Layers, Crop, Scissors, RotateCw, Volume2, Type,
   SlidersHorizontal, Zap, AlertTriangle, Github, Copy
@@ -277,7 +278,7 @@ export default function VideoEditor() {
 
   const handleCopyLink = () => {
     if (typeof window === "undefined") return;
-    const encoded = btoa(JSON.stringify(recipe));
+    const encoded = encodeRecipe(recipe);
     const url = new URL(window.location.href);
     url.searchParams.set("settings", encoded);
     history.replaceState(null, "", url.toString());

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -24,6 +24,7 @@ import {
   RECIPE_STORAGE_KEY,
   LEGACY_SETTINGS_KEY,
 } from "@/lib/editorPersistence";
+import { decodeRecipe, encodeRecipe } from "@/lib/shareLink";
 
 const DEFAULT_TITLE = "Reframe — Resize, trim, and export videos in your browser";
 
@@ -132,19 +133,6 @@ function validateRecipe(recipe: EditRecipe, duration: number ): string | null {
     validations.find(([condition]) => condition)?.[1] ??
     null
   );
-}
-
-function encodeRecipe(recipe: EditRecipe): string {
-  return btoa(JSON.stringify(recipe));
-}
-
-function decodeRecipe(encoded: string): Partial<EditRecipe> | null {
-  try {
-    const decoded = JSON.parse(atob(encoded));
-    return decoded as Partial<EditRecipe>;
-  } catch {
-    return null;
-  }
 }
 
 export function useVideoEditor() {

--- a/src/lib/shareLink.ts
+++ b/src/lib/shareLink.ts
@@ -1,0 +1,30 @@
+import type { EditRecipe } from "@/lib/types";
+
+function encodeBytes(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function decodeBytes(encoded: string): Uint8Array {
+  const binary = atob(encoded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+export function encodeRecipe(recipe: EditRecipe): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(recipe));
+  return encodeBytes(bytes);
+}
+
+export function decodeRecipe(encoded: string): Partial<EditRecipe> | null {
+  try {
+    const json = new TextDecoder().decode(decodeBytes(encoded));
+    return JSON.parse(json) as Partial<EditRecipe>;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/tests/shareLink.test.ts
+++ b/src/lib/tests/shareLink.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_RECIPE } from "@/lib/constants";
+import { decodeRecipe, encodeRecipe } from "../shareLink";
+
+describe("shareLink", () => {
+  it("round-trips non-ASCII recipe data", () => {
+    const recipe = {
+      ...DEFAULT_RECIPE,
+      textOverlays: [
+        {
+          id: "1",
+          text: "नमस्ते 👋 café",
+          x: 24,
+          y: 48,
+          fontSize: 36,
+          fontFamily: "Inter",
+          fontWeight: "bold" as const,
+          color: "#ffffff",
+          backgroundColor: "transparent",
+        },
+      ],
+    };
+
+    const encoded = encodeRecipe(recipe);
+    expect(encoded).toMatch(/^[A-Za-z0-9+/=]+$/);
+    expect(decodeRecipe(encoded)).toEqual(recipe);
+  });
+});


### PR DESCRIPTION
Closes #1474.\n\nReplaces the raw JSON btoa/atob pair with UTF-8 safe encoding so share links work for emoji, accents, and non-Latin recipe data. Added a round-trip test for multilingual overlay text.\n\nValidation:\n- node node_modules/typescript/bin/tsc --noEmit\n- node node_modules/vitest/vitest.mjs run src/lib/tests/shareLink.test.ts\n- git diff --check