### PR TITLE
feat: add section dividers between editor control groups

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -480,6 +480,8 @@ export default function VideoEditor() {
                     />
                   </AccordionSection>
 
+                  <hr className="border-white/10 my-2" />
+
                   <AccordionSection
                     id="rotation"
                     icon={<RotateCw size={12} />}
@@ -490,6 +492,8 @@ export default function VideoEditor() {
                   >
                     <RotateControl recipe={recipe} onChange={updateRecipe} />
                   </AccordionSection>
+
+                  <hr className="border-white/10 my-2" />
 
                   <AccordionSection
                     id="text"
@@ -518,6 +522,9 @@ export default function VideoEditor() {
                   >
                     <AudioSpeedControl recipe={recipe} onChange={updateRecipe} />
                   </AccordionSection>
+
+                  <hr className="border-white/10 my-2" />
+
                   <Section
                     icon={<SlidersHorizontal size={12} />}
                     title="Adjustments"


### PR DESCRIPTION
## Description
Added subtle horizontal rule separators between each control section in VideoEditor.tsx for better visual grouping.

### Changes
- Added `<hr className="border-white/10 my-2" />` dividers between:
  - Trim and Rotation sections
  - Rotation and Text Overlay sections  
  - Audio & Speed and Adjustments sections
- Uses `border-white/10` for consistent dark theme styling
- No visual clutter, maintains clean aesthetic

## Related Issue
Closes #192

## Type of Change
- [x] Enhancement (non-breaking change which adds functionality)
