### PR TITLE
fix(#1705): add dispose method to prevent blob URL memory leaks

### DIFF
--- a/src/lib/ffmpeg.ts
+++ b/src/lib/ffmpeg.ts
@@ -109,13 +109,19 @@ function handleWorkerMessage(event: MessageEvent<WorkerResponse>) {
   if (data.type === "result") {
     if (pendingExport?.id !== data.id) return;
     const blob = new Blob([data.data], { type: data.mimeType });
+    const blobUrl = URL.createObjectURL(blob);
     pendingExport.resolve({
-      blobUrl: URL.createObjectURL(blob),
+      blobUrl,
       blob,
       size: data.size,
       width: data.width,
       height: data.height,
       format: data.format,
+      // Dispose method allows cleanup of blob URLs to prevent memory leaks
+      // Call this when the exported video is no longer needed by the application
+      dispose: () => {
+        URL.revokeObjectURL(blobUrl);
+      },
     });
     pendingExport = null;
     pendingProgress = null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -66,6 +66,7 @@ export interface ExportResult {
   height: number;
   format: "mp4" | "webm" | "mkv" | "gif";
   exportDurationMs?: number;
+  dispose(): void;
 }
 
 export type ExportStatus =


### PR DESCRIPTION
## Summary
Prevent memory leaks from unreleased blob URLs by adding a dispose mechanism to ExportResult.

## Problem (Issue #1705)
Blob URLs created via URL.createObjectURL() are never revoked, causing:
- Memory leaks growing with every export in a single session
- Unbounded memory growth in long-running applications
- Browser performance degradation as memory accumulates

## Root Cause
No cleanup mechanism for blob URLs after export completes

## Solution
Add dispose() method to ExportResult:
- Method revokes the blob URL when called
- Allows proper cleanup after download/processing
- Prevents memory accumulation in long-session scenarios

## Usage Pattern


## Changes
- src/lib/types.ts: Added dispose() method to ExportResult
- src/lib/ffmpeg.ts: Implement dispose to call URL.revokeObjectURL()

## Testing
- Build passes with TypeScript strict mode ✓

Fixes #1705

---
GSSoC 2026 Contribution