### PR TITLE
feat: preview rotation and adjustment effects

### DIFF
--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { Camera } from "lucide-react";
 import ComparisonPreview from "./ComparisonPreview";
 import DraggableTextOverlays from "./DraggableTextOverlays";
+import { buildPreviewEffects } from "@/lib/previewEffects";
 
 interface Props {
   file: File | null;
@@ -229,6 +230,7 @@ export default function VideoPreview({
       }
     }
   })();
+  const previewEffects = buildPreviewEffects(recipe);
 
   if (!file) return null;
 
@@ -276,6 +278,7 @@ export default function VideoPreview({
           ref={videoRef}
           controls
           className={cn("w-full h-full object-contain transition-opacity duration-300", isLoading ? "opacity-0" : "opacity-100")}
+          style={previewEffects}
           onLoadedData={() => setIsLoading(false)}
           playsInline
           muted={!recipe?.keepAudio}

--- a/src/lib/previewEffects.ts
+++ b/src/lib/previewEffects.ts
@@ -1,0 +1,30 @@
+import { CSSProperties } from "react";
+import { EditRecipe } from "./types";
+
+export function buildPreviewEffects(recipe?: EditRecipe): CSSProperties {
+  if (!recipe) return {};
+
+  const styles: CSSProperties = {};
+  const filters: string[] = [];
+
+  if (recipe.rotate) {
+    styles.transform = `rotate(${recipe.rotate}deg)`;
+    styles.transformOrigin = "center center";
+  }
+
+  if (recipe.brightness !== 0) {
+    filters.push(`brightness(${Math.max(0, 1 + recipe.brightness)})`);
+  }
+  if (recipe.contrast !== 1) {
+    filters.push(`contrast(${recipe.contrast})`);
+  }
+  if (recipe.saturation !== 1) {
+    filters.push(`saturate(${recipe.saturation})`);
+  }
+
+  if (filters.length > 0) {
+    styles.filter = filters.join(" ");
+  }
+
+  return styles;
+}

--- a/src/lib/tests/previewEffects.test.ts
+++ b/src/lib/tests/previewEffects.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_RECIPE } from "../constants";
+import { buildPreviewEffects } from "../previewEffects";
+
+describe("buildPreviewEffects", () => {
+  it("returns no inline effects for neutral adjustments", () => {
+    expect(buildPreviewEffects(DEFAULT_RECIPE)).toEqual({});
+  });
+
+  it("builds transform and filter styles for previewable adjustments", () => {
+    const styles = buildPreviewEffects({
+      ...DEFAULT_RECIPE,
+      rotate: 90,
+      brightness: 0.25,
+      contrast: 1.5,
+      saturation: 1.2,
+    });
+
+    expect(styles.transform).toBe("rotate(90deg)");
+    expect(styles.filter).toBe("brightness(1.25) contrast(1.5) saturate(1.2)");
+  });
+});


### PR DESCRIPTION
Closes #1510.

Applies rotation and color adjustment effects directly in the editor preview so users can see those changes before export. Aspect-ratio framing remains reflected by the existing preview overlay.

Validation: git diff --check; bun run test -- src/lib/tests/previewEffects.test.ts; bunx tsc --noEmit