### PR TITLE
chore: update repo references for reframe-oss org, credit Chromatic in README

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,14 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💡 Feature Request or Idea
-    url: https://github.com/magic-peach/reframe/discussions/categories/ideas
+    url: https://github.com/reframe-oss/reframe/discussions/categories/ideas
     about: Share your idea in Discussions before opening an issue
   - name: 🙋 Ask a Question
-    url: https://github.com/magic-peach/reframe/discussions/categories/q-a
+    url: https://github.com/reframe-oss/reframe/discussions/categories/q-a
     about: Use Discussions for questions — not Issues
   - name: 🐛 Report a Bug
-    url: https://github.com/magic-peach/reframe/discussions/categories/bug-reports
+    url: https://github.com/reframe-oss/reframe/discussions/categories/bug-reports
     about: Report bugs in Discussions first
   - name: ⭐ Star the repo
-    url: https://github.com/magic-peach/reframe/stargazers
+    url: https://github.com/reframe-oss/reframe/stargazers
     about: If Reframe helped you, please star the repo!

--- a/.github/workflows/claude-manager.yml
+++ b/.github/workflows/claude-manager.yml
@@ -38,7 +38,7 @@ jobs:
           allowed_non_write_users: "*"
           trigger_phrase: ""
           direct_prompt: |
-            You are the automated manager for magic-peach/reframe, a GSSoC'26 open-source project.
+            You are the automated manager for reframe-oss/reframe, a GSSoC'26 open-source project.
             Follow the rules in CLAUDE.md exactly.
 
             Current PR: #${{ github.event.pull_request.number }}
@@ -78,7 +78,7 @@ jobs:
           allowed_non_write_users: "*"
           trigger_phrase: ""
           direct_prompt: |
-            You are the automated manager for magic-peach/reframe, a GSSoC'26 open-source project.
+            You are the automated manager for reframe-oss/reframe, a GSSoC'26 open-source project.
             Follow the rules in CLAUDE.md exactly.
 
             A new issue was opened: #${{ github.event.issue.number }}
@@ -127,7 +127,7 @@ jobs:
           allowed_non_write_users: "*"
           trigger_phrase: ""
           direct_prompt: |
-            You are the automated manager for magic-peach/reframe, a GSSoC'26 open-source project.
+            You are the automated manager for reframe-oss/reframe, a GSSoC'26 open-source project.
             Follow the rules in CLAUDE.md exactly.
 
             A comment was posted on issue #${{ github.event.issue.number }} by @${{ github.event.comment.user.login }}.

--- a/.github/workflows/issue-assignment-bot.yml
+++ b/.github/workflows/issue-assignment-bot.yml
@@ -131,7 +131,7 @@ jobs:
             // Enforce single assignee: reject if anyone is already assigned
             if (currentAssignees.length > 0) {
               await postComment(
-                `Hey @${commenter}, this issue is already assigned to @${currentAssignees[0]}. Please pick another issue or wait for it to become available. You can browse open unassigned issues here: https://github.com/magic-peach/reframe/issues?q=is%3Aissue+is%3Aopen+no%3Aassignee`
+                `Hey @${commenter}, this issue is already assigned to @${currentAssignees[0]}. Please pick another issue or wait for it to become available. You can browse open unassigned issues here: https://github.com/reframe-oss/reframe/issues?q=is%3Aissue+is%3Aopen+no%3Aassignee`
               );
               return;
             }

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,7 +26,7 @@ jobs:
             If you're still interested in working on this, please leave a comment! 
             For GSSoC'26 contributors: make sure to keep your assigned issues active.
 
-            ⭐ [Star Reframe](https://github.com/magic-peach/reframe) if you find it useful!
+            ⭐ [Star Reframe](https://github.com/reframe-oss/reframe) if you find it useful!
           stale-pr-message: |
             👋 This PR has been inactive for **21 days**. It will be automatically closed in 14 days if there's no further activity.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ When a PR has merge conflicts, resolve them automatically **before** doing anyth
 
 2. **Clone and resolve locally:**
    ```bash
-   git clone https://github.com/magic-peach/reframe.git
+   git clone https://github.com/reframe-oss/reframe.git
    cd reframe
    git fetch origin
    git checkout <pr-branch>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-> ⭐ **If Reframe helped you, [star the repo](https://github.com/magic-peach/reframe)** — it helps more people discover it!
+> ⭐ **If Reframe helped you, [star the repo](https://github.com/reframe-oss/reframe)** — it helps more people discover it!
 >
-> 💬 **Have a question or idea?** Head to [Discussions](https://github.com/magic-peach/reframe/discussions) instead of opening an issue.
+> 💬 **Have a question or idea?** Head to [Discussions](https://github.com/reframe-oss/reframe/discussions) instead of opening an issue.
 >
-> 🟢 **Ready to contribute?** Check out our [Good First Issues](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3A%22good+first+issue%22) — perfect for first-time contributors!
+> 🟢 **Ready to contribute?** Check out our [Good First Issues](https://github.com/reframe-oss/reframe/issues?q=is%3Aopen+label%3A%22good+first+issue%22) — perfect for first-time contributors!
 
 ***
 
@@ -14,11 +14,11 @@ Whether you're fixing a typo, adding a feature, improving accessibility, or writ
 
 ---
 
-## 👋 Want to contribute to magic-peach/reframe?
+## 👋 Want to contribute to reframe-oss/reframe?
 
 If you have a bug or an idea, read this guide before opening an issue.
 
-If you're ready to tackle some open issues, **[we've collected some good first issues for you](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3A%22good+first+issue%22)**.
+If you're ready to tackle some open issues, **[we've collected some good first issues for you](https://github.com/reframe-oss/reframe/issues?q=is%3Aopen+label%3A%22good+first+issue%22)**.
 
 ---
 
@@ -57,7 +57,7 @@ git clone https://github.com/<your-username>/reframe.git
 cd reframe
 
 # 3. Add the upstream remote
-git remote add upstream https://github.com/magic-peach/reframe.git
+git remote add upstream https://github.com/reframe-oss/reframe.git
 ```
 
 ---
@@ -230,14 +230,14 @@ We have **300+ open issues** across all skill levels:
 
 | Level | Where to look |
 |-------|--------------|
-| 🟢 **Beginner** | [`good first issue`](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3A%22good+first+issue%22) label — 100+ beginner tasks |
-| 🟡 **Intermediate** | [`enhancement`](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3Aenhancement) label |
-| 🔴 **Advanced** | [`feature`](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3Afeature) label |
-| 🐛 **Bug Fixes** | [`bug`](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3Abug) label |
-| ♿ **Accessibility** | [`accessibility`](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3Aaccessibility) label |
-| 📝 **Documentation** | [`documentation`](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3Adocumentation) label |
-| 🔒 **Security** | [`security`](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3Asecurity) label |
-| ⚡ **Performance** | [`performance`](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3Aperformance) label |
+| 🟢 **Beginner** | [`good first issue`](https://github.com/reframe-oss/reframe/issues?q=is%3Aopen+label%3A%22good+first+issue%22) label — 100+ beginner tasks |
+| 🟡 **Intermediate** | [`enhancement`](https://github.com/reframe-oss/reframe/issues?q=is%3Aopen+label%3Aenhancement) label |
+| 🔴 **Advanced** | [`feature`](https://github.com/reframe-oss/reframe/issues?q=is%3Aopen+label%3Afeature) label |
+| 🐛 **Bug Fixes** | [`bug`](https://github.com/reframe-oss/reframe/issues?q=is%3Aopen+label%3Abug) label |
+| ♿ **Accessibility** | [`accessibility`](https://github.com/reframe-oss/reframe/issues?q=is%3Aopen+label%3Aaccessibility) label |
+| 📝 **Documentation** | [`documentation`](https://github.com/reframe-oss/reframe/issues?q=is%3Aopen+label%3Adocumentation) label |
+| 🔒 **Security** | [`security`](https://github.com/reframe-oss/reframe/issues?q=is%3Aopen+label%3Asecurity) label |
+| ⚡ **Performance** | [`performance`](https://github.com/reframe-oss/reframe/issues?q=is%3Aopen+label%3Aperformance) label |
 
 **Before claiming an issue:**
 1. Check if it already has an assignee — if so, pick a different one
@@ -423,8 +423,8 @@ Reframe is an **official GirlScript Summer of Code 2026 project**!
 
 ### Getting Started as a GSSoC Contributor
 
-1. Browse issues labeled [`gssoc'26`](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3A%22gssoc%2726%22)
-2. Start with [`good first issue`](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3A%22gssoc%2726%22) if you're new to open source
+1. Browse issues labeled [`gssoc'26`](https://github.com/reframe-oss/reframe/issues?q=is%3Aopen+label%3A%22gssoc%2726%22)
+2. Start with [`good first issue`](https://github.com/reframe-oss/reframe/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3A%22gssoc%2726%22) if you're new to open source
 3. Comment `/assign` on the issue — our bot will assign it to you instantly, no maintainer needed
 4. Submit your PR within **5 days** and remember to link it with `Fixes #issue_number`
 
@@ -440,8 +440,8 @@ Reframe is an **official GirlScript Summer of Code 2026 project**!
 
 ## Questions?
 
-- **Found a bug?** → [Open a bug report](https://github.com/magic-peach/reframe/issues/new?labels=bug)
-- **Have a feature idea?** → [Open a feature request](https://github.com/magic-peach/reframe/issues/new?labels=feature)
+- **Found a bug?** → [Open a bug report](https://github.com/reframe-oss/reframe/issues/new?labels=bug)
+- **Have a feature idea?** → [Open a feature request](https://github.com/reframe-oss/reframe/issues/new?labels=feature)
 - **Stuck on an issue?** → Comment on the issue and tag `@magic-peach`
 
 ---

--- a/PHASE_1_MVP.md
+++ b/PHASE_1_MVP.md
@@ -1,6 +1,6 @@
 # Multi-Track Timeline: Phase 1 MVP
 
-**Issue**: [#1204 - Multi-Track Non-Linear Timeline Architecture](https://github.com/magic-peach/reframe/issues/1204)
+**Issue**: [#1204 - Multi-Track Non-Linear Timeline Architecture](https://github.com/reframe-oss/reframe/issues/1204)
 
 **Status**: Phase 1 MVP - Foundation architecture complete, ready for integration
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 ### No login. No uploads. No ads. 100% private.
 
 <p align="center">
-  <a href="https://github.com/magic-peach/reframe/stargazers">
-    <img src="https://img.shields.io/github/stars/magic-peach/reframe?style=flat-square&logo=github&label=Stars&color=yellow&logoColor=white">
+  <a href="https://github.com/reframe-oss/reframe/stargazers">
+    <img src="https://img.shields.io/github/stars/reframe-oss/reframe?style=flat-square&logo=github&label=Stars&color=yellow&logoColor=white">
   </a>
-  <a href="https://github.com/magic-peach/reframe/network/members">
-    <img src="https://img.shields.io/github/forks/magic-peach/reframe?style=flat-square&logo=github">
+  <a href="https://github.com/reframe-oss/reframe/network/members">
+    <img src="https://img.shields.io/github/forks/reframe-oss/reframe?style=flat-square&logo=github">
   </a>
-  <a href="https://github.com/magic-peach/reframe/issues">
-    <img src="https://img.shields.io/github/issues/magic-peach/reframe?style=flat-square&logo=github&label=Issues&color=E53E3E&logoColor=white">
+  <a href="https://github.com/reframe-oss/reframe/issues">
+    <img src="https://img.shields.io/github/issues/reframe-oss/reframe?style=flat-square&logo=github&label=Issues&color=E53E3E&logoColor=white">
   </a>
 </p>
 
@@ -104,7 +104,7 @@ Everything stays on your device. No servers. No tracking. No login.
 ### Installation
 
 ```bash
-git clone https://github.com/magic-peach/reframe.git
+git clone https://github.com/reframe-oss/reframe.git
 cd reframe
 bun install
 ```
@@ -407,19 +407,19 @@ Reframe is an **official project in GirlScript Summer of Code (GSSoC) 2026**! We
 
 | Level               | Label                                                                                                          | Description                                                                        |
 | ------------------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| 🟢 **Beginner**     | [`good first issue`](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3A%22good+first+issue%22) | Small, well-defined tasks — perfect if this is your first open source contribution |
-| 🟡 **Intermediate** | [`enhancement`](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3Aenhancement)                 | Feature improvements and UX enhancements                                           |
-| 🔴 **Advanced**     | [`feature`](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3Afeature)                         | New features requiring deeper understanding of FFmpeg/WASM                         |
-| 🔵 **Any Level**    | [`documentation`](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3Adocumentation)             | Docs, guides, and README improvements                                              |
-| ♿ **Any Level**    | [`accessibility`](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3Aaccessibility)             | Making Reframe usable for everyone                                                 |
+| 🟢 **Beginner**     | [`good first issue`](https://github.com/reframe-oss/reframe/issues?q=is%3Aopen+label%3A%22good+first+issue%22) | Small, well-defined tasks — perfect if this is your first open source contribution |
+| 🟡 **Intermediate** | [`enhancement`](https://github.com/reframe-oss/reframe/issues?q=is%3Aopen+label%3Aenhancement)                 | Feature improvements and UX enhancements                                           |
+| 🔴 **Advanced**     | [`feature`](https://github.com/reframe-oss/reframe/issues?q=is%3Aopen+label%3Afeature)                         | New features requiring deeper understanding of FFmpeg/WASM                         |
+| 🔵 **Any Level**    | [`documentation`](https://github.com/reframe-oss/reframe/issues?q=is%3Aopen+label%3Adocumentation)             | Docs, guides, and README improvements                                              |
+| ♿ **Any Level**    | [`accessibility`](https://github.com/reframe-oss/reframe/issues?q=is%3Aopen+label%3Aaccessibility)             | Making Reframe usable for everyone                                                 |
 
-**[→ Browse all GSSoC'26 issues](https://github.com/magic-peach/reframe/issues?q=is%3Aopen+label%3A%22gssoc%2726%22)**
+**[→ Browse all GSSoC'26 issues](https://github.com/reframe-oss/reframe/issues?q=is%3Aopen+label%3A%22gssoc%2726%22)**
 
 ---
 
 ### How to Contribute
 
-1. **Find an issue** — Browse [open issues](https://github.com/magic-peach/reframe/issues) or pick one from the table above
+1. **Find an issue** — Browse [open issues](https://github.com/reframe-oss/reframe/issues) or pick one from the table above
 2. **Comment on the issue** — Say you'd like to work on it so we don't duplicate effort
 3. **Fork the repo** — Click the Fork button at the top right
 4. **Create a branch** — `git checkout -b feat/your-feature-name`
@@ -440,9 +440,17 @@ Reframe processes all videos **100% client-side**. Your video files are never up
 
 Thanks to all the amazing people who have contributed to Reframe!
 
-[![Contributors](https://contrib.rocks/image?repo=magic-peach/reframe)](https://github.com/magic-peach/reframe/graphs/contributors)
+[![Contributors](https://contrib.rocks/image?repo=reframe-oss/reframe)](https://github.com/reframe-oss/reframe/graphs/contributors)
 
 We welcome contributions of all kinds — code, documentation, design, and feedback. Check out our [Contributing Guide](CONTRIBUTING.md) to get started.
+
+---
+
+## Thanks
+
+<a href="https://www.chromatic.com/"><img src="https://user-images.githubusercontent.com/321738/84662277-e3db4f80-af1b-11ea-88f5-91d67a5e59f6.png" width="153" height="30" alt="Chromatic" /></a>
+
+Thanks to [Chromatic](https://www.chromatic.com/) for providing the visual testing platform that helps us review UI changes and catch visual regressions.
 
 ---
 
@@ -454,7 +462,7 @@ MIT License — See [LICENSE](LICENSE) for details.
 
 <div align="center">
 
-**If Reframe saved you time, please [⭐ star the repo](https://github.com/magic-peach/reframe) — it helps others discover it!**
+**If Reframe saved you time, please [⭐ star the repo](https://github.com/reframe-oss/reframe) — it helps others discover it!**
 
 Made with ❤️ for everyone who just wants to edit a video without the hassle.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ If you discover a security vulnerability in Reframe, please **do not** open a pu
 
 Instead, report it using one of the following methods:
 
-- **GitHub Issue (labeled `security`):** Open a [new issue](https://github.com/magic-peach/reframe/issues/new) and apply the `security` label. For sensitive details, use a private channel below.
+- **GitHub Issue (labeled `security`):** Open a [new issue](https://github.com/reframe-oss/reframe/issues/new) and apply the `security` label. For sensitive details, use a private channel below.
 - **Email:** Contact the maintainer directly at [maintainer email] with the subject line `[SECURITY] Reframe Vulnerability Report`.
 
 ### What to Include in Your Report

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ export default function Home() {
   return (
     <>
       <a
-        href="https://github.com/magic-peach/reframe"
+        href="https://github.com/reframe-oss/reframe"
         target="_blank"
         rel="noopener noreferrer"
         aria-label="View Reframe on GitHub"

--- a/src/components/DownloadResult.tsx
+++ b/src/components/DownloadResult.tsx
@@ -10,7 +10,7 @@ import successAnim from "@/lib/lottie/success.json";
 import { cn } from "@/lib/utils";
 
 const SHARE_TWEET_TEXT =
-  "I just edited my video with @reframevideo — free browser-based video editor! Check it out: https://github.com/magic-peach/reframe";
+  "I just edited my video with @reframevideo — free browser-based video editor! Check it out: https://github.com/reframe-oss/reframe";
 
 function formatExportDuration(ms: number): string {
   const totalSeconds = Math.max(0, Math.round(ms / 1000));

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -76,7 +76,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
                             </button>
 
                             <a
-                                href="https://github.com/magic-peach/reframe/issues"
+                                href="https://github.com/reframe-oss/reframe/issues"
                                 target="_blank"
                                 rel="noreferrer"
                                 className="rounded-lg border px-4 py-2 transition hover:opacity-80"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -59,7 +59,7 @@ export default function Footer() {
 
           <nav className="flex flex-col gap-3 text-sm">
             <a
-              href="https://github.com/magic-peach/reframe"
+              href="https://github.com/reframe-oss/reframe"
               target="_blank"
               rel="noopener noreferrer"
               aria-label="GitHub repository"
@@ -133,7 +133,7 @@ export default function Footer() {
 
               {[
                 {
-                  href: "https://github.com/magic-peach/reframe",
+                  href: "https://github.com/reframe-oss/reframe",
                   icon: <Github size={18} />,
                   label: "GitHub",
                 },


### PR DESCRIPTION
## Summary
- Repo was transferred from the `magic-peach` personal account to the `reframe-oss` org. Updates every hardcoded `magic-peach/reframe` link/clone URL to `reframe-oss/reframe` across README, CONTRIBUTING, SECURITY, PHASE_1_MVP, CLAUDE.md's merge-conflict automation instructions, GitHub workflows, the issue template config, and in-app footer/error/share links.
- Adds a "Thanks" section to the README crediting Chromatic for the visual testing platform, per their sponsorship-mention request.

## Not in scope here (flagged separately to the maintainer)
- `SNYK_TOKEN` is not yet set as a repo secret — the Snyk workflow (on `feat/snyk-and-netlify`, #1753) will fail once merged until that's added from the Snyk dashboard.
- Netlify site needs to be (re)connected to the `reframe-oss` org in the Netlify dashboard — no code changes needed for that.

## Test plan
- [x] `grep -rn "magic-peach/reframe"` returns no results outside the intentional `@magic-peach` person-tag in CONTRIBUTING.md
- [ ] Visual check of the new README "Thanks" section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5gqyU5QKQtLAza6hL6dXv