### PR TITLE
feat: improve comparison video synchronization with frame callbacks

### DIFF
--- a/src/components/ComparisonPreview.tsx
+++ b/src/components/ComparisonPreview.tsx
@@ -81,16 +81,55 @@ export default function ComparisonPreview({ file, recipe, videoRef }: Props) {
 
     if (!leftVideo || !rightVideo || !file) return;
 
-    const handleTimeUpdate = () => {
+    // const handleTimeUpdate = () => {
+    //   rightVideo.currentTime = leftVideo.currentTime;
+    // };
+
+    // Track the active frame callback so it can be cancelled when playback stops.
+    let animationFrameId: number | null = null;
+
+    // Synchronize the comparison video once per rendered frame for smoother playback.
+    const syncVideos = () => {
+      // Sync the playback time
       rightVideo.currentTime = leftVideo.currentTime;
+        
+      // Schedule the next sync on the next rendered frame
+      if ('requestVideoFrameCallback' in leftVideo) {
+        animationFrameId = leftVideo.requestVideoFrameCallback(syncVideos);
+      } else {
+        animationFrameId = requestAnimationFrame(syncVideos);
+      }
+    };
+
+    // Cancel any pending frame callback to stop synchronization.
+    const stopSync = () => {
+      if (animationFrameId !== null) {
+        if ('cancelVideoFrameCallback' in leftVideo) {
+          leftVideo.cancelVideoFrameCallback(animationFrameId);
+        } else {
+          cancelAnimationFrame(animationFrameId);
+        }
+
+        animationFrameId = null;
+      }
     };
 
     const handlePlay = () => {
       rightVideo.play().catch(() => {});
+      
+      // Start synchronization only if a frame callback isn't already running.
+      if (animationFrameId === null) {
+        syncVideos();
+      }
     };
 
-    const handlePause = () => {
+    const handleSeek = () => {
+      rightVideo.currentTime = leftVideo.currentTime;
+    }
+
+    const handleStop = () => {
       rightVideo.pause();
+      stopSync();
     };
 
     const handleRateChange = () => {
@@ -101,16 +140,21 @@ export default function ComparisonPreview({ file, recipe, videoRef }: Props) {
       leftVideo.play().catch(() => {});
     };
 
-    leftVideo.addEventListener("timeupdate", handleTimeUpdate);
     leftVideo.addEventListener("play", handlePlay);
-    leftVideo.addEventListener("pause", handlePause);
+    leftVideo.addEventListener("pause", handleStop);
+    leftVideo.addEventListener("seeking", handleSeek);
+    leftVideo.addEventListener("seeked", handleSeek);
+    leftVideo.addEventListener("ended", handleStop);
     leftVideo.addEventListener("ratechange", handleRateChange);
     leftVideo.addEventListener("loadeddata", handleLoadedData);
 
     return () => {
-      leftVideo.removeEventListener("timeupdate", handleTimeUpdate);
+      stopSync();
       leftVideo.removeEventListener("play", handlePlay);
-      leftVideo.removeEventListener("pause", handlePause);
+      leftVideo.removeEventListener("pause", handleStop);
+      leftVideo.removeEventListener("seeking", handleSeek);
+      leftVideo.removeEventListener("seeked", handleSeek);
+      leftVideo.removeEventListener("ended", handleStop);
       leftVideo.removeEventListener("ratechange", handleRateChange);
       leftVideo.removeEventListener("loadeddata", handleLoadedData);
     };


### PR DESCRIPTION
## Description

- Replaced the throttled `timeupdate`-based synchronization mechanism with a frame-based synchronization loop using `requestVideoFrameCallback()`, with a fallback to `requestAnimationFrame()` for unsupported browsers. 
- The synchronization loop is started on playback, cancelled on pause, end, and component unmount, resulting in smoother playback synchronization between the comparison videos.
- Prevented duplicate synchronization loops by ensuring only one active frame callback is scheduled at a time.

## Related Issue

- Closes #1672 

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] GSSoC contribution

## Participant Info
- GitHub username: Priyanshu1-62
- Contribution level: Intermediate (Some experience required)

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project structure
- [x] I have tested my changes in Chrome, Firefox, and Safari
- [x] `bun run lint` passes (no ESLint errors)
- [x] `bunx tsc --noEmit` passes (no TypeScript errors)
- [ ] New interactive elements have `aria-label` / accessible names
- [x] No `console.log` statements left in
- [x] This PR is related to a valid issue
- [ ] Screen recording attached above