### PR TITLE
fix: validate recipe denoise flag

### DIFF
--- a/src/lib/tests/types.test.ts
+++ b/src/lib/tests/types.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_RECIPE } from "@/lib/constants";
+import { isValidRecipe } from "@/lib/types";
+
+describe("isValidRecipe", () => {
+  it("accepts the default recipe", () => {
+    expect(isValidRecipe(DEFAULT_RECIPE)).toBe(true);
+  });
+
+  it("rejects a non-boolean denoise value", () => {
+    expect(
+      isValidRecipe({
+        ...DEFAULT_RECIPE,
+        denoise: "invalid",
+      } as never)
+    ).toBe(false);
+  });
+});

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -137,6 +137,7 @@ export function isValidRecipe(value: unknown): value is EditRecipe {
   if (typeof v.quality !== "number" || !isFinite(v.quality)) return false;
   if (!["mp4", "webm", "mkv", "gif"].includes(v.format)) return false;
   if (typeof v.stabilization !== "boolean") return false;
+  if (typeof v.denoise !== "boolean") return false;
   if (typeof v.brightness !== "number" || !isFinite(v.brightness)) return false;
   if (typeof v.contrast !== "number" || !isFinite(v.contrast)) return false;
   if (typeof v.saturation !== "number" || !isFinite(v.saturation)) return false;


### PR DESCRIPTION
Closes #1419\n\nAdd a missing boolean guard for the denoise field in recipe validation so malformed persisted or imported recipes are rejected instead of being treated as valid.\n\nValidation:\n- bunx vitest run src/lib/tests/types.test.ts\n- bunx tsc -p tsconfig.json --noEmit\n- git diff --check