### PR TITLE
fix: add audio toggle focus state

### DIFF
--- a/src/components/AudioSpeedControl.tsx
+++ b/src/components/AudioSpeedControl.tsx
@@ -45,7 +45,7 @@ export default function AudioSpeedControl({ recipe, onChange }: Props) {
         aria-pressed={recipe.keepAudio}
         className={cn(
           "w-full flex items-center gap-3 p-3 rounded-lg border transition-all duration-150",
-          "hover:scale-[1.01] active:scale-[0.99]",
+          "hover:scale-[1.01] active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-film-600 focus-visible:ring-offset-2",
           recipe.keepAudio
             ? "border-film-300 bg-film-50 text-film-700"
             : "border-[var(--border)] bg-[var(--surface)] text-[var(--muted)]"


### PR DESCRIPTION
Closes #33\n\nAdd a visible focus ring to the audio toggle so keyboard users can clearly see when the control is focused.\n\nValidation:\n- bunx tsc -p tsconfig.json --noEmit\n- git diff --check