### PR TITLE
fix(storybook): make Lottie and onboarding-tour snapshots deterministic

### DIFF
--- a/src/components/ExportOverlay.stories.tsx
+++ b/src/components/ExportOverlay.stories.tsx
@@ -6,42 +6,38 @@ import ExportOverlay from "./ExportOverlay";
  * Full-screen modal shown while an export runs.
  *
  * ── Why this file works the way it does ──────────────────────────────────────
- * Two things inside this overlay move on their own, and a visual regression
- * service screenshots at an arbitrary moment:
+ * The overlay contains a <TipCarousel/> that rotates to the next tip every
+ * 6000ms. A visual regression service screenshots at an arbitrary moment, so
+ * that rotation reports a change on every build that reflects nothing but
+ * timing. It is marked data-chromatic="ignore": Chromatic still renders it,
+ * but excludes it from the diff.
  *
- *   1. a Lottie spinner, played by lottie-web via requestAnimationFrame
- *   2. a <TipCarousel/>, which rotates to the next tip every 6000ms
+ * The Lottie spinner used to need the same treatment. It no longer does —
+ * LottiePlayer checks isChromatic() and renders frame 0 statically, so the
+ * spinner is deterministic and stays fully covered by the diff.
  *
- * An earlier version of this file froze both by stubbing window.setInterval
- * and window.requestAnimationFrame. That was a mistake: Chromatic's capture
- * instrumentation relies on requestAnimationFrame to decide a story has
- * settled, so with rAF stubbed the story never signalled ready and all six
- * snapshots (3 stories x light/dark) failed with "took too long to load".
- *
- * Never stub browser globals to stabilise a snapshot. Instead, tell Chromatic
- * which regions to ignore: it excludes them from the diff but still renders
- * them, and the rest of the overlay — heading, progress bar, percentage,
- * cancel button — is compared normally.
+ * A word of warning from how this file got here: an earlier version froze both
+ * by stubbing window.setInterval and window.requestAnimationFrame. Chromatic's
+ * capture instrumentation relies on requestAnimationFrame to decide a story
+ * has settled, so starving it meant all six snapshots (3 stories x light/dark)
+ * failed with "took too long to load". Never stub browser globals to stabilise
+ * a snapshot.
  */
-const withMovingPartsIgnored: Decorator = (Story) => (
-  <IgnoreMovingParts>
+const withCarouselIgnored: Decorator = (Story) => (
+  <IgnoreCarousel>
     <Story />
-  </IgnoreMovingParts>
+  </IgnoreCarousel>
 );
 
-function IgnoreMovingParts({ children }: { children: React.ReactNode }) {
+function IgnoreCarousel({ children }: { children: React.ReactNode }) {
   React.useEffect(() => {
-    // .w-20.h-20        -> the wrapper LottiePlayer fills with its <svg>
-    // [class*=min-h-]   -> the TipCarousel root (min-h-[142px])
-    const selectors = ['.w-20.h-20', '[class*="min-h-[142px]"]'];
+    // The TipCarousel root, identified by its min-h-[142px] utility.
     const marked: Element[] = [];
 
-    for (const selector of selectors) {
-      document.querySelectorAll(selector).forEach((el) => {
-        el.setAttribute("data-chromatic", "ignore");
-        marked.push(el);
-      });
-    }
+    document.querySelectorAll('[class*="min-h-[142px]"]').forEach((el) => {
+      el.setAttribute("data-chromatic", "ignore");
+      marked.push(el);
+    });
 
     return () => marked.forEach((el) => el.removeAttribute("data-chromatic"));
   }, []);
@@ -53,7 +49,7 @@ const meta = {
   title: "Editor/Modals/ExportOverlay",
   component: ExportOverlay,
   parameters: { layout: "fullscreen" },
-  decorators: [withMovingPartsIgnored],
+  decorators: [withCarouselIgnored],
   args: {
     // With a real timestamp the component starts a 1s interval and renders
     // Date.now() - exportStartedAt as elapsed time, which would differ between

--- a/src/components/LottiePlayer.tsx
+++ b/src/components/LottiePlayer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import isChromatic from "chromatic/isChromatic";
 
 interface Props {
   animationData: object;
@@ -21,6 +22,16 @@ export default function LottiePlayer({
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // lottie-web plays through requestAnimationFrame, which no amount of CSS can
+  // freeze. Chromatic screenshots at an arbitrary moment, so a playing
+  // animation reports a visual change on every build that has nothing to do
+  // with the code. Rendering the first frame statically keeps snapshots
+  // deterministic while still exercising the component.
+  //
+  // isChromatic() is false everywhere except inside Chromatic's renderer, so
+  // this has no effect on the app or on local Storybook.
+  const shouldAutoplay = autoplay && !isChromatic();
+
   useEffect(() => {
     if (!containerRef.current) return;
     let cancelled = false;
@@ -33,7 +44,7 @@ export default function LottiePlayer({
         container: containerRef.current,
         renderer: "svg",
         loop,
-        autoplay,
+        autoplay: shouldAutoplay,
         animationData,
       });
     }).catch((error) => {
@@ -47,7 +58,7 @@ export default function LottiePlayer({
       anim?.destroy();
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [animationData, loop, autoplay]);
+  }, [animationData, loop, shouldAutoplay]);
 
   return (
     <>

--- a/src/components/VideoEditor.stories.tsx
+++ b/src/components/VideoEditor.stories.tsx
@@ -8,8 +8,14 @@ import VideoEditor from "./VideoEditor";
  *
  * It renders its pre-upload state here. VideoEditor owns real state via
  * useVideoEditor, but FFmpeg.wasm is lazy-loaded and only touched on export,
- * so mounting it is cheap and side-effect free. Without a file the editor
- * shows the upload screen and its surrounding chrome, which is deterministic.
+ * so mounting it is cheap and side-effect free.
+ *
+ * The onboarding tour is marked complete before the story renders. Two
+ * reasons: it measures its target element and animates a spotlight over a
+ * chain of timeouts, so a screenshot taken at an arbitrary moment catches it
+ * mid-move and reports a change that is purely timing; and the tour's dimming
+ * overlay covers most of the editor, which is precisely what this story exists
+ * to show.
  *
  * Interacting further (choosing a file, exporting) needs real media and a
  * ~30 MB WASM download, so those paths are covered by the individual control
@@ -20,8 +26,11 @@ const meta = {
   component: VideoEditor,
   parameters: {
     layout: "fullscreen",
-    // The shell is tall; give Chromatic the full page rather than a viewport crop.
     chromatic: { delay: 300 },
+  },
+  beforeEach: async () => {
+    // Matches TOUR_KEY in OnboardingTour.tsx.
+    window.localStorage.setItem("reframe_onboarding_complete", "1");
   },
 } satisfies Meta<typeof VideoEditor>;
 


### PR DESCRIPTION
Follow-up to #1749 / #1750. Removes the false-positive visual diffs that were left in the Chromatic setup.

## The problem

I swept all 50 stories — capturing each twice at different moments and comparing pixels — and **10 were unstable**. They correlated perfectly with a single cause: **every unstable story renders a Lottie animation** (VideoEditor via FileUpload).

| Stories | Unstable bytes | Lottie |
|---|---|---|
| `ExportOverlay` ×3 | ~19,000 | spinner |
| `FileUpload` ×3 | 275–1,295 | upload arrow |
| `DownloadResult` ×3 | 31–80 | success tick |
| `VideoEditor` ×1 | 531 | via `FileUpload` |

`lottie-web` plays through `requestAnimationFrame`, which CSS cannot freeze — so `.storybook/preview.css` never touched them. Chromatic screenshots at an arbitrary moment, so these would report changes on builds where nothing changed. **A check that cries wolf trains people to accept diffs without reading them**, which quietly defeats the point of having it.

## The fix

`LottiePlayer` now checks `isChromatic()` and renders **frame 0 statically** instead of autoplaying — Chromatic's documented approach for JS-driven animation. `isChromatic()` is false everywhere except inside Chromatic's renderer, so the app and local Storybook are unaffected.

`VideoEditor`'s story was unstable for a second, unrelated reason: it renders `OnboardingTour`, which measures its target and animates a spotlight across a chain of timeouts. The story now marks the tour complete in `localStorage` before rendering. That removes the timing dependency **and gives a better snapshot** — the tour's dimming overlay was covering most of the editor this story exists to show.

With the spinner deterministic, `ExportOverlay` no longer needs to hide it from the diff. Only the 6s `TipCarousel` stays ignored, so **the spinner is back under visual coverage**.

## Verification

Re-ran the sweep under a **Chromatic user-agent** — the real detection path, rather than the URL param, which Storybook rewrites away:

**47 / 50 stories pixel-identical.** The 3 exceptions are `ExportOverlay`'s, each differing by an identical 18,568 bytes, entirely inside the `TipCarousel` region already marked `data-chromatic="ignore"` — so Chromatic does not diff it. Effectively 50/50.

`bun run build`, `bunx tsc --noEmit` and `bun run lint` all pass.

## Expect changed baselines

Frozen animations mean the affected snapshots will differ from the current baseline. Those changes are **expected and should be accepted once** — after that they should stop moving.

## One trade-off worth naming

This imports `chromatic/isChromatic`, a devDependency, into app code. It adds ~200 bytes to a 1.4 MB bundle and is inert at runtime, but it does mean a production-only install would fail to build. CI installs all dependencies, so it's theoretical here — happy to inline the four-line check instead if you'd rather keep app code free of test tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhT15Aq6XUyhZSHa2HAh57