### PR TITLE
fix: confirm reset all settings

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -622,6 +622,13 @@ export function useVideoEditor() {
   }, []);
 
   const resetSettings = useCallback(() => {
+    if (typeof window !== "undefined") {
+      const confirmed = window.confirm(
+        "Reset all settings to defaults? This cannot be undone.",
+      );
+      if (!confirmed) return;
+    }
+
     setRecipe(DEFAULT_RECIPE);
     try {
       localStorage.removeItem(RECIPE_STORAGE_KEY);


### PR DESCRIPTION
Closes #684\n\nAdd a confirmation gate to the shared reset-all-settings path so users do not lose their current editor state with a single accidental click or shortcut.\n\nValidation:\n- bunx tsc -p tsconfig.json --noEmit\n- git diff --check