### PR TITLE
feat: add progress steps indicator (Upload → Configure → Export → Download)

### DIFF
--- a/src/components/ProgressSteps.tsx
+++ b/src/components/ProgressSteps.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { Upload, SlidersHorizontal, Zap, Download, Check } from "lucide-react";
+import type { ExportStatus } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+interface ProgressStepsProps {
+  file: File | null;
+  status: ExportStatus;
+}
+
+const STEPS = [
+  { label: "Upload", icon: Upload },
+  { label: "Configure", icon: SlidersHorizontal },
+  { label: "Export", icon: Zap },
+  { label: "Download", icon: Download },
+] as const;
+
+type StepState = "completed" | "active" | "upcoming";
+
+export default function ProgressSteps({ file, status }: ProgressStepsProps) {
+  const currentStep = !file
+    ? 0
+    : status === "loading-engine" || status === "exporting"
+      ? 2
+      : status === "done"
+        ? 3
+        : 1;
+
+  return (
+    <nav aria-label="Workflow progress" className="w-full">
+      <ol className="flex items-start">
+        {STEPS.map((step, i) => {
+          const state: StepState =
+            i < currentStep ? "completed" : i === currentStep ? "active" : "upcoming";
+          const Icon = step.icon;
+          const isLast = i === STEPS.length - 1;
+
+          return (
+            <li
+              key={step.label}
+              className="flex items-start flex-1 last:flex-none"
+              aria-current={state === "active" ? "step" : undefined}
+            >
+              <div className="flex flex-col items-center gap-1.5 shrink-0">
+                <span
+                  className={cn(
+                    "flex items-center justify-center w-9 h-9 rounded-full border-2 transition-colors duration-200 motion-reduce:transition-none",
+                    state === "completed" && "bg-[var(--accent)] border-[var(--accent)] text-white",
+                    state === "active" && "border-[var(--accent)] text-[var(--accent)] bg-[var(--surface)]",
+                    state === "upcoming" && "border-[var(--border)] text-[var(--muted)] bg-[var(--surface)]"
+                  )}
+                >
+                  {state === "completed" ? (
+                    <Check size={16} aria-hidden="true" />
+                  ) : (
+                    <Icon size={16} aria-hidden="true" />
+                  )}
+                </span>
+                <span
+                  className={cn(
+                    "text-[11px] font-heading font-semibold uppercase tracking-widest whitespace-nowrap",
+                    state === "upcoming" ? "text-[var(--muted)]" : "text-[var(--text)]"
+                  )}
+                >
+                  {step.label}
+                </span>
+                <span className="sr-only">
+                  {state === "completed" ? "completed" : state === "active" ? "current step" : "upcoming"}
+                </span>
+              </div>
+
+              {!isLast && (
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    "flex-1 h-0.5 rounded-full mt-[18px] transition-colors duration-200 motion-reduce:transition-none",
+                    i < currentStep ? "bg-[var(--accent)]" : "bg-[var(--border)]"
+                  )}
+                />
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -25,6 +25,7 @@ import {
   SlidersHorizontal, Zap, AlertTriangle, Github, Copy
 } from "lucide-react";
 import OnboardingTour from "./OnboardingTour";
+import ProgressSteps from "./ProgressSteps";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { loadOverlayState, persistOverlayState } from "@/lib/editorPersistence";
 
@@ -407,6 +408,11 @@ return () => {
     No login. No ads. 100% private - your video never leaves your device.
   </div>
     </header>
+
+        <div className="mb-8 rounded-xl border border-[var(--border)] bg-[var(--surface)] p-5 animate-fade-in">
+          <ProgressSteps file={file} status={status} />
+        </div>
+
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-5">
 
           <div className="space-y-4 min-w-0">


### PR DESCRIPTION
## Summary
- Adds a 4-step workflow stepper at the top of the editor: **Upload → Configure → Export → Download**.
- Step state derives from the editor's `file`/`status` (per issue mapping): `Upload` when no file, `Configure` when a file is loaded and idle, `Export` during `loading-engine`/`exporting`, `Download` when `done`.
- Completed steps show a checkmark; the active step is highlighted with the accent color; connectors fill as steps complete.
- Accessible: wrapped in a labelled `nav` + `ol`, each step uses `aria-current="step"` when active, and a visually-hidden state label is provided for screen readers. Respects `prefers-reduced-motion`.

## Acceptance Criteria
- [x] 4-step indicator visible at top of page
- [x] Active step highlighted
- [x] Completed steps show checkmark
- [x] Accessible with ARIA

## Test plan
- `npx tsc --noEmit` — passes
- `npm run lint` — passes
- `npm run build` — builds successfully

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)