### PR TITLE
feat: display video upload requirements

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState, useEffect, useCallback } from "react";
-import { Film, FolderOpen } from "lucide-react";
+import { Film, FolderOpen, Info } from "lucide-react";
 import LottiePlayer from "./LottiePlayer";
 import uploadAnim from "@/lib/lottie/upload.json";
 import { cn, formatBytes, formatDuration } from "@/lib/utils";
@@ -12,6 +12,82 @@ interface Props {
   currentFile: File | null;
   fileError: string;
   duration: number;
+}
+
+function UploadRequirements() {
+  return (
+    <section
+      aria-labelledby="upload-requirements-title"
+      className="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-[var(--shadow)]"
+    >
+      <div className="flex items-start gap-3">
+        <div
+          aria-hidden="true"
+          className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[var(--accent-muted)] text-film-600"
+        >
+          <Info size={16} />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <h3
+            id="upload-requirements-title"
+            className="font-heading text-sm font-semibold text-[var(--text)]"
+          >
+            Upload requirements
+          </h3>
+
+          <p className="mt-1 text-xs text-[var(--muted)]">
+            Check these details before choosing a video.
+          </p>
+
+          <dl className="mt-3 grid gap-3 sm:grid-cols-2">
+            <div>
+              <dt className="text-xs font-semibold text-[var(--text)]">
+                File size
+              </dt>
+              <dd className="mt-1 text-xs leading-5 text-[var(--muted)]">
+                Up to {formatBytes(MAX_FILE_SIZE)}. Files over{" "}
+                {formatBytes(WARNING_FILE_SIZE)} may process more slowly.
+              </dd>
+            </div>
+
+            <div>
+              <dt className="text-xs font-semibold text-[var(--text)]">
+                Supported formats
+              </dt>
+              <dd className="mt-1 text-xs leading-5 text-[var(--muted)]">
+                MP4, MOV, AVI, MKV and WebM.
+              </dd>
+            </div>
+
+            <div>
+              <dt className="text-xs font-semibold text-[var(--text)]">
+                Best compatibility
+              </dt>
+              <dd className="mt-1 text-xs leading-5 text-[var(--muted)]">
+                MP4 with H.264 video and AAC audio is recommended.
+              </dd>
+            </div>
+
+            <div>
+              <dt className="text-xs font-semibold text-[var(--text)]">
+                Processing
+              </dt>
+              <dd className="mt-1 text-xs leading-5 text-[var(--muted)]">
+                Processing happens locally in your browser using FFmpeg.wasm.
+              </dd>
+            </div>
+          </dl>
+
+          <p className="mt-3 border-t border-[var(--border)] pt-3 text-xs leading-5 text-[var(--muted)]">
+            Large, high-resolution or complex videos can exceed browser memory,
+            especially on devices with limited RAM. For smoother exports, close
+            unused tabs and use the recommended MP4 format.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
 }
 
 export default function FileUpload({
@@ -301,7 +377,14 @@ export default function FileUpload({
             {warning}
           </p>
         )}
-        {currentFile ? <FileInfo /> : <DropZone />}
+        {currentFile ? (
+          <FileInfo />
+        ) : (
+          <div className="space-y-3">
+            <DropZone />
+            <UploadRequirements />
+          </div>
+        )}
         <input
           ref={inputRef}
           type="file"


### PR DESCRIPTION
## Description

Adds a clear upload requirements section below the video upload area so users can understand the supported file limitations before selecting a video.

The section displays:

- Maximum file size of 2 GB
- Large-file warning threshold of 500 MB
- Supported video formats
- Recommended MP4, H.264 and AAC configuration
- Browser memory and FFmpeg.wasm processing limitations
- Recommendations for smoother exports

## Related Issue

Closes #1601

## Type of Contribution

- [x] New feature

## Participant Info

GitHub username: Roopathanushree  
Contribution level: Beginner

## Testing

- [x] The upload requirements appear before video selection
- [x] Existing upload interaction remains functional
- [x] Only `src/components/FileUpload.tsx` was modified
- [x] No unnecessary `console.log` statements added