### PR TITLE
fix: keep video preview visible while scrolling

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -410,7 +410,7 @@ return () => {
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-5">
 
           <div className="space-y-4 min-w-0">
-            <div className="bg-[var(--surface)] rounded-xl p-3 border border-[var(--border)] animate-fade-in">
+            <div className="bg-[var(--surface)] rounded-xl p-3 border border-[var(--border)] animate-fade-in lg:sticky lg:top-8 lg:self-start">
               <FileUpload onFileSelect={handleFileSelect} currentFile={file} fileError={fileError} duration={duration} />
 
               {!file && (


### PR DESCRIPTION
Closes #1511.\n\nMakes the video preview card sticky on desktop so users can keep the current frame in view while adjusting the lower editing controls. This is a small layout-only change that matches the issue goal without reshaping the entire editor.\n\nValidation:\n- node node_modules/typescript/bin/tsc --noEmit\n- git diff --check