### PR TITLE
fix(share): replace btoa/atob with encodeURIComponent for Unicode support #1660

### DIFF
--- a/src/components/VideoEditor.tsx
+++ b/src/components/VideoEditor.tsx
@@ -17,13 +17,22 @@ import FormatSelector from "./FormatSelector";
 import ExportSettings from "./ExportSettings";
 import ExportOverlay from "./ExportOverlay";
 import DownloadResult from "./DownloadResult";
-import ImageOverlay from "./ImageOverlay"
+import ImageOverlay from "./ImageOverlay";
 import { getPresetById } from "@/lib/presets";
 
 import { cn } from "@/lib/utils";
 import {
-  Layers, Crop, Scissors, RotateCw, Volume2, Type,
-  SlidersHorizontal, Zap, AlertTriangle, Github, Copy
+  Layers,
+  Crop,
+  Scissors,
+  RotateCw,
+  Volume2,
+  Type,
+  SlidersHorizontal,
+  Zap,
+  AlertTriangle,
+  Github,
+  Copy,
 } from "lucide-react";
 import OnboardingTour from "./OnboardingTour";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
@@ -38,10 +47,7 @@ interface SectionProps {
 
 function Section({ icon, title, children, delay = 0 }: SectionProps) {
   return (
-    <div
-      className="space-y-3 animate-fade-in"
-      style={{ animationDelay: `${delay}ms` }}
-    >
+    <div className="space-y-3 animate-fade-in" style={{ animationDelay: `${delay}ms` }}>
       <div className="flex items-center gap-2">
         <span className="text-film-500 opacity-80">{icon}</span>
         <h3 className="text-sm font-heading font-bold uppercase tracking-widest text-[var(--muted)]">
@@ -82,8 +88,12 @@ function AccordionSection({
         className="w-full flex items-center justify-between px-3 py-2 text-left hover:bg-[var(--border)] transition-all duration-200 group rounded-lg"
       >
         <div className="flex items-center gap-2">
-          <span className="text-film-500 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-transform duration-200">{icon}</span>
-          <span className="text-sm font-heading font-bold uppercase tracking-widest text-[var(--muted)]">{title}</span>
+          <span className="text-film-500 opacity-80 group-hover:opacity-100 group-hover:scale-110 transition-transform duration-200">
+            {icon}
+          </span>
+          <span className="text-sm font-heading font-bold uppercase tracking-widest text-[var(--muted)]">
+            {title}
+          </span>
         </div>
         <svg
           aria-hidden="true"
@@ -91,18 +101,24 @@ function AccordionSection({
           height="12"
           viewBox="0 0 12 12"
           fill="none"
-          className={cn("text-[var(--muted)] transition-transform duration-200", isOpen && "rotate-180")}
+          className={cn(
+            "text-[var(--muted)] transition-transform duration-200",
+            isOpen && "rotate-180"
+          )}
         >
-          <path d="M2 4l4 4 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          <path
+            d="M2 4l4 4 4-4"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
         </svg>
       </button>
 
       <div
         id={`${id}-panel`}
-        className={cn(
-          "transition-all duration-200",
-          isOpen ? "block" : "hidden"
-        )}
+        className={cn("transition-all duration-200", isOpen ? "block" : "hidden")}
       >
         <div className="px-3 pt-3 pb-0">{children}</div>
       </div>
@@ -124,45 +140,55 @@ function KeyboardShortcutsPanel() {
   const [open, setOpen] = useState(false);
 
   const shortcuts: { keys: React.ReactNode[]; label: string }[] = [
-  {
-    keys: [
-      <Kbd key="ctrl">Ctrl</Kbd>,
-      <span key="plus1" className="text-[var(--muted)] text-xs">+</span>,
-      <Kbd key="shift">Shift</Kbd>,
-      <span key="plus2" className="text-[var(--muted)] text-xs">+</span>,
-      <Kbd key="e">E</Kbd>
-    ],
-    label: "Export video",
-  },
-  {
-    keys: [<Kbd key="m">M</Kbd>],
-    label: "Toggle audio mute",
-  },
-  {
-    keys: [<Kbd key="r">R</Kbd>],
-    label: "Reset all settings",
-  },
-  {
-    keys: [<Kbd key="esc">Esc</Kbd>],
-    label: "Cancel export",
-  },
-  {
-    keys: [<Kbd key="1">1</Kbd>, <span key="dash" className="text-[var(--muted)] text-xs">–</span>, <Kbd key="9">9</Kbd>],
-    label: "Switch preset by index",
-  },
-  {
-    keys: [<Kbd key="question">?</Kbd>],
-    label: "Toggle this panel",
-  },
-  {
-    keys: [<Kbd key="i">I</Kbd>],
-    label: "Set trim in point",
-  },
-  {
-    keys: [<Kbd key="o">O</Kbd>],
-    label: "Set trim out point",
-  },
-];
+    {
+      keys: [
+        <Kbd key="ctrl">Ctrl</Kbd>,
+        <span key="plus1" className="text-[var(--muted)] text-xs">
+          +
+        </span>,
+        <Kbd key="shift">Shift</Kbd>,
+        <span key="plus2" className="text-[var(--muted)] text-xs">
+          +
+        </span>,
+        <Kbd key="e">E</Kbd>,
+      ],
+      label: "Export video",
+    },
+    {
+      keys: [<Kbd key="m">M</Kbd>],
+      label: "Toggle audio mute",
+    },
+    {
+      keys: [<Kbd key="r">R</Kbd>],
+      label: "Reset all settings",
+    },
+    {
+      keys: [<Kbd key="esc">Esc</Kbd>],
+      label: "Cancel export",
+    },
+    {
+      keys: [
+        <Kbd key="1">1</Kbd>,
+        <span key="dash" className="text-[var(--muted)] text-xs">
+          –
+        </span>,
+        <Kbd key="9">9</Kbd>,
+      ],
+      label: "Switch preset by index",
+    },
+    {
+      keys: [<Kbd key="question">?</Kbd>],
+      label: "Toggle this panel",
+    },
+    {
+      keys: [<Kbd key="i">I</Kbd>],
+      label: "Set trim in point",
+    },
+    {
+      keys: [<Kbd key="o">O</Kbd>],
+      label: "Set trim out point",
+    },
+  ];
 
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] animate-fade-in overflow-hidden">
@@ -183,9 +209,18 @@ function KeyboardShortcutsPanel() {
           height="12"
           viewBox="0 0 12 12"
           fill="none"
-          className={cn("text-[var(--muted)] transition-transform duration-200", open && "rotate-180")}
+          className={cn(
+            "text-[var(--muted)] transition-transform duration-200",
+            open && "rotate-180"
+          )}
         >
-          <path d="M2 4l4 4 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          <path
+            d="M2 4l4 4 4-4"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
         </svg>
       </button>
 
@@ -208,15 +243,31 @@ function KeyboardShortcutsPanel() {
 
 export default function VideoEditor() {
   const {
-    file, duration, recipe, status, progress,
-    result, error, exportStartedAt, updateRecipe,
-    handleFileSelect, fileError, handleExport, cancelExport, reset, resetSettings,
+    file,
+    duration,
+    recipe,
+    status,
+    progress,
+    result,
+    error,
+    exportStartedAt,
+    updateRecipe,
+    handleFileSelect,
+    fileError,
+    handleExport,
+    cancelExport,
+    reset,
+    resetSettings,
     videoRef,
     seekTo,
-    overlayFile, setOverlayFile,
-    overlayPosition, setOverlayPosition,
-    overlaySize, setOverlaySize,
-    overlayOpacity, setOverlayOpacity,
+    overlayFile,
+    setOverlayFile,
+    overlayPosition,
+    setOverlayPosition,
+    overlaySize,
+    setOverlaySize,
+    overlayOpacity,
+    setOverlayOpacity,
     recommendedPreset,
     currentTime,
     toggleSound,
@@ -288,7 +339,7 @@ export default function VideoEditor() {
 
   const handleCopyLink = () => {
     if (typeof window === "undefined") return;
-    const encoded = btoa(JSON.stringify(recipe));
+    const encoded = encodeURIComponent(JSON.stringify(recipe));
     const url = new URL(window.location.href);
     url.searchParams.set("settings", encoded);
     history.replaceState(null, "", url.toString());
@@ -300,7 +351,6 @@ export default function VideoEditor() {
 
   useEffect(() => {
     if (status === "done" && downloadRef.current) {
-      
       const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
       downloadRef.current.scrollIntoView({
         behavior: prefersReducedMotion ? "instant" : "smooth",
@@ -308,7 +358,6 @@ export default function VideoEditor() {
       });
     }
   }, [status]);
-
 
   const isProcessing = status === "loading-engine" || status === "exporting";
   const [isMac, setIsMac] = useState(false);
@@ -324,23 +373,19 @@ export default function VideoEditor() {
     return 30;
   }, [duration]);
 
-  const videoSrc = useMemo(
-    () => (file ? URL.createObjectURL(file) : null),
-    [file]
-  );
+  const videoSrc = useMemo(() => (file ? URL.createObjectURL(file) : null), [file]);
 
   const exportSummary = useMemo(() => {
     const preset = getPresetById(recipe.preset);
-    const width = recipe.preset === "custom" ? recipe.customWidth : (preset?.width ?? recipe.customWidth);
-    const height = recipe.preset === "custom" ? recipe.customHeight : (preset?.height ?? recipe.customHeight);
+    const width =
+      recipe.preset === "custom" ? recipe.customWidth : (preset?.width ?? recipe.customWidth);
+    const height =
+      recipe.preset === "custom" ? recipe.customHeight : (preset?.height ?? recipe.customHeight);
 
     const framingLabel = recipe.framing === "fit" ? "Fit" : "Fill";
     const speedLabel = `${recipe.speed}× speed`;
-    const qualityLabel = recipe.quality <= 21
-      ? "High"
-      : recipe.quality <= 25
-      ? "Balanced"
-      : "Small file";
+    const qualityLabel =
+      recipe.quality <= 21 ? "High" : recipe.quality <= 25 ? "Balanced" : "Small file";
 
     return `Exporting to ${width}×${height} ${recipe.format.toUpperCase()} • ${framingLabel} • ${speedLabel} • Quality: ${qualityLabel}`;
   }, [recipe]);
@@ -367,58 +412,67 @@ export default function VideoEditor() {
         {status === "error" && `Export failed: ${error}`}
       </div>
 
-      <div className={cn(
-        "max-w-6xl mx-auto px-4 py-8 pb-6 flex-1 w-full",
-        // Reserve space on mobile so the fixed export bar never covers content.
-        file && "max-lg:pb-28"
-      )}>
+      <div
+        className={cn(
+          "max-w-6xl mx-auto px-4 py-8 pb-6 flex-1 w-full",
+          // Reserve space on mobile so the fixed export bar never covers content.
+          file && "max-lg:pb-28"
+        )}
+      >
         <header className="mb-10 flex flex-col items-center justify-center gap-4 animate-fade-in">
-        <div
-          className="inline-block rounded-xl border border-[var(--border)] bg-[var(--surface)] shadow-sm border-l-4 border-l-film-600 mx-auto w-fit min-w-min"
-          style={{ padding: 'clamp(0.75rem,3vw,1.25rem) clamp(1rem,5vw,2rem)', boxSizing: 'border-box' }}
-          aria-label="Reframe — video editor"
-        >
-        <h1
-          className="font-display leading-none tracking-widest2 text-[var(--text)] break-words text-center transition-all"
-          style={{ fontSize: 'clamp(2rem,10vw,4rem)', viewTransitionName: 'reframe-text' }}
-        >
-          REFRAME
-        </h1>
-        <p
-          className="font-heading text-[var(--muted)] uppercase tracking-widest text-center"
-          style={{
-            fontSize: 'clamp(0.7rem,2vw,0.875rem)',
-            marginTop: 'clamp(0.25rem,1vw,0.5rem)',
-          }}
-        >
-          Your video, any format
-        </p>
-    <div
-      className="flex md:hidden items-center justify-center gap-2 font-heading font-semibold uppercase tracking-widest text-[var(--muted)] border-t border-[var(--border)]"
-      style={{
-        fontSize: 'clamp(0.6rem,1.5vw,0.75rem)',
-        marginTop: 'clamp(0.5rem,2vw,0.75rem)',
-        paddingTop: 'clamp(0.5rem,2vw,0.75rem)',
-      }}
-    >
-      <span className="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-[var(--accent)] inline-block animate-pulse" />
-      No login. No ads. 100% private.
-    </div>
-  </div>  
-  <div
-    className="flex flex-wrap justify-center text-center items-center gap-2 text-sm font-heading font-semibold uppercase tracking-widest text-[var(--muted)] pb-1"
-    style={{ justifyContent: 'center', textAlign: 'center', margin: '0', width: 'auto' }}
-  >
-    <span className="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-[var(--accent)] inline-block animate-pulse" />
-    No login. No ads. 100% private - your video never leaves your device.
-  </div>
-    </header>
+          <div
+            className="inline-block rounded-xl border border-[var(--border)] bg-[var(--surface)] shadow-sm border-l-4 border-l-film-600 mx-auto w-fit min-w-min"
+            style={{
+              padding: "clamp(0.75rem,3vw,1.25rem) clamp(1rem,5vw,2rem)",
+              boxSizing: "border-box",
+            }}
+            aria-label="Reframe — video editor"
+          >
+            <h1
+              className="font-display leading-none tracking-widest2 text-[var(--text)] break-words text-center transition-all"
+              style={{ fontSize: "clamp(2rem,10vw,4rem)", viewTransitionName: "reframe-text" }}
+            >
+              REFRAME
+            </h1>
+            <p
+              className="font-heading text-[var(--muted)] uppercase tracking-widest text-center"
+              style={{
+                fontSize: "clamp(0.7rem,2vw,0.875rem)",
+                marginTop: "clamp(0.25rem,1vw,0.5rem)",
+              }}
+            >
+              Your video, any format
+            </p>
+            <div
+              className="flex md:hidden items-center justify-center gap-2 font-heading font-semibold uppercase tracking-widest text-[var(--muted)] border-t border-[var(--border)]"
+              style={{
+                fontSize: "clamp(0.6rem,1.5vw,0.75rem)",
+                marginTop: "clamp(0.5rem,2vw,0.75rem)",
+                paddingTop: "clamp(0.5rem,2vw,0.75rem)",
+              }}
+            >
+              <span className="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-[var(--accent)] inline-block animate-pulse" />
+              No login. No ads. 100% private.
+            </div>
+          </div>
+          <div
+            className="flex flex-wrap justify-center text-center items-center gap-2 text-sm font-heading font-semibold uppercase tracking-widest text-[var(--muted)] pb-1"
+            style={{ justifyContent: "center", textAlign: "center", margin: "0", width: "auto" }}
+          >
+            <span className="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-[var(--accent)] inline-block animate-pulse" />
+            No login. No ads. 100% private - your video never leaves your device.
+          </div>
+        </header>
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-5">
-
           <div className="space-y-4 min-w-0">
             {!file && <PrivacyBanner />}
             <div className="bg-[var(--surface)] rounded-xl p-3 border border-[var(--border)] animate-fade-in">
-              <FileUpload onFileSelect={handleFileSelect} currentFile={file} fileError={fileError} duration={duration} />
+              <FileUpload
+                onFileSelect={handleFileSelect}
+                currentFile={file}
+                fileError={fileError}
+                duration={duration}
+              />
 
               {!file && (
                 <div className="text-center text-[var(--muted)] py-6">
@@ -459,10 +513,12 @@ export default function VideoEditor() {
               </p>
             )}
             {file && (
-              <div className={cn(
-                "grid grid-cols-1 gap-4",
-                isProcessing && "pointer-events-none opacity-50"
-              )}>
+              <div
+                className={cn(
+                  "grid grid-cols-1 gap-4",
+                  isProcessing && "pointer-events-none opacity-50"
+                )}
+              >
                 <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6">
                   <AccordionSection
                     id="trim"
@@ -518,11 +574,7 @@ export default function VideoEditor() {
                   >
                     <AudioSpeedControl recipe={recipe} onChange={updateRecipe} />
                   </AccordionSection>
-                  <Section
-                    icon={<SlidersHorizontal size={12} />}
-                    title="Adjustments"
-                    delay={175}
-                  >
+                  <Section icon={<SlidersHorizontal size={12} />} title="Adjustments" delay={175}>
                     <div className="space-y-5">
                       {/* Brightness */}
                       <div className="space-y-2">
@@ -667,12 +719,15 @@ export default function VideoEditor() {
                 <button
                   type="button"
                   onClick={() => {
-                    navigator.clipboard.writeText(error).then(() => {
-                      setCopied(true);
-                      setTimeout(() => setCopied(false), 2000);
-                    }).catch((err) => {
-                      console.error("Failed to copy error to clipboard:", err);
-                    });
+                    navigator.clipboard
+                      .writeText(error)
+                      .then(() => {
+                        setCopied(true);
+                        setTimeout(() => setCopied(false), 2000);
+                      })
+                      .catch((err) => {
+                        console.error("Failed to copy error to clipboard:", err);
+                      });
                   }}
                   className="px-3 py-1.5 bg-[var(--border)] border border-[var(--border)] rounded-lg text-sm font-semibold hover:opacity-80 transition-colors shrink-0 whitespace-nowrap"
                   aria-label="Copy error message to clipboard"
@@ -693,15 +748,22 @@ export default function VideoEditor() {
 
             {status === "done" && result && (
               <div role="status" className="animate-fade-in" ref={downloadRef}>
-                <DownloadResult result={result} onReset={reset} soundOnCompletion={recipe.soundOnCompletion} onToggleSound={toggleSound} />
+                <DownloadResult
+                  result={result}
+                  onReset={reset}
+                  soundOnCompletion={recipe.soundOnCompletion}
+                  onToggleSound={toggleSound}
+                />
               </div>
             )}
           </div>
 
-          <div className={cn(
-            "space-y-5 transition-opacity duration-300 sticky top-8 self-start",
-            (isProcessing || !file) && "pointer-events-none opacity-50"
-          )}>
+          <div
+            className={cn(
+              "space-y-5 transition-opacity duration-300 sticky top-8 self-start",
+              (isProcessing || !file) && "pointer-events-none opacity-50"
+            )}
+          >
             {!file && (
               <div className="bg-[var(--surface)] border border-[var(--border)] rounded-xl p-4 animate-fade-in">
                 <p className="text-[10px] font-heading font-bold text-film-600 uppercase tracking-widest">
@@ -712,7 +774,10 @@ export default function VideoEditor() {
                 </p>
               </div>
             )}
-            <div className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6 animate-fade-in" style={{ animationDelay: "50ms" }}>
+            <div
+              className="bg-[var(--surface)] rounded-xl border border-[var(--border)] p-5 space-y-6 animate-fade-in"
+              style={{ animationDelay: "50ms" }}
+            >
               <AccordionSection
                 id="resize"
                 icon={<Layers size={12} />}
@@ -724,7 +789,9 @@ export default function VideoEditor() {
                 {recommendedPreset && (
                   <div className="mb-4 rounded-2xl border border-film-200 bg-film-50 p-3 text-sm text-film-700">
                     <p>
-                      We detected a {recommendedPreset.label.replace(/\s/g, "")} video → Recommended: {(recommendedPreset.platform.split("·")[0] ?? "").trim()} ({recommendedPreset.label.replace(/\s/g, "")})
+                      We detected a {recommendedPreset.label.replace(/\s/g, "")} video →
+                      Recommended: {(recommendedPreset.platform.split("·")[0] ?? "").trim()} (
+                      {recommendedPreset.label.replace(/\s/g, "")})
                     </p>
                   </div>
                 )}
@@ -765,10 +832,10 @@ export default function VideoEditor() {
               id="export-button"
               type="button"
               onClick={handleExport}
-                disabled={!file || isProcessing}
-                aria-label='Export video'
-                aria-disabled={!file || isProcessing ? "true" : undefined}
-                title={!file ? "Upload a video to enable export" : undefined}
+              disabled={!file || isProcessing}
+              aria-label="Export video"
+              aria-disabled={!file || isProcessing ? "true" : undefined}
+              title={!file ? "Upload a video to enable export" : undefined}
               className={cn(
                 // Hidden on mobile — replaced by the fixed bottom bar below.
                 "w-full hidden lg:flex items-center justify-center gap-3 py-5 min-h-[44px] rounded-xl",
@@ -778,7 +845,7 @@ export default function VideoEditor() {
                   : "bg-[var(--border)] text-[var(--muted)] cursor-not-allowed"
               )}
             >
-             <Zap size={20} className={cn(file && !isProcessing && "animate-pulse")} />
+              <Zap size={20} className={cn(file && !isProcessing && "animate-pulse")} />
               {isProcessing ? "PROCESSING" : "EXPORT"}
             </button>
 

--- a/src/hooks/useVideoEditor.ts
+++ b/src/hooks/useVideoEditor.ts
@@ -1,7 +1,16 @@
 "use client";
 
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
-import { EditRecipe, ExportResult, ExportStatus, MAX_FILE_SIZE, OverlayPosition, TimelineTrack, MultiTrackEditorState, isValidRecipe } from "@/lib/types";
+import {
+  EditRecipe,
+  ExportResult,
+  ExportStatus,
+  MAX_FILE_SIZE,
+  OverlayPosition,
+  TimelineTrack,
+  MultiTrackEditorState,
+  isValidRecipe,
+} from "@/lib/types";
 import { DEFAULT_RECIPE, SPEED_STEPS } from "@/lib/constants";
 import { getPresetById } from "@/lib/presets";
 import { loadFFmpeg, exportVideo, terminateFFmpeg, FFmpegLoadError } from "@/lib/ffmpeg";
@@ -28,18 +37,24 @@ import { saveSessionFile, loadSessionFile, clearSessionFile } from "@/lib/sessio
 
 const DEFAULT_TITLE = "Reframe — Resize, trim, and export videos in your browser";
 
-export function extractMetadata(file: File): Promise<{ width: number; height: number; duration: number }> {
+export function extractMetadata(
+  file: File
+): Promise<{ width: number; height: number; duration: number }> {
   return new Promise((resolve, reject) => {
     const url = URL.createObjectURL(file);
     const video = document.createElement("video");
     const timeout = setTimeout(() => {
       URL.revokeObjectURL(url);
-      reject( new Error("Video metaData load timeout — the file may be too large or the device too slow. Please try again.") );
+      reject(
+        new Error(
+          "Video metaData load timeout — the file may be too large or the device too slow. Please try again."
+        )
+      );
     }, 5000);
 
     video.preload = "metadata";
     video.onloadedmetadata = () => {
-      clearTimeout(timeout)
+      clearTimeout(timeout);
       resolve({
         width: video.videoWidth,
         height: video.videoHeight,
@@ -48,7 +63,7 @@ export function extractMetadata(file: File): Promise<{ width: number; height: nu
       URL.revokeObjectURL(url);
     };
     video.onerror = () => {
-      clearTimeout(timeout)
+      clearTimeout(timeout);
       URL.revokeObjectURL(url);
       reject(new Error("Failed to load video metadata"));
     };
@@ -65,7 +80,10 @@ function verifyMagicBytes(file: File): Promise<boolean> {
         return;
       }
       const arr = new Uint8Array(e.target.result as ArrayBuffer);
-      const hex = Array.from(arr).map(b => b.toString(16).padStart(2, "0")).join("").toUpperCase();
+      const hex = Array.from(arr)
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("")
+        .toUpperCase();
       const ascii = String.fromCharCode(...arr);
 
       // WebM / MKV
@@ -81,71 +99,63 @@ function verifyMagicBytes(file: File): Promise<boolean> {
   });
 }
 
-function validateRecipe(recipe: EditRecipe, duration: number ): string | null {
+function validateRecipe(recipe: EditRecipe, duration: number): string | null {
   const validations: Array<[boolean, string]> = [
-    [
-      recipe.trimStart < 0,
-      "Trim start time cannot be less than 0 seconds.",
-    ],
+    [recipe.trimStart < 0, "Trim start time cannot be less than 0 seconds."],
     [
       recipe.trimEnd !== null && duration > 0 && recipe.trimEnd > duration,
       `Trim end time cannot exceed the video duration (${Math.floor(duration)}s).`,
     ],
     [
-      recipe.trimEnd !== null 
-        ? recipe.trimStart >= recipe.trimEnd 
-        : (duration > 0 && recipe.trimStart >= duration),
+      recipe.trimEnd !== null
+        ? recipe.trimStart >= recipe.trimEnd
+        : duration > 0 && recipe.trimStart >= duration,
       "Trim start time must be earlier than the end time.",
     ],
     [
-      recipe.preset === "custom" && (Number.isNaN(recipe.customWidth) || recipe.customWidth < 16 || recipe.customWidth > 7680),
+      recipe.preset === "custom" &&
+        (Number.isNaN(recipe.customWidth) || recipe.customWidth < 16 || recipe.customWidth > 7680),
       "Width must be between 16px and 7680px.",
     ],
     [
-      recipe.preset === "custom" && (Number.isNaN(recipe.customHeight) || recipe.customHeight < 16 || recipe.customHeight > 7680),
+      recipe.preset === "custom" &&
+        (Number.isNaN(recipe.customHeight) ||
+          recipe.customHeight < 16 ||
+          recipe.customHeight > 7680),
       "Height must be between 16px and 7680px.",
     ],
     [
       !(SPEED_STEPS as readonly number[]).includes(recipe.speed),
       "Please select a valid playback speed.",
     ],
-    [
-      recipe.quality < 18 || recipe.quality > 30,
-      "Quality must be between 18 and 30.",
-    ],
-    [
-      recipe.brightness < -1 || recipe.brightness > 1,
-      "Brightness must be between -1 and 1.",
-    ],
+    [recipe.quality < 18 || recipe.quality > 30, "Quality must be between 18 and 30."],
+    [recipe.brightness < -1 || recipe.brightness > 1, "Brightness must be between -1 and 1."],
 
-    [
-      recipe.contrast < 0 || recipe.contrast > 2,
-      "Contrast must be between 0 and 2.",
-    ],
+    [recipe.contrast < 0 || recipe.contrast > 2, "Contrast must be between 0 and 2."],
 
-    [
-      recipe.saturation < 0 || recipe.saturation > 3,
-      "Saturation must be between 0 and 3.",
-    ],
-    [
-      recipe.sharpness < 0 || recipe.sharpness > 3,
-      "Sharpness must be between 0 and 3.",
-    ],
+    [recipe.saturation < 0 || recipe.saturation > 3, "Saturation must be between 0 and 3."],
+    [recipe.sharpness < 0 || recipe.sharpness > 3, "Sharpness must be between 0 and 3."],
   ];
 
-  return (
-    validations.find(([condition]) => condition)?.[1] ??
-    null
-  );
+  return validations.find(([condition]) => condition)?.[1] ?? null;
 }
 
 function encodeRecipe(recipe: EditRecipe): string {
-  return btoa(JSON.stringify(recipe));
+  return encodeURIComponent(JSON.stringify(recipe));
 }
 
 function decodeRecipe(encoded: string): Partial<EditRecipe> | null {
   try {
-    const decoded = JSON.parse(atob(encoded));
+    let jsonString: string;
+    try {
+      jsonString = decodeURIComponent(encoded);
+      if (!jsonString.trim().startsWith("{")) {
+        throw new Error();
+      }
+    } catch {
+      jsonString = atob(encoded);
+    }
+    const decoded = JSON.parse(jsonString);
     if (!decoded || typeof decoded !== "object") return null;
     // Validate the merged recipe before accepting any decoded values.
     // This prevents a tampered or malformed share URL from injecting
@@ -191,36 +201,40 @@ export function useVideoEditor() {
   const [currentTime, setCurrentTime] = useState(0);
 
   // Phase 1 MVP: Multi-track timeline support
-  const [multiTrackState, setMultiTrackState] = useState<MultiTrackEditorState>(createMultiTrackState);
+  const [multiTrackState, setMultiTrackState] =
+    useState<MultiTrackEditorState>(createMultiTrackState);
 
   const addTrack = useCallback((track: TimelineTrack) => {
-    setMultiTrackState(prev => addTrackToTimeline(prev, track));
+    setMultiTrackState((prev) => addTrackToTimeline(prev, track));
   }, []);
 
   const removeTrack = useCallback((trackId: string) => {
-    setMultiTrackState(prev => removeTrackFromTimeline(prev, trackId));
+    setMultiTrackState((prev) => removeTrackFromTimeline(prev, trackId));
   }, []);
 
   const updateTrack = useCallback((trackId: string, updates: Partial<TimelineTrack>) => {
-    setMultiTrackState(prev => updateTrackInTimeline(prev, trackId, updates));
+    setMultiTrackState((prev) => updateTrackInTimeline(prev, trackId, updates));
   }, []);
 
-  const addVideoTrack = useCallback((videoFile: File, startTime: number = 0) => {
-    const track = createTimelineTrack("video", videoFile, startTime);
-    addTrack(track);
-    return track;
-  }, [addTrack]);
+  const addVideoTrack = useCallback(
+    (videoFile: File, startTime: number = 0) => {
+      const track = createTimelineTrack("video", videoFile, startTime);
+      addTrack(track);
+      return track;
+    },
+    [addTrack]
+  );
 
   const updateRecipe = useCallback((patch: Partial<EditRecipe>) => {
-  setRecipe((prev) => {
-    const next = { ...prev, ...patch };
-    // GIF has no audio — force keepAudio off
-    if (next.format === "gif") {
-      next.keepAudio = false;
-    }
-    return next;
-  });
-}, []);
+    setRecipe((prev) => {
+      const next = { ...prev, ...patch };
+      // GIF has no audio — force keepAudio off
+      if (next.format === "gif") {
+        next.keepAudio = false;
+      }
+      return next;
+    });
+  }, []);
   const isValidValue = (key: keyof EditRecipe, val: any): boolean => {
     switch (key) {
       case "preset":
@@ -238,7 +252,11 @@ export function useVideoEditor() {
       case "rotate":
         return val === 0 || val === 90 || val === 180 || val === 270;
       case "speed":
-        return typeof val === "number" && !isNaN(val) && [0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 4].includes(val);
+        return (
+          typeof val === "number" &&
+          !isNaN(val) &&
+          [0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 4].includes(val)
+        );
       case "quality":
         return typeof val === "number" && !isNaN(val) && val >= 18 && val <= 30;
       case "format":
@@ -256,21 +274,23 @@ export function useVideoEditor() {
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    
+
     // Auto-restore saved video session
-    loadSessionFile().then(async (savedFile) => {
-      if (savedFile) {
-        try {
-          const { width, height, duration: dur } = await extractMetadata(savedFile);
-          setDuration(dur);
-          setVideoMetadata({ width, height, duration: dur });
-          setFile(savedFile);
-        } catch (e) {
-          console.error("Failed to restore video session:", e);
-          clearSessionFile().catch(console.error);
+    loadSessionFile()
+      .then(async (savedFile) => {
+        if (savedFile) {
+          try {
+            const { width, height, duration: dur } = await extractMetadata(savedFile);
+            setDuration(dur);
+            setVideoMetadata({ width, height, duration: dur });
+            setFile(savedFile);
+          } catch (e) {
+            console.error("Failed to restore video session:", e);
+            clearSessionFile().catch(console.error);
+          }
         }
-      }
-    }).catch(console.error);
+      })
+      .catch(console.error);
 
     try {
       const params = new URLSearchParams(window.location.search);
@@ -284,7 +304,7 @@ export function useVideoEditor() {
       }
 
       const recipeKeys = Object.keys(DEFAULT_RECIPE) as Array<keyof EditRecipe>;
-      const hasRecipeParams = recipeKeys.some(key => params.has(key));
+      const hasRecipeParams = recipeKeys.some((key) => params.has(key));
 
       if (hasRecipeParams) {
         const updatedPatch: Partial<EditRecipe> = {};
@@ -309,16 +329,21 @@ export function useVideoEditor() {
         });
 
         if (Object.keys(updatedPatch).length > 0) {
-          setRecipe(prev => ({
+          setRecipe((prev) => ({
             ...prev,
-            ...updatedPatch
+            ...updatedPatch,
           }));
         }
       } else {
-        setRecipe((current) => loadPersistedRecipe(localStorage, migratePersistedRecipe({
-          ...current,
-          soundOnCompletion: getStoredSoundPreference(localStorage),
-        })));
+        setRecipe((current) =>
+          loadPersistedRecipe(
+            localStorage,
+            migratePersistedRecipe({
+              ...current,
+              soundOnCompletion: getStoredSoundPreference(localStorage),
+            })
+          )
+        );
       }
     } catch (e) {
       // ignore
@@ -378,7 +403,7 @@ export function useVideoEditor() {
     setError(null);
     setFile(null);
     setVideoMetadata(null);
-    
+
     if (!selectedFile) {
       setFileError("");
       return;
@@ -398,17 +423,21 @@ export function useVideoEditor() {
       return;
     }
 
-    const validExtensions = ['.mp4', '.mov', '.avi', '.webm', '.mkv'];
+    const validExtensions = [".mp4", ".mov", ".avi", ".webm", ".mkv"];
     const filename = selectedFile.name.toLowerCase();
-    const hasValidExtension = validExtensions.some(ext => filename.endsWith(ext));
+    const hasValidExtension = validExtensions.some((ext) => filename.endsWith(ext));
     if (!hasValidExtension) {
-      setError(`Layer 1 Validation Failed: Invalid file extension. Expected one of: ${validExtensions.join(', ')}`);
+      setError(
+        `Layer 1 Validation Failed: Invalid file extension. Expected one of: ${validExtensions.join(", ")}`
+      );
       setStatus("error");
       return;
     }
 
     if (!selectedFile.type.startsWith("video/")) {
-      setError(`Layer 2 Validation Failed: Invalid MIME type. Expected video/*, got ${selectedFile.type || 'unknown'}`);
+      setError(
+        `Layer 2 Validation Failed: Invalid MIME type. Expected video/*, got ${selectedFile.type || "unknown"}`
+      );
       setStatus("error");
       return;
     }
@@ -418,7 +447,9 @@ export function useVideoEditor() {
       try {
         const isVideo = await verifyMagicBytes(selectedFile);
         if (!isVideo) {
-          setError("Layer 3 Validation Failed: Invalid file content. The file's magic bytes do not match known video formats.");
+          setError(
+            "Layer 3 Validation Failed: Invalid file content. The file's magic bytes do not match known video formats."
+          );
           setStatus("error");
           return;
         }
@@ -431,7 +462,7 @@ export function useVideoEditor() {
           const suggested = getDownscaledDimensions(width, height);
           setError(
             `Layer 5 Validation Failed: Resolution too high (${width}×${height}). ` +
-            `Maximum supported is 8K. Suggested safe size: ${suggested.width}×${suggested.height}.`
+              `Maximum supported is 8K. Suggested safe size: ${suggested.width}×${suggested.height}.`
           );
           setStatus("error");
           return;
@@ -443,7 +474,9 @@ export function useVideoEditor() {
         saveSessionFile(selectedFile).catch(console.error);
 
         if (dimensionCheck === "warning") {
-          console.warn(`[Reframe] High resolution video detected (${width}×${height}). Export may be slow.`);
+          console.warn(
+            `[Reframe] High resolution video detected (${width}×${height}). Export may be slow.`
+          );
         }
         setRecipe((prev) => {
           const suggestedPreset = suggestPreset(width, height);
@@ -457,11 +490,12 @@ export function useVideoEditor() {
           };
         });
       } catch (err) {
-        setError(`Layer 4 Validation Failed: ${err instanceof Error ? err.message : "Unknown error"}`);
+        setError(
+          `Layer 4 Validation Failed: ${err instanceof Error ? err.message : "Unknown error"}`
+        );
         setStatus("error");
       }
     })();
-
   }, []);
 
   const handleExport = useCallback(async () => {
@@ -521,23 +555,22 @@ export function useVideoEditor() {
         exportDurationMs: Date.now() - startedAt,
       });
       setStatus("done");
-     }  catch (err) {
+    } catch (err) {
       if (exportCancelledRef.current) return;
 
       console.error("export failed:", err);
       if (err instanceof FFmpegLoadError) {
         setError(err.message);
-      } else if (err instanceof Error && err.message.includes('network')) {
-        setError('Network error. Check your internet connection and try again.');
-      } else if (err instanceof Error && err.message.includes('codec')) {
-        setError('This video format is not supported. Try converting to MP4 first.');
+      } else if (err instanceof Error && err.message.includes("network")) {
+        setError("Network error. Check your internet connection and try again.");
+      } else if (err instanceof Error && err.message.includes("codec")) {
+        setError("This video format is not supported. Try converting to MP4 first.");
       } else {
-        setError('Export failed. Please try again or use a different video.');
+        setError("Export failed. Please try again or use a different video.");
       }
       setExportStartedAt(null);
       setStatus("error");
-    }
-    finally {
+    } finally {
       if (exportAbortControllerRef.current === abortController) {
         exportAbortControllerRef.current = null;
       }
@@ -557,7 +590,6 @@ export function useVideoEditor() {
     result,
     status,
   ]);
-
 
   useEffect(() => {
     if (status === "exporting") {
@@ -580,9 +612,7 @@ export function useVideoEditor() {
   }, []);
 
   useEffect(() => {
-    const shouldWarn =
-      status === "exporting" ||
-      status === "loading-engine";
+    const shouldWarn = status === "exporting" || status === "loading-engine";
 
     if (!shouldWarn) return;
 
@@ -594,7 +624,7 @@ export function useVideoEditor() {
     window.addEventListener("beforeunload", handler);
     return () => window.removeEventListener("beforeunload", handler);
   }, [status]);
-  
+
   useEffect(() => {
     const handleKeydown = (e: KeyboardEvent) => {
       if (
@@ -622,11 +652,7 @@ export function useVideoEditor() {
       if (e.key.toLowerCase() !== "m" || e.ctrlKey || e.metaKey || e.altKey) return;
 
       const target = e.target as HTMLElement;
-      if (
-        target.tagName === "INPUT" ||
-        target.tagName === "TEXTAREA" ||
-        target.isContentEditable
-      ) {
+      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable) {
         return;
       }
 
@@ -639,13 +665,13 @@ export function useVideoEditor() {
     };
   }, [file]);
 
-  useEffect(()=>{
-    return ()=>{
-      if(result?.blobUrl){
+  useEffect(() => {
+    return () => {
+      if (result?.blobUrl) {
         URL.revokeObjectURL(result.blobUrl);
       }
-    }
-   },[result?.blobUrl])
+    };
+  }, [result?.blobUrl]);
 
   useEffect(() => {
     return () => {
@@ -675,7 +701,6 @@ export function useVideoEditor() {
     setExportStartedAt(null);
   }, []);
 
-
   const reset = useCallback(() => {
     if (result?.blobUrl) URL.revokeObjectURL(result.blobUrl);
     setFile(null);
@@ -696,7 +721,6 @@ export function useVideoEditor() {
     }
   }, [result]);
 
-
   useEffect(() => {
     persistSoundPreference(localStorage, recipe.soundOnCompletion);
   }, [recipe.soundOnCompletion]);
@@ -714,8 +738,8 @@ export function useVideoEditor() {
   });
 
   const toggleSound = useCallback(() => {
-  updateRecipe({ soundOnCompletion: !recipe.soundOnCompletion });
-}, [recipe.soundOnCompletion, updateRecipe]);
+    updateRecipe({ soundOnCompletion: !recipe.soundOnCompletion });
+  }, [recipe.soundOnCompletion, updateRecipe]);
 
   return {
     file,


### PR DESCRIPTION
## Description
This PR addresses issue #1660 where `btoa` throws an `InvalidCharacterError` when the user includes Unicode characters (like emojis or non-Latin text) in the editor state and attempts to copy the share link.

### Fixes Made:
- **Encoding/Decoding:** Replaced `btoa(JSON.stringify(recipe))` with `encodeURIComponent(JSON.stringify(recipe))` in `VideoEditor.tsx` and `useVideoEditor.ts`.
- **Backward Compatibility:** Updated `decodeRecipe` to safely attempt decoding via `decodeURIComponent` first. If the decoded string isn't a valid JSON object (meaning the link was generated with the old base64 method), it gracefully falls back to `atob(encoded)`. This guarantees that existing share links out in the wild will not break!

## Related Issues
Fixes #1660 
Fixes #1725

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Backwards compatible enhancement

## Additional Notes
- Contributing under GSSoC 2026.
