### PR TITLE
[FEATURE] Timeline-based overlays for text

### DIFF
--- a/src/components/DraggableTextOverlays.tsx
+++ b/src/components/DraggableTextOverlays.tsx
@@ -2,13 +2,14 @@
 
 import { TextOverlay, EditRecipe } from "@/lib/types";
 import { useRef, useState, useCallback, useEffect, useMemo } from "react";
-import { getTextPixelPosition, getTextPercentPosition } from "@/lib/text-overlay";
+import { getTextPixelPosition, getTextPercentPosition, isTextOverlayActive } from "@/lib/text-overlay";
 import { getFontFamily, ensureFontLoaded } from "@/utils/fontLoader";
 
 interface DraggableTextOverlaysProps {
   recipe?: EditRecipe;
   containerWidth: number;
   containerHeight: number;
+  currentTime?: number;
   selectedTextId: string | null;
   onUpdateText: (id: string, updates: Partial<TextOverlay>) => void;
   onSelectText: (id: string | null) => void;
@@ -22,6 +23,7 @@ export default function DraggableTextOverlays({
   recipe,
   containerWidth,
   containerHeight,
+  currentTime,
   selectedTextId,
   onUpdateText,
   onSelectText,
@@ -40,8 +42,9 @@ export default function DraggableTextOverlays({
    */
   const textOverlays = useMemo(() => {
     const overlays = recipe?.textOverlays;
-    return Array.isArray(overlays) ? overlays : [];
-  }, [recipe?.textOverlays]);
+    const all = Array.isArray(overlays) ? overlays : [];
+    return all.filter((overlay) => isTextOverlayActive(overlay, currentTime));
+  }, [currentTime, recipe?.textOverlays]);
 
   /**
    * Handles the start of a drag operation.

--- a/src/components/TextControls.tsx
+++ b/src/components/TextControls.tsx
@@ -13,6 +13,7 @@ interface TextControlsProps {
   onChange: (patch: Partial<EditRecipe>) => void;
   selectedTextId: string | null;
   onSelectText: (id: string | null) => void;
+  duration?: number;
 }
 
 /**
@@ -24,6 +25,7 @@ export default function TextControls({
   onChange,
   selectedTextId,
   onSelectText,
+  duration = 0,
 }: TextControlsProps) {
   const { customFonts, addFonts, removeFont, getErrors } = useFontManager();
 
@@ -139,6 +141,47 @@ export default function TextControls({
               className="w-full px-2 py-1.5 text-xs rounded border border-[var(--border)] bg-[var(--bg)] text-[var(--text)] placeholder-[var(--muted)] focus:outline-none focus:ring-2 focus:ring-film-500 resize-none"
               rows={2}
             />
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label htmlFor="overlay-start" className="text-xs text-[var(--muted)] font-medium mb-1 block">
+                Start
+              </label>
+              <input
+                id="overlay-start"
+                type="number"
+                min="0"
+                max={duration > 0 ? duration : undefined}
+                step="0.1"
+                value={selectedOverlay.startTime ?? 0}
+                onChange={(e) =>
+                  handleUpdateText(selectedTextId!, {
+                    startTime: Number(e.target.value),
+                  })
+                }
+                className="w-full px-2 py-1.5 text-xs rounded border border-[var(--border)] bg-[var(--bg)] text-[var(--text)] focus:outline-none focus:ring-2 focus:ring-film-500"
+              />
+            </div>
+            <div>
+              <label htmlFor="overlay-end" className="text-xs text-[var(--muted)] font-medium mb-1 block">
+                End
+              </label>
+              <input
+                id="overlay-end"
+                type="number"
+                min="0"
+                max={duration > 0 ? duration : undefined}
+                step="0.1"
+                value={selectedOverlay.endTime ?? ""}
+                onChange={(e) =>
+                  handleUpdateText(selectedTextId!, {
+                    endTime: e.target.value === "" ? null : Number(e.target.value),
+                  })
+                }
+                className="w-full px-2 py-1.5 text-xs rounded border border-[var(--border)] bg-[var(--bg)] text-[var(--text)] focus:outline-none focus:ring-2 focus:ring-film-500"
+              />
+            </div>
           </div>
 
           {/* Font Selector */}

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -426,6 +426,7 @@ return () => {
                     file={file}
                     recipe={recipe}
                     videoRef={videoRef}
+                    currentTime={currentTime}
                     selectedTextId={selectedTextId}
                     onSelectText={setSelectedTextId}
                     onUpdateText={handleUpdateTextOverlay}
@@ -497,6 +498,7 @@ return () => {
                       onChange={updateRecipe}
                       selectedTextId={selectedTextId}
                       onSelectText={setSelectedTextId}
+                      duration={duration}
                     />
                   </AccordionSection>
                 </div>

--- a/src/components/VideoPreview.tsx
+++ b/src/components/VideoPreview.tsx
@@ -13,6 +13,7 @@ interface Props {
   file: File | null;
   recipe?: EditRecipe;
   videoRef: RefObject<HTMLVideoElement | null>;
+  currentTime?: number;
   selectedTextId?: string | null;
   onSelectText?: (id: string | null) => void;
   onUpdateText?: (id: string, updates: Partial<TextOverlay>) => void;
@@ -25,6 +26,7 @@ export default function VideoPreview({
   file,
   recipe,
   videoRef,
+  currentTime,
   selectedTextId = null,
   onSelectText,
   onUpdateText,
@@ -369,8 +371,9 @@ export default function VideoPreview({
           <DraggableTextOverlays
             recipe={recipe}
             containerWidth={containerDimensions.width}
-            containerHeight={containerDimensions.height}
-            selectedTextId={selectedTextId ?? null}
+                    containerHeight={containerDimensions.height}
+                    currentTime={currentTime}
+                    selectedTextId={selectedTextId ?? null}
             onSelectText={onSelectText || (() => {})}
             onUpdateText={onUpdateText || (() => {})}
           />

--- a/src/lib/tests/textOverlayTiming.test.ts
+++ b/src/lib/tests/textOverlayTiming.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { createDefaultTextOverlay, buildTextFilter, isTextOverlayActive } from "../text-overlay";
+
+describe("text overlay timing", () => {
+  it("defaults overlays to the full timeline", () => {
+    const overlay = createDefaultTextOverlay();
+    expect(overlay.startTime).toBe(0);
+    expect(overlay.endTime).toBeNull();
+    expect(isTextOverlayActive(overlay, 0)).toBe(true);
+    expect(isTextOverlayActive(overlay, 999)).toBe(true);
+  });
+
+  it("limits overlay visibility to the configured time window", () => {
+    const overlay = {
+      ...createDefaultTextOverlay(),
+      startTime: 5,
+      endTime: 10,
+    };
+
+    expect(isTextOverlayActive(overlay, 4.9)).toBe(false);
+    expect(isTextOverlayActive(overlay, 5)).toBe(true);
+    expect(isTextOverlayActive(overlay, 10)).toBe(true);
+    expect(isTextOverlayActive(overlay, 10.1)).toBe(false);
+  });
+
+  it("emits an FFmpeg enable expression for time-limited overlays", () => {
+    const result = buildTextFilter(
+      {
+        ...createDefaultTextOverlay(),
+        text: "Hello",
+        startTime: 2,
+        endTime: 4,
+      },
+      1920,
+      1080
+    );
+
+    expect(result).toContain("enable='between(t,2.000,4.000)'");
+  });
+});

--- a/src/lib/text-overlay.ts
+++ b/src/lib/text-overlay.ts
@@ -21,6 +21,8 @@ export function createDefaultTextOverlay(): TextOverlay {
     color: "#ffffff",
     fontWeight: "normal",
     fontFamily: "Arial", // Default to Arial for immediate visibility
+    startTime: 0,
+    endTime: null,
   };
 }
 
@@ -78,24 +80,22 @@ export function buildTextFilter(
   const pixelX = Math.round((overlay.x / 100) * targetWidth);
   const pixelY = Math.round((overlay.y / 100) * targetHeight);
 
-  // Build font parameters
-  const fontWeightParam = overlay.fontWeight === "900"
-    ? "bold"
-    : overlay.fontWeight === "bold"
-    ? "bold"
-    : "normal";
-
   // Get font file parameter for custom fonts (if available)
   const fontFileParam = getFFmpegFontArg(overlay.fontFamily, overlay.fontPath);
 
   // Build the drawtext filter with font support
-  let filter = `drawtext=text='${escapedText}':x=${pixelX}:y=${pixelY}:fontsize=${overlay.fontSize}:fontcolor=${overlay.color}:fontweight=${fontWeightParam}`;
+  let filter = `drawtext=text='${escapedText}':x=${pixelX}:y=${pixelY}:fontsize=${overlay.fontSize}:fontcolor=${overlay.color}`;
 
-  // Add font family if specified
-  if (overlay.fontFamily) {
-    // Sanitize font name for FFmpeg
-    const safeFontName = overlay.fontFamily.replace(/[^a-zA-Z0-9-]/g, "");
-    filter += `:fontfile='${safeFontName}'`;
+  if (overlay.fontWeight === "bold" || overlay.fontWeight === "900") {
+    filter += `:bold=1`;
+  }
+
+  if (typeof overlay.startTime === "number" && overlay.startTime > 0 && typeof overlay.endTime === "number") {
+    filter += `:enable='between(t,${overlay.startTime.toFixed(3)},${overlay.endTime.toFixed(3)})'`;
+  } else if (typeof overlay.startTime === "number" && overlay.startTime > 0) {
+    filter += `:enable='gte(t,${overlay.startTime.toFixed(3)})'`;
+  } else if (typeof overlay.endTime === "number") {
+    filter += `:enable='lte(t,${overlay.endTime.toFixed(3)})'`;
   }
 
   // Add custom font file path if available
@@ -104,4 +104,18 @@ export function buildTextFilter(
   }
 
   return filter;
+}
+
+export function isTextOverlayActive(
+  overlay: TextOverlay,
+  currentTime: number | null | undefined,
+): boolean {
+  if (typeof currentTime !== "number" || Number.isNaN(currentTime)) return true;
+
+  const start = typeof overlay.startTime === "number" ? overlay.startTime : 0;
+  const end = typeof overlay.endTime === "number" ? overlay.endTime : null;
+
+  if (currentTime < start) return false;
+  if (end !== null && currentTime > end) return false;
+  return true;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -13,6 +13,8 @@ export interface TextOverlay {
   fontWeight: "normal" | "bold" | "900";
   fontFamily?: string; // Font family name (e.g., "Arial", "Inter", "CustomFont")
   fontPath?: string; // Path/URL to custom font file for export
+  startTime?: number; // Seconds from start of video
+  endTime?: number | null; // Seconds from start of video, or null for full length
 }
 
 export interface EditRecipe {


### PR DESCRIPTION
Closes #1287\n\nAdds start/end timing controls for text overlays, filters preview rendering by the active timestamp, and emits FFmpeg enable expressions for export.\n\nValidation:\n- bunx vitest run src/lib/tests/textOverlayTiming.test.ts\n- bunx tsc -p tsconfig.json --noEmit\n- git diff --check