### PR TITLE
fix: align custom ratio badge

### DIFF
--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -320,7 +320,7 @@ export default function PresetSelector({ recipe, onChange }: Props) {
             />
           </div>
 
-          <div className="hidden h-full flex-col justify-end sm:flex">
+          <div className="hidden h-full flex-col justify-start sm:flex">
             <span className="mb-1.5 block text-center text-[10px] font-heading font-semibold uppercase tracking-wider text-[var(--muted)]">
               Ratio
             </span>


### PR DESCRIPTION
Closes #1278\n\nTop-align the custom ratio badge column so it stays visually aligned with the width and height inputs in the Resize & Aspect Ratio panel.\n\nValidation:\n- bunx tsc -p tsconfig.json --noEmit\n- git diff --check