### PR TITLE
fix: missing early return in validateMultiTrackState, division by zero in frame-export, stale closure in useFontManager

### DIFF
--- a/src/hooks/useFontManager.ts
+++ b/src/hooks/useFontManager.ts
@@ -3,7 +3,7 @@
  * Handles font file uploads, validation, and registration.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { validateFontFile, extractFontName, detectDuplicateFonts } from "@/utils/fontValidation";
 import {
   registerCustomFont,
@@ -46,6 +46,7 @@ interface UseFontManagerReturn {
  */
 export function useFontManager(): UseFontManagerReturn {
   const [customFonts, setCustomFonts] = useState<CustomFont[]>([]);
+  const customFontsRef = useRef(customFonts);
   const [errors, setErrors] = useState<string[]>([]);
 
   // Initialize font registry on mount
@@ -80,7 +81,7 @@ export function useFontManager(): UseFontManagerReturn {
         const fontName = extractFontName(file.name);
 
         // Check for duplicate name
-        if (customFonts.some((f) => f.name === fontName)) {
+        if (customFontsRef.current.some((f) => f.name === fontName)) {
           newErrors.push(`${file.name}: Font "${fontName}" already uploaded`);
           continue;
         }
@@ -130,7 +131,7 @@ export function useFontManager(): UseFontManagerReturn {
         errors: newErrors,
       };
     },
-    [customFonts]
+    []
   );
 
   /**
@@ -153,6 +154,8 @@ export function useFontManager(): UseFontManagerReturn {
     // Clear errors when removing fonts
     setErrors([]);
   }, []);
+
+  customFontsRef.current = customFonts;
 
   return {
     customFonts,

--- a/src/lib/frame-export.ts
+++ b/src/lib/frame-export.ts
@@ -75,6 +75,10 @@ export async function captureFrameAsPng(
     video.videoHeight
   );
 
+  if (width === 0 || height === 0 || !isFinite(scale) || scale <= 0) {
+    throw new Error("Invalid output dimensions computed for frame export.");
+  }
+
   const canvas = document.createElement("canvas");
   canvas.width = width;
   canvas.height = height;

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -152,6 +152,7 @@ export function validateMultiTrackState(state: MultiTrackEditorState): {
 
   if (!Array.isArray(state.timelineTracks)) {
     errors.push("timelineTracks must be an array");
+    return { valid: false, errors };
   }
 
   const videoTracks = state.timelineTracks.filter(t => t.type === "video");


### PR DESCRIPTION
Real fixes:
1. timeline.ts: validateMultiTrackState continues past type check - TypeError when timelineTracks is not array
2. frame-export.ts: captureFrameAsPng has no guard for 0-dimension video - divide by zero, NaN scale
3. useFontManager.ts: stale closure in addFonts allows duplicate font entries on concurrent calls