### PR TITLE
fix: remove placeholder social links

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,9 +3,6 @@
 import Link from "next/link";
 import {
   Github,
-  Twitter,
-  Instagram,
-  Linkedin,
   ArrowRight,
   ShieldCheck,
   Zap,
@@ -133,21 +130,6 @@ export default function Footer() {
                   href: "https://github.com/magic-peach/reframe",
                   icon: <Github size={18} />,
                   label: "GitHub",
-                },
-                {
-                  href: "https://twitter.com",
-                  icon: <Twitter size={18} />,
-                  label: "Twitter",
-                },
-                {
-                  href: "https://instagram.com",
-                  icon: <Instagram size={18} />,
-                  label: "Instagram",
-                },
-                {
-                  href: "https://linkedin.com",
-                  icon: <Linkedin size={18} />,
-                  label: "LinkedIn",
                 },
               ].map((social) => (
                 <a


### PR DESCRIPTION
Closes #1279.\n\nRemoves the footer social icons that pointed at generic platform homepages, leaving only the valid GitHub community link until real official social profiles are available.\n\nValidation:\n- node node_modules/typescript/bin/tsc --noEmit\n- git diff --check