### PR TITLE
fix: import isValidRecipe in useVideoEditor

### DIFF
--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
-import { EditRecipe, ExportResult, ExportStatus, MAX_FILE_SIZE, OverlayPosition, TimelineTrack, MultiTrackEditorState } from "@/lib/types";
+import { EditRecipe, ExportResult, ExportStatus, MAX_FILE_SIZE, OverlayPosition, TimelineTrack, MultiTrackEditorState, isValidRecipe } from "@/lib/types";
 import { DEFAULT_RECIPE, SPEED_STEPS } from "@/lib/constants";
 import { getPresetById } from "@/lib/presets";
 import { loadFFmpeg, exportVideo, terminateFFmpeg, FFmpegLoadError } from "@/lib/ffmpeg";


### PR DESCRIPTION
`main` is currently red. Two PRs merged during the backlog triage were textually independent but semantically conflicting:

- one added an `isValidRecipe(merged)` guard to `decodeRecipe`
- the other rewrote the `@/lib/types` import line in the same file without that symbol

Git merged both cleanly, and `bunx tsc --noEmit` fails with:

```
src/hooks/useVideoEditor.ts(156,10): error TS2552: Cannot find name 'isValidRecipe'.
```

`isValidRecipe` is exported from `@/lib/types` and the call site is correct — only the import was missing. One-line fix.

Verified locally: `tsc --noEmit` clean and `next build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhT15Aq6XUyhZSHa2HAh57