### PR TITLE
feat: lock custom dimensions to source aspect ratio

### DIFF
--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -1,16 +1,19 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
-import { Search, Settings2 } from "lucide-react";
+import { Link2, Search, Settings2 } from "lucide-react";
 
 import { PRESETS } from "@/lib/presets";
 import { EditRecipe } from "@/lib/types";
 import { cn } from "@/lib/utils";
+import { getLockedCustomDimensions } from "@/lib/customDimensions";
 
 interface Props {
   recipe: EditRecipe;
   onChange: (patch: Partial<EditRecipe>) => void;
+  sourceWidth?: number | null;
+  sourceHeight?: number | null;
 }
 
 function getOrientationLabel(width: number, height: number): string {
@@ -102,8 +105,15 @@ const QUICK_ACTIONS = [
   },
 ] as const;
 
-export default function PresetSelector({ recipe, onChange }: Props) {
+export default function PresetSelector({ recipe, onChange, sourceWidth, sourceHeight }: Props) {
   const [search, setSearch] = useState("");
+  const [lockAspectRatio, setLockAspectRatio] = useState(false);
+
+  const sourceAspectRatio = useMemo(() => {
+    if (!sourceWidth || !sourceHeight) return null;
+    if (sourceHeight === 0) return null;
+    return sourceWidth / sourceHeight;
+  }, [sourceWidth, sourceHeight]);
 
   const filteredPresets = PRESETS.filter(
     (preset) =>
@@ -123,19 +133,43 @@ export default function PresetSelector({ recipe, onChange }: Props) {
   const handleWidthChange = useCallback(
     (width: number) => {
       if (!isNaN(width) && width >= 16 && width <= 7680) {
+        if (lockAspectRatio && sourceAspectRatio) {
+          onChange({
+            ...getLockedCustomDimensions(
+              "width",
+              width,
+              sourceAspectRatio,
+              recipe.customWidth,
+              recipe.customHeight,
+            ),
+          });
+          return;
+        }
         onChange({ customWidth: width });
       }
     },
-    [onChange],
+    [lockAspectRatio, onChange, recipe.customHeight, recipe.customWidth, sourceAspectRatio],
   );
 
   const handleHeightChange = useCallback(
     (height: number) => {
       if (!isNaN(height) && height >= 16 && height <= 7680) {
+        if (lockAspectRatio && sourceAspectRatio) {
+          onChange({
+            ...getLockedCustomDimensions(
+              "height",
+              height,
+              sourceAspectRatio,
+              recipe.customWidth,
+              recipe.customHeight,
+            ),
+          });
+          return;
+        }
         onChange({ customHeight: height });
       }
     },
-    [onChange],
+    [lockAspectRatio, onChange, recipe.customHeight, recipe.customWidth, sourceAspectRatio],
   );
 
   return (
@@ -295,9 +329,23 @@ export default function PresetSelector({ recipe, onChange }: Props) {
           </div>
 
           <div className="flex h-full flex-col items-center justify-center">
-            <span className="font-heading text-sm font-medium text-[var(--muted)]">
-              ×
-            </span>
+            <button
+              type="button"
+              aria-pressed={lockAspectRatio}
+              aria-label={lockAspectRatio ? "Unlock aspect ratio" : "Lock aspect ratio"}
+              title={lockAspectRatio ? "Unlock aspect ratio" : "Lock aspect ratio"}
+              disabled={!sourceAspectRatio}
+              onClick={() => setLockAspectRatio((current) => !current)}
+              className={cn(
+                "inline-flex h-9 w-9 items-center justify-center rounded-md border transition-all duration-150",
+                sourceAspectRatio
+                  ? "border-[var(--border)] bg-[var(--bg)] hover:border-film-300 hover:text-film-600"
+                  : "cursor-not-allowed border-[var(--border)] bg-[var(--bg)] text-[var(--muted)] opacity-50",
+                lockAspectRatio && "border-film-500 bg-film-50 text-film-600",
+              )}
+            >
+              <Link2 size={14} />
+            </button>
           </div>
 
           <div className="flex-1">

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -199,7 +199,7 @@ function KeyboardShortcutsPanel() {
 
 export default function VideoEditor() {
   const {
-    file, duration, recipe, status, progress,
+    file, duration, videoMetadata, recipe, status, progress,
     result, error, exportStartedAt, updateRecipe,
     handleFileSelect, fileError, handleExport, cancelExport, reset, resetSettings,
     videoRef,
@@ -698,7 +698,12 @@ return () => {
                   </div>
                 )}
                 <div className="space-y-3">
-                  <PresetSelector recipe={recipe} onChange={updateRecipe} />
+                  <PresetSelector
+                    recipe={recipe}
+                    onChange={updateRecipe}
+                    sourceWidth={videoMetadata?.width ?? null}
+                    sourceHeight={videoMetadata?.height ?? null}
+                  />
                   <FramingControl recipe={recipe} onChange={updateRecipe} />
                 </div>
               </AccordionSection>

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -686,6 +686,7 @@ export function useVideoEditor() {
   return {
     file,
     duration,
+    videoMetadata,
     recipe,
     status,
     progress,

--- a/src/lib/customDimensions.ts
+++ b/src/lib/customDimensions.ts
@@ -1,0 +1,34 @@
+const MIN_DIMENSION = 16;
+const MAX_DIMENSION = 7680;
+
+export function clampCustomDimension(value: number): number {
+  return Math.max(MIN_DIMENSION, Math.min(MAX_DIMENSION, Math.round(value)));
+}
+
+export function getLockedCustomDimensions(
+  axis: "width" | "height",
+  nextValue: number,
+  aspectRatio: number | null,
+  currentWidth: number,
+  currentHeight: number,
+): { customWidth: number; customHeight: number } {
+  const clampedValue = clampCustomDimension(nextValue);
+
+  if (!aspectRatio || !Number.isFinite(aspectRatio) || aspectRatio <= 0) {
+    return axis === "width"
+      ? { customWidth: clampedValue, customHeight: currentHeight }
+      : { customWidth: currentWidth, customHeight: clampedValue };
+  }
+
+  if (axis === "width") {
+    return {
+      customWidth: clampedValue,
+      customHeight: clampCustomDimension(clampedValue / aspectRatio),
+    };
+  }
+
+  return {
+    customWidth: clampCustomDimension(clampedValue * aspectRatio),
+    customHeight: clampedValue,
+  };
+}

--- a/src/lib/tests/customDimensions.test.ts
+++ b/src/lib/tests/customDimensions.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { clampCustomDimension, getLockedCustomDimensions } from "../customDimensions";
+
+describe("customDimensions", () => {
+  it("clamps custom dimensions into the supported export range", () => {
+    expect(clampCustomDimension(8)).toBe(16);
+    expect(clampCustomDimension(9000)).toBe(7680);
+    expect(clampCustomDimension(1920)).toBe(1920);
+  });
+
+  it("keeps width and height in sync when locking from width", () => {
+    expect(getLockedCustomDimensions("width", 1280, 16 / 9, 1920, 1080)).toEqual({
+      customWidth: 1280,
+      customHeight: 720,
+    });
+  });
+
+  it("keeps width and height in sync when locking from height", () => {
+    expect(getLockedCustomDimensions("height", 720, 16 / 9, 1920, 1080)).toEqual({
+      customWidth: 1280,
+      customHeight: 720,
+    });
+  });
+});


### PR DESCRIPTION
Closes #1286.

Adds a lock toggle in the Custom preset panel so width and height stay proportional to the source video aspect ratio while resizing. The toggle is disabled until a source video is loaded.

Validation: git diff --check; bun run test -- src/lib/tests/customDimensions.test.ts; bunx tsc --noEmit