### PR TITLE
fix: allow built-in text fonts to export

### DIFF
--- a/src/lib/tests/text-overlay.test.ts
+++ b/src/lib/tests/text-overlay.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { buildTextFilter } from "../text-overlay";
+
+describe("buildTextFilter", () => {
+  it("does not add a fontfile for built-in fonts", () => {
+    const result = buildTextFilter(
+      {
+        id: "overlay-1",
+        text: "Hello",
+        x: 50,
+        y: 50,
+        fontSize: 48,
+        color: "#ffffff",
+        fontWeight: "normal",
+        fontFamily: "Arial",
+      },
+      1920,
+      1080
+    );
+
+    expect(result).not.toContain("fontfile='Arial'");
+    expect(result).not.toContain("fontfile=Arial");
+  });
+
+  it("keeps the custom fontfile argument for uploaded fonts", () => {
+    const result = buildTextFilter(
+      {
+        id: "overlay-2",
+        text: "Hello",
+        x: 50,
+        y: 50,
+        fontSize: 48,
+        color: "#ffffff",
+        fontWeight: "normal",
+        fontFamily: "CustomFont",
+        fontPath: "/tmp/CustomFont.ttf",
+      },
+      1920,
+      1080
+    );
+
+    expect(result).toContain("fontfile=/tmp/CustomFont.ttf");
+  });
+});

--- a/src/lib/tests/text-overlay.test.ts
+++ b/src/lib/tests/text-overlay.test.ts
@@ -41,4 +41,24 @@ describe("buildTextFilter", () => {
 
     expect(result).toContain("fontfile=/tmp/CustomFont.ttf");
   });
+
+  it("uses the bold flag instead of fontweight for bold overlays", () => {
+    const result = buildTextFilter(
+      {
+        id: "overlay-3",
+        text: "Hello",
+        x: 50,
+        y: 50,
+        fontSize: 48,
+        color: "#ffffff",
+        fontWeight: "bold",
+        fontFamily: "Arial",
+      },
+      1920,
+      1080
+    );
+
+    expect(result).toContain(":bold=1");
+    expect(result).not.toContain("fontweight=");
+  });
 });

--- a/src/lib/text-overlay.ts
+++ b/src/lib/text-overlay.ts
@@ -78,18 +78,15 @@ export function buildTextFilter(
   const pixelX = Math.round((overlay.x / 100) * targetWidth);
   const pixelY = Math.round((overlay.y / 100) * targetHeight);
 
-  // Build font parameters
-  const fontWeightParam = overlay.fontWeight === "900"
-    ? "bold"
-    : overlay.fontWeight === "bold"
-    ? "bold"
-    : "normal";
-
   // Get font file parameter for custom fonts (if available)
   const fontFileParam = getFFmpegFontArg(overlay.fontFamily, overlay.fontPath);
 
   // Build the drawtext filter with font support
-  let filter = `drawtext=text='${escapedText}':x=${pixelX}:y=${pixelY}:fontsize=${overlay.fontSize}:fontcolor=${overlay.color}:fontweight=${fontWeightParam}`;
+  let filter = `drawtext=text='${escapedText}':x=${pixelX}:y=${pixelY}:fontsize=${overlay.fontSize}:fontcolor=${overlay.color}`;
+
+  if (overlay.fontWeight === "bold" || overlay.fontWeight === "900") {
+    filter += `:bold=1`;
+  }
 
   // Add custom font file path if available
   if (fontFileParam) {

--- a/src/lib/text-overlay.ts
+++ b/src/lib/text-overlay.ts
@@ -91,13 +91,6 @@ export function buildTextFilter(
   // Build the drawtext filter with font support
   let filter = `drawtext=text='${escapedText}':x=${pixelX}:y=${pixelY}:fontsize=${overlay.fontSize}:fontcolor=${overlay.color}:fontweight=${fontWeightParam}`;
 
-  // Add font family if specified
-  if (overlay.fontFamily) {
-    // Sanitize font name for FFmpeg
-    const safeFontName = overlay.fontFamily.replace(/[^a-zA-Z0-9-]/g, "");
-    filter += `:fontfile='${safeFontName}'`;
-  }
-
   // Add custom font file path if available
   if (fontFileParam) {
     filter += `:${fontFileParam}`;


### PR DESCRIPTION
Closes #1449 and helps #1518 / #1343.

Removes the fake fontfile injection for built-in/default text fonts so the FFmpeg drawtext filter can export successfully, and switches bold overlays to the drawtext bold flag instead of an invalid fontweight argument. Custom fonts still keep their real fontfile path.

Validation: git diff --check; bun run test -- src/lib/tests/text-overlay.test.ts; bunx tsc --noEmit