### PR TITLE
fix: validate denoise field in isValidRecipe (#1661)

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -97,6 +97,7 @@ export function isValidRecipe(value: unknown): value is EditRecipe {
   if (typeof v.quality !== "number" || !isFinite(v.quality)) return false;
   if (!["mp4", "webm", "mkv", "gif"].includes(v.format)) return false;
   if (typeof v.stabilization !== "boolean") return false;
+  if (typeof v.denoise !== "boolean") return false;
   if (typeof v.brightness !== "number" || !isFinite(v.brightness)) return false;
   if (typeof v.contrast !== "number" || !isFinite(v.contrast)) return false;
   if (typeof v.saturation !== "number" || !isFinite(v.saturation)) return false;


### PR DESCRIPTION
Closes #1661
## Description
`isValidRecipe` in `src/lib/types.ts` was missing validation for the `denoise` field on `EditRecipe`. This meant malformed or missing `denoise` values could pass validation and reach downstream code expecting a `boolean`. Added a `typeof v.denoise !== "boolean"` check, following the same pattern as the existing `stabilization` check.

## Related Issue
Fixes #1661

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] GSSoC contribution

## Participant Info
- GitHub username: aaniya22
- Contribution level (Beginner/Intermediate/Advanced): <!-- fill in -->

## Screen Recording
**Recording / Loom link:** <!-- this is a type-guard/validation change with no visible UI difference; check with maintainers if a recording is still required, or note in the PR that it's a non-UI validation fix -->

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [ ] I have tested my changes in Chrome, Firefox, and Safari
- [ ] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors) — the only errors present are pre-existing, in a generated build file (`out/_next/static/media/ffmpeg.worker.*.ts`), unrelated to this change
- [ ] New interactive elements have `aria-label` / accessible names
- [x] This PR is related to a valid issue
- [ ] **Screen recording attached above** (required for UI/feature/design changes)