### PR TITLE
fix: keep background music when muting original audio

### DIFF
--- a/src/lib/audioMix.ts
+++ b/src/lib/audioMix.ts
@@ -1,0 +1,13 @@
+export function hasBackgroundMusicTrack(
+  musicFile: { name: string } | null | undefined,
+): boolean {
+  return Boolean(musicFile);
+}
+
+export function shouldKeepAudioTrack(
+  keepOriginalAudio: boolean,
+  hasOriginalAudio: boolean,
+  hasMusicTrack: boolean,
+): boolean {
+  return hasMusicTrack || (keepOriginalAudio && hasOriginalAudio);
+}

--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -1,6 +1,7 @@
 import { EditRecipe, ExportResult, BackgroundMusicOptions, ImageOverlayOptions } from "./types";
 import { getPresetById } from "./presets";
 import { buildTextFilter } from "./text-overlay";
+import { shouldKeepAudioTrack } from "./audioMix";
 
 export class FFmpegLoadError extends Error {}
 
@@ -458,7 +459,7 @@ function buildArguments(
   }
 
   const needsFilterComplex = hasOverlay || hasMusicTrack;
-  const shouldKeepAudio = recipe.keepAudio && (hasOriginalAudio || hasMusicTrack);
+  const shouldKeepAudio = shouldKeepAudioTrack(recipe.keepAudio, hasOriginalAudio, hasMusicTrack);
 
   if (needsFilterComplex) {
     const filterParts: string[] = [];
@@ -499,7 +500,7 @@ interface PositionCoords {
     if (shouldKeepAudio) {
       if (hasMusicTrack) {
         const musicVol = (musicOptions!.musicVolume / 100).toFixed(2);
-        if (hasOriginalAudio) {
+        if (recipe.keepAudio && hasOriginalAudio) {
           const origVol  = (musicOptions!.originalAudioVolume / 100).toFixed(2);
           const origChain = afParts.length > 0
             ? `[0:a]${afParts.join(",")},volume=${origVol}[orig]`
@@ -512,7 +513,7 @@ interface PositionCoords {
           filterParts.push(`[${musicIdx}:a]volume=${musicVol}[aout]`);
           audioOut = "[aout]";
         }
-      } else if (hasOriginalAudio && af) {
+      } else if (recipe.keepAudio && hasOriginalAudio && af) {
         filterParts.push(`[0:a]${af}[aout]`);
         audioOut = "[aout]";
       }

--- a/src/lib/ffmpeg.worker.ts
+++ b/src/lib/ffmpeg.worker.ts
@@ -3,6 +3,7 @@ import { toBlobURL } from "@ffmpeg/util";
 import { EditRecipe, BackgroundMusicOptions, ImageOverlayOptions } from "./types";
 import { getPresetById } from "./presets";
 import { buildTextFilter } from "./text-overlay";
+import { hasBackgroundMusicTrack, shouldKeepAudioTrack } from "./audioMix";
 
 const CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.10/dist/umd";
 const MT_CORE_BASE_URL = "https://cdn.jsdelivr.net/npm/@ffmpeg/core-mt@0.12.6/dist/esm";
@@ -209,7 +210,7 @@ function buildArguments(
   }
 
   const needsFilterComplex = hasOverlay || hasMusicTrack;
-  const shouldKeepAudio = recipe.keepAudio && (hasOriginalAudio || hasMusicTrack);
+  const shouldKeepAudio = shouldKeepAudioTrack(recipe.keepAudio, hasOriginalAudio, hasMusicTrack);
 
   if (needsFilterComplex) {
     const filterParts: string[] = [];
@@ -250,7 +251,7 @@ interface PositionCoords {
     if (shouldKeepAudio) {
       if (hasMusicTrack) {
         const musicVol = (musicOptions!.musicVolume / 100).toFixed(2);
-        if (hasOriginalAudio) {
+        if (recipe.keepAudio && hasOriginalAudio) {
           const origVol = (musicOptions!.originalAudioVolume / 100).toFixed(2);
           const origChain = afParts.length > 0
             ? `[0:a]${afParts.join(",")},volume=${origVol}[orig]`
@@ -263,7 +264,7 @@ interface PositionCoords {
           filterParts.push(`[${musicIdx}:a]volume=${musicVol}[aout]`);
           audioOut = "[aout]";
         }
-      } else if (hasOriginalAudio && af) {
+      } else if (recipe.keepAudio && hasOriginalAudio && af) {
         filterParts.push(`[0:a]${af}[aout]`);
         audioOut = "[aout]";
       }
@@ -410,7 +411,7 @@ async function runExport(request: ExportRequest): Promise<ResultPayload> {
   const fileBytes = serializeFileBuffer(request.file);
   await ffmpeg.writeFile(inputName, fileBytes, { signal: activeExportAbortController?.signal });
 
-  const hasMusicTrack = !!(request.musicFile && recipe.keepAudio);
+  const hasMusicTrack = hasBackgroundMusicTrack(request.musicFile);
   const musicInputName = `music_input_${sessionId}.mp3`;
   if (hasMusicTrack) {
     cleanupFiles.add(musicInputName);

--- a/src/lib/tests/audioMix.test.ts
+++ b/src/lib/tests/audioMix.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { hasBackgroundMusicTrack, shouldKeepAudioTrack } from "../audioMix";
+
+describe("audioMix", () => {
+  it("keeps background music independent from original-audio mute state", () => {
+    expect(shouldKeepAudioTrack(false, true, true)).toBe(true);
+    expect(shouldKeepAudioTrack(false, true, false)).toBe(false);
+    expect(shouldKeepAudioTrack(true, true, false)).toBe(true);
+  });
+
+  it("detects when a music file is present", () => {
+    expect(hasBackgroundMusicTrack({ name: "song.mp3" })).toBe(true);
+    expect(hasBackgroundMusicTrack(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #1579.\n\nSeparates background-music attachment from the original-audio mute state so uploaded music still exports when keepAudio is off. Added a small shared helper and regression test to keep the worker path consistent.\n\nValidation:\n- node node_modules/typescript/bin/tsc --noEmit\n- node node_modules/vitest/vitest.mjs run src/lib/tests/audioMix.test.ts src/lib/tests/ffmpeg.test.ts\n- git diff --check