### PR TITLE
design: align a couple of dark-mode holdouts with theme tokens

### DIFF
--- a/src/components/ComparisonPreview.tsx
+++ b/src/components/ComparisonPreview.tsx
@@ -238,7 +238,7 @@ export default function ComparisonPreview({ file, recipe, videoRef }: Props) {
       {/* Draggable divider slider */}
       <div
         className={cn(
-          "absolute top-0 bottom-0 w-1 bg-white pointer-events-none transition-opacity",
+          "absolute top-0 bottom-0 w-1 bg-[var(--surface)] pointer-events-none transition-opacity",
           isDragging ? "opacity-100" : "opacity-75 hover:opacity-100"
         )}
         style={{ left: `${sliderPosition}%`, transform: "translateX(-50%)" }}
@@ -249,15 +249,15 @@ export default function ComparisonPreview({ file, recipe, videoRef }: Props) {
           type="button"
           onMouseDown={handleMouseDown}
           onTouchStart={handleMouseDown}
-          className="absolute top-1/2 left-1/2 w-8 h-8 -ml-4 -mt-4 rounded-full bg-white shadow-lg pointer-events-auto cursor-grab active:cursor-grabbing flex items-center justify-center transition-shadow"
+          className="absolute top-1/2 left-1/2 w-8 h-8 -ml-4 -mt-4 rounded-full bg-[var(--surface)] shadow-lg pointer-events-auto cursor-grab active:cursor-grabbing flex items-center justify-center transition-shadow border border-[var(--border)]"
           style={{
-            boxShadow: isDragging ? "0 0 12px rgba(255, 255, 255, 0.8)" : undefined,
+            boxShadow: isDragging ? "0 0 12px var(--accent-muted)" : undefined,
           }}
           aria-label="Drag to compare original vs reframed"
           title="Drag left/right to compare"
         >
           <svg
-            className="w-4 h-4 text-black"
+            className="w-4 h-4 text-[var(--text)]"
             fill="currentColor"
             viewBox="0 0 24 24"
           >

--- a/src/components/NativeShareButton.tsx
+++ b/src/components/NativeShareButton.tsx
@@ -79,7 +79,7 @@ export function NativeShareButton({
       disabled={isSharing}
       type="button"
       aria-label="Share video"
-      className={`inline-flex items-center justify-center px-4 py-2 text-sm font-medium text-white transition-colors duration-200 bg-blue-600 rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
+      className={`inline-flex items-center justify-center px-4 py-2 text-sm font-medium text-white transition-colors duration-200 bg-[var(--accent)] rounded-md shadow-sm hover:bg-[var(--accent-hover)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)] focus:ring-offset-2 focus:ring-offset-[var(--bg)] disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
     >
       <svg
         className="w-5 h-5 mr-2 -ml-1"


### PR DESCRIPTION
Closes #673\n\nReplaces a couple of obvious hard-coded color values in the comparison splitter and native share button with the app's theme tokens so they track light/dark mode consistently.\n\nValidation:\n- bunx tsc -p tsconfig.json --noEmit\n- git diff --check