### PR TITLE
feat: optimize editor layout for mobile / narrow screens

### DIFF
--- a/src/components/PresetSelector.tsx
+++ b/src/components/PresetSelector.tsx
@@ -141,7 +141,7 @@ export default function PresetSelector({ recipe, onChange }: Props) {
   return (
     <div className="space-y-3">
       {/* Quick-action row */}
-      <div className="grid grid-cols-5 gap-1.5">
+      <div className="grid grid-cols-3 gap-1.5 sm:grid-cols-5">
         {QUICK_ACTIONS.map(({ preset, label, platform, icon }) => {
           const isActive = recipe.preset === preset;
           return (
@@ -284,7 +284,8 @@ export default function PresetSelector({ recipe, onChange }: Props) {
             <input
               id="custom-width"
               type="number"
-              autoComplete="off" 
+              inputMode="numeric"
+              autoComplete="off"
               min={16}
               max={7680}
               step={2}
@@ -310,6 +311,7 @@ export default function PresetSelector({ recipe, onChange }: Props) {
             <input
               id="custom-height"
               type="number"
+              inputMode="numeric"
               autoComplete="off"
               min={16}
               max={7680}

--- a/src/components/TrimControl.tsx
+++ b/src/components/TrimControl.tsx
@@ -247,6 +247,7 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
           <input
             id="trim-start"
             type="number"
+            inputMode="decimal"
             autoComplete="off"
             min={0}
             max={duration > 0 ? duration : undefined}
@@ -284,6 +285,7 @@ export default function TrimControl({ recipe, onChange, duration, file }: Props)
           <input
             id="trim-end"
             type="number"
+            inputMode="decimal"
             autoComplete="off"
             min={0}
             max={duration > 0 ? duration : undefined}

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -365,7 +365,11 @@ return () => {
         {status === "error" && `Export failed: ${error}`}
       </div>
 
-      <div className="max-w-6xl mx-auto px-4 py-8 pb-6 flex-1 w-full">
+      <div className={cn(
+        "max-w-6xl mx-auto px-4 py-8 pb-6 flex-1 w-full",
+        // Reserve space on mobile so the fixed export bar never covers content.
+        file && "max-lg:pb-28"
+      )}>
         <header className="mb-10 flex flex-col items-center justify-center gap-4 animate-fade-in">
         <div
           className="inline-block rounded-xl border border-[var(--border)] bg-[var(--surface)] shadow-sm border-l-4 border-l-film-600 mx-auto w-fit min-w-min"
@@ -739,7 +743,8 @@ return () => {
                 aria-disabled={!file || isProcessing ? "true" : undefined}
                 title={!file ? "Upload a video to enable export" : undefined}
               className={cn(
-                "w-full flex items-center justify-center gap-3 py-5 min-h-[44px] rounded-xl",
+                // Hidden on mobile — replaced by the fixed bottom bar below.
+                "w-full hidden lg:flex items-center justify-center gap-3 py-5 min-h-[44px] rounded-xl",
                 "font-display text-2xl tracking-widest transition-all duration-200",
                 file && !isProcessing
                   ? "bg-[var(--accent)] hover:bg-[var(--accent-hover)] hover:scale-[1.02] text-white shadow-[var(--shadow)] active:scale-[0.98] cursor-pointer"
@@ -751,13 +756,36 @@ return () => {
             </button>
 
             {file && !isProcessing && (
-              <p className="text-xs text-center font-mono text-[var(--muted)] opacity-50 mt-1">
+              <p className="hidden lg:block text-xs text-center font-mono text-[var(--muted)] opacity-50 mt-1">
                 {isMac ? "⌘" : "Ctrl"} + Enter to export
               </p>
             )}
           </div>
         </div>
       </div>
+
+      {/* Mobile-only export bar — keeps Export reachable without scrolling to the sidebar. */}
+      {file && (
+        <div className="lg:hidden fixed inset-x-0 bottom-0 z-40 border-t border-[var(--border)] bg-[var(--bg)]/95 px-4 py-3 backdrop-blur [padding-bottom:calc(0.75rem+env(safe-area-inset-bottom))]">
+          <button
+            type="button"
+            onClick={handleExport}
+            disabled={isProcessing}
+            aria-label="Export video"
+            aria-disabled={isProcessing ? "true" : undefined}
+            className={cn(
+              "w-full flex items-center justify-center gap-3 py-4 min-h-[44px] rounded-xl",
+              "font-display text-xl tracking-widest transition-all duration-200",
+              !isProcessing
+                ? "bg-[var(--accent)] hover:bg-[var(--accent-hover)] text-white shadow-[var(--shadow)] active:scale-[0.98] cursor-pointer"
+                : "bg-[var(--border)] text-[var(--muted)] cursor-not-allowed"
+            )}
+          >
+            <Zap size={18} className={cn(!isProcessing && "animate-pulse")} />
+            {isProcessing ? "PROCESSING" : "EXPORT"}
+          </button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

On narrow viewports the controls panel was cramped and the Export button sat at the very bottom of the page, out of reach while editing. This reflows the editor for mobile.

Closes #674

## What changed

- **Mobile export bar** — a fixed bottom Export bar (`lg:hidden`, shown once a file is loaded) keeps Export reachable without scrolling to the sidebar. The sidebar Export button is now desktop-only (`hidden lg:flex`) to avoid duplication.
- The content container gets `max-lg:pb-28` when a file is loaded, so the fixed bar never covers content. The bar also respects `env(safe-area-inset-bottom)`.
- **Quick-action presets** reflow to 3-up on mobile (`grid-cols-3 sm:grid-cols-5`), unchanged 5-up on desktop.
- **Mobile keyboards** — `inputMode="numeric"` on Custom width/height, `inputMode="decimal"` on Trim start/end.

## Acceptance criteria

- [x] App is fully usable on a 375px viewport
- [x] No horizontal overflow or hidden content at 375px
- [x] Export button is always reachable on mobile
- [x] All numeric inputs use `inputmode` / `type="number"` for mobile keyboards
- [x] Tested with Chrome DevTools Device Toolbar at iPhone SE (375×667) and Pixel 7 (412×915)


## Testing

- `next lint` — clean on the changed files
- `tsc --noEmit` — no errors from the changed files
- Desktop verified (no regression); mobile verified in Chrome DevTools device toolbar

---

@magic-peach please review this PR 

