### PR TITLE
ci(chromatic): allow re-running fork visual review via a label

### DIFF
--- a/.github/workflows/chromatic-fork-build.yml
+++ b/.github/workflows/chromatic-fork-build.yml
@@ -22,6 +22,11 @@ name: 🎨 Chromatic Fork — Build
 on:
   pull_request:
     branches: [main]
+    # `labeled` lets a maintainer re-run visual review on a fork PR on demand
+    # by applying the `visual-review` label, without asking the contributor to
+    # push a no-op commit. It is also the only way to exercise this workflow
+    # end-to-end without waiting for a fresh fork PR to arrive.
+    types: [opened, synchronize, reopened, labeled]
 
 # No secrets are used here, and the token is read-only.
 permissions:
@@ -36,10 +41,19 @@ jobs:
     name: Build Storybook (fork)
     runs-on: ubuntu-latest
 
-    # Same-repo PRs already get a full Chromatic run from chromatic.yml, which
-    # can use the secret directly. Restricting this to forks avoids building
-    # and snapshotting every same-repo PR twice.
-    if: github.event.pull_request.head.repo.full_name != github.repository
+    # Two gates:
+    #
+    #  * forks only — same-repo PRs already get a full Chromatic run from
+    #    chromatic.yml, which can use the secret directly, so building here too
+    #    would snapshot every same-repo PR twice.
+    #
+    #  * on a `labeled` event, only the `visual-review` label counts. Without
+    #    this, the auto-labeller applying `gssoc'26`, `level:*` and `type:*` to
+    #    every new PR would fire a duplicate build per label.
+    if: >-
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      (github.event.action != 'labeled' ||
+       github.event.label.name == 'visual-review')
 
     steps:
       - name: Checkout PR code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -378,6 +378,10 @@ You'll see up to three checks:
 accepting, that is a maintainer's call, not a problem with your branch — a
 maintainer accepts or rejects each change in the Chromatic UI.
 
+**Maintainers:** to re-run visual review on a fork PR without asking the
+contributor to push again, apply the `visual-review` label. Fork PRs are built
+automatically on open and on every push; the label is for re-running on demand.
+
 If your PR touches a component, please **add or update its story** in
 `src/components/<Component>.stories.tsx`. Stories are what Chromatic can see;
 a change with no story gets no visual review.


### PR DESCRIPTION
Follow-up to #1750. That PR added the fork visual-review path — but **it has never actually executed.**

It only fires on a fork PR event, and no fork PR has been opened or pushed since it merged. The `chromatic-fork-publish` workflow has zero runs. That's uncomfortable for a workflow that holds `CHROMATIC_PROJECT_TOKEN`: the artifact handoff between the two workflows is unverified.

## What this adds

`labeled` joins the trigger types, so applying the **`visual-review`** label to a fork PR runs visual review on it. Two uses:

- **Maintainers** can re-run visual review on a stale fork PR without asking the contributor to push a no-op commit.
- **The path becomes testable on demand**, rather than only when a fresh fork PR happens to arrive.

The job condition ignores every label except `visual-review` — the auto-labeller applies `gssoc'26`, `level:*` and `type:*` to every new PR, and each would otherwise fire a duplicate build.

The `visual-review` label has been created on the repo.

## What is already verified

Not everything here is untested. On #1750 the fork-build job showed `completed/skipped` for a same-repo PR, and `chromatic-fork-publish` correctly did **not** fire — so the fork-only gating and the "don't publish when the build skipped" behaviour are both confirmed working.

What remains unverified is the fork-specific half: artifact upload → cross-workflow download → publish with `CHROMATIC_SHA` / `CHROMATIC_BRANCH` / `CHROMATIC_SLUG`.

## Chicken-and-egg, again

For `pull_request` events GitHub takes the workflow from the PR's **merge ref**, so this label trigger only works once it is on `main` — same rollout constraint as #1750 itself.

**Once merged, apply `visual-review` to any open fork PR and the whole chain runs.** There are 192 to choose from. Happy to do that and report the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhT15Aq6XUyhZSHa2HAh57