### PR TITLE
docs: remove unresolved merge conflict markers from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@
     <img src="https://github.com/Sneha079-codes/reframe/actions/workflows/main.yml/badge.svg">
   </a>
 </p>
-<<<<<<< HEAD
-=======
 
 </div>
 
@@ -58,7 +56,6 @@
 ![FFmpeg](https://img.shields.io/badge/FFmpeg.wasm-0.12.10-green?style=flat-square&logo=ffmpeg)
 ![Lucide](https://img.shields.io/badge/Lucide_React-latest-orange?style=flat-square)
 ![Lottie](https://img.shields.io/badge/Lottie_Web-latest-purple?style=flat-square)
->>>>>>> f3b7ebeac4ae0b71305509eb79f9285c952b467a
 
 </div>
 


### PR DESCRIPTION
## What changed
Removed three unresolved git merge conflict markers (`<<<<<<< HEAD`, `=======`, `>>>>>>> f3b7ebe...`) from README.md that were accidentally committed and rendered as literal text on the GitHub README page.

## Why
The conflict markers appeared between the badge section and the "Built With" section, making them visible to anyone viewing the repository README. This is a documentation quality issue.

## How I checked
- Verified the diff only removes the three conflict marker lines
- Confirmed no remaining conflict markers via grep
- Checked that the `<div>` open/close structure is still correct after the fix