### PR TITLE
fix: add keyboard controls for draggable text overlays

### DIFF
--- a/src/components/DraggableTextOverlays.tsx
+++ b/src/components/DraggableTextOverlays.tsx
@@ -121,6 +121,44 @@ export default function DraggableTextOverlays({
     [handleSaveEdit]
   );
 
+  const handleOverlayKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>, overlayId: string) => {
+      const overlay = textOverlays.find((o) => o.id === overlayId);
+      if (!overlay) return;
+
+      if (editingId === overlayId) {
+        handleEditKeyDown(e, overlayId);
+        return;
+      }
+
+      if (e.key === "Enter") {
+        e.preventDefault();
+        setEditingId(overlayId);
+        setEditText(overlay.text);
+        return;
+      }
+
+      const moveBy = e.shiftKey ? 5 : 1;
+      const moves: Record<string, { x: number; y: number }> = {
+        ArrowUp: { x: 0, y: -moveBy },
+        ArrowDown: { x: 0, y: moveBy },
+        ArrowLeft: { x: -moveBy, y: 0 },
+        ArrowRight: { x: moveBy, y: 0 },
+      };
+
+      const delta = moves[e.key];
+      if (!delta) return;
+
+      e.preventDefault();
+      onSelectText(overlayId);
+      onUpdateText(overlayId, {
+        x: Math.max(0, Math.min(100, overlay.x + delta.x)),
+        y: Math.max(0, Math.min(100, overlay.y + delta.y)),
+      });
+    },
+    [editingId, handleEditKeyDown, onSelectText, onUpdateText, textOverlays]
+  );
+
   /**
    * Handles dragging of text overlays.
    */
@@ -237,14 +275,7 @@ export default function DraggableTextOverlays({
             tabIndex={0}
             onMouseDown={(e) => handleMouseDown(e, overlay.id)}
             onDoubleClick={(e) => handleDoubleClick(e, overlay.id)}
-            onKeyDown={(e) => {
-              if (editingId === overlay.id) {
-                handleEditKeyDown(e, overlay.id);
-              } else if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                onSelectText(overlay.id);
-              }
-            }}
+            onKeyDown={(e) => handleOverlayKeyDown(e, overlay.id)}
             className={`absolute pointer-events-auto ${
               editingId === overlay.id ? "cursor-text" : "cursor-move"
             } select-none transition-all ${
@@ -253,7 +284,7 @@ export default function DraggableTextOverlays({
               isSelected
                 ? "ring-2 ring-film-500 ring-offset-1 ring-offset-black/50"
                 : ""
-            }`}
+            } focus-visible:ring-2 focus-visible:ring-film-500 focus-visible:ring-offset-1 focus-visible:ring-offset-black/50`}
             style={{
               left: `${left}px`,
               top: `${top}px`,

--- a/src/components/__tests__/DraggableTextOverlays.test.tsx
+++ b/src/components/__tests__/DraggableTextOverlays.test.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import "@testing-library/jest-dom/vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import DraggableTextOverlays from "../DraggableTextOverlays";
+
+vi.mock("@/utils/fontLoader", () => ({
+  getFontFamily: (fontName?: string) => fontName ?? "Arial",
+  ensureFontLoaded: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("DraggableTextOverlays keyboard support", () => {
+  const overlay = {
+    id: "text-1",
+    text: "Hello",
+    x: 50,
+    y: 50,
+    fontSize: 32,
+    color: "#ffffff",
+    fontWeight: "normal" as const,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("moves the overlay with arrow keys", async () => {
+    const onUpdateText = vi.fn();
+
+    render(
+      React.createElement(DraggableTextOverlays, {
+        recipe: { textOverlays: [overlay] } as any,
+        containerWidth: 200,
+        containerHeight: 100,
+        selectedTextId: overlay.id,
+        onUpdateText,
+        onSelectText: vi.fn(),
+      })
+    );
+
+    const node = screen.getByRole("button", { name: /text overlay: hello/i });
+    node.focus();
+
+    act(() => {
+      fireEvent.keyDown(node, { key: "ArrowRight" });
+    });
+
+    expect(onUpdateText).toHaveBeenCalledWith(overlay.id, { x: 51, y: 50 });
+  });
+
+  it("enters edit mode with Enter", () => {
+    render(
+      React.createElement(DraggableTextOverlays, {
+        recipe: { textOverlays: [overlay] } as any,
+        containerWidth: 200,
+        containerHeight: 100,
+        selectedTextId: overlay.id,
+        onUpdateText: vi.fn(),
+        onSelectText: vi.fn(),
+      })
+    );
+
+    const node = screen.getByRole("button", { name: /text overlay: hello/i });
+    node.focus();
+
+    fireEvent.keyDown(node, { key: "Enter" });
+
+    expect(screen.getByRole("button", { name: /text overlay: hello/i })).toHaveClass("cursor-text");
+  });
+});


### PR DESCRIPTION
Closes #1162\n\nAdds keyboard support to text overlays in the preview: arrow keys nudge the selected overlay, Shift+Arrow moves by larger steps, Enter enters edit mode, and Escape exits editing. I also added a focused component test for the keyboard interactions.\n\nValidation:\n- bunx vitest run src/components/__tests__/DraggableTextOverlays.test.tsx\n- bunx tsc -p tsconfig.json --noEmit\n- git diff --check