### PR TITLE
fix: split title-set and title-reset effects to stop title flash (#1662)

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -539,10 +539,13 @@ export function useVideoEditor() {
     } else {
       document.title = DEFAULT_TITLE;
     }
+  }, [status, progress, file]);
+
+  useEffect(() => {
     return () => {
       document.title = DEFAULT_TITLE;
     };
-  }, [status, progress, file]);
+  }, []);
 
   useEffect(() => {
     const shouldWarn =


### PR DESCRIPTION
Closes https://github.com/magic-peach/reframe/issues/1662
## Description
Fixes a document title flash bug in `useVideoEditor.ts`. The `useEffect` that sets `document.title` based on export status/progress/file also had a cleanup function that reset the title to `DEFAULT_TITLE`. Since `progress` was in the dependency array, this cleanup ran on every progress tick during export, causing the tab title to flash back to the default before showing the updated value.

The fix splits this into two effects:
1. One effect (with `[status, progress, file]` deps) that only sets `document.title` — no cleanup.
2. A separate effect (with `[]` deps) that resets `document.title` to `DEFAULT_TITLE` only on unmount.

This removes the flash while preserving the original intent of resetting the title when the component unmounts.

## Related Issue
Fixes #1662

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] GSSoC contribution

## Participant Info
- GitHub username: aaniya22
- Contribution level (Beginner/Intermediate/Advanced): <!-- fill in -->

## Screen Recording
**Recording / Loom link:** <!-- record a short clip showing the title updating smoothly during export without flashing, per the instructions above -->

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [ ] I have tested my changes in Chrome, Firefox, and Safari
- [ ] `bun run lint` passes (no ESLint errors)
- [ ] `bunx tsc --noEmit` passes (no TypeScript errors)
- [ ] New interactive elements have `aria-label` / accessible names
- [x] This PR is related to a valid issue
- [ ] **Screen recording attached above** (required for UI/feature/design changes)