### PR TITLE
[BUG] Fix text overlay export failure

### DIFF
--- a/src/lib/tests/textOverlayExport.test.ts
+++ b/src/lib/tests/textOverlayExport.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { buildTextFilter, createDefaultTextOverlay } from "../text-overlay";
+
+describe("text overlay export", () => {
+  it("uses the FFmpeg bold flag for bold text instead of an invalid fontweight parameter", () => {
+    const filter = buildTextFilter(
+      {
+        ...createDefaultTextOverlay(),
+        text: "Hello",
+        fontWeight: "bold",
+      },
+      1920,
+      1080
+    );
+
+    expect(filter).toContain(":bold=1");
+    expect(filter).not.toContain(":fontweight=");
+  });
+
+  it("only appends a fontfile argument for real custom font paths", () => {
+    const filter = buildTextFilter(
+      {
+        ...createDefaultTextOverlay(),
+        text: "Hello",
+        fontFamily: "Arial",
+      },
+      1920,
+      1080
+    );
+
+    expect(filter).not.toContain(":fontfile='Arial'");
+    expect(filter).not.toContain(":fontfile=Arial");
+  });
+});

--- a/src/lib/text-overlay.ts
+++ b/src/lib/text-overlay.ts
@@ -78,24 +78,14 @@ export function buildTextFilter(
   const pixelX = Math.round((overlay.x / 100) * targetWidth);
   const pixelY = Math.round((overlay.y / 100) * targetHeight);
 
-  // Build font parameters
-  const fontWeightParam = overlay.fontWeight === "900"
-    ? "bold"
-    : overlay.fontWeight === "bold"
-    ? "bold"
-    : "normal";
-
   // Get font file parameter for custom fonts (if available)
   const fontFileParam = getFFmpegFontArg(overlay.fontFamily, overlay.fontPath);
 
   // Build the drawtext filter with font support
-  let filter = `drawtext=text='${escapedText}':x=${pixelX}:y=${pixelY}:fontsize=${overlay.fontSize}:fontcolor=${overlay.color}:fontweight=${fontWeightParam}`;
+  let filter = `drawtext=text='${escapedText}':x=${pixelX}:y=${pixelY}:fontsize=${overlay.fontSize}:fontcolor=${overlay.color}`;
 
-  // Add font family if specified
-  if (overlay.fontFamily) {
-    // Sanitize font name for FFmpeg
-    const safeFontName = overlay.fontFamily.replace(/[^a-zA-Z0-9-]/g, "");
-    filter += `:fontfile='${safeFontName}'`;
+  if (overlay.fontWeight === "bold" || overlay.fontWeight === "900") {
+    filter += `:bold=1`;
   }
 
   // Add custom font file path if available


### PR DESCRIPTION
Closes #1518\n\nFixes the FFmpeg text overlay filter so export uses valid drawtext settings: bold text now uses , and built-in font names are no longer treated as font files. Custom font paths still flow through the existing font loader path.\n\nValidation:\n- bunx vitest run src/lib/tests/textOverlayExport.test.ts\n- bunx tsc -p tsconfig.json --noEmit\n- git diff --check