### PR TITLE
fix: change header h1 to span for proper heading hierarchy

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -82,7 +82,7 @@ export default function RootLayout({
             >
               <div className="flex items-center gap-2">
                 <BrandLogo size={24} />
-                <h1 className="text-lg font-semibold">Reframe</h1>
+                <span className="text-lg font-semibold">Reframe</span>
               </div>
               <ThemeToggle />
             </header>


### PR DESCRIPTION
## What this does

Fixed heading hierarchy in the main page by changing the header h1 to a span element.

## Why

Proper heading hierarchy (h1 → h2 → h3) is important for accessibility and SEO. The page had two h1 elements:
1. In the header: `<h1>Reframe</h1>`
2. In VideoEditor: `<h1>REFRAME</h1>`

## Changes

- Changed `<h1>` to `<span>` in `src/app/layout.tsx` (header)
- Now there is exactly one h1 per page (the main REFRAME title)

## Acceptance Criteria

- [x] One `<h1>` on the page
- [x] Logical heading hierarchy maintained
- [x] No heading levels skipped

## Contributor

**Abhinav Jha** ([@Youngmaster0304](https://github.com/Youngmaster0304)) | abhinavjha0304@gmail.com
**GSSoC 2026 Participant**

Fixes #69
