### PR TITLE
test: Set up automated integration tests for useVideoEditor core controller #1334

### DIFF
--- a/src/hooks/tests/useVideoEditor.test.ts
+++ b/src/hooks/tests/useVideoEditor.test.ts
@@ -1,0 +1,86 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useVideoEditor } from "../useVideoEditor";
+import { DEFAULT_RECIPE } from "@/lib/constants";
+
+// Mock the dependencies
+vi.mock("@/lib/ffmpeg", () => ({
+  loadFFmpeg: vi.fn().mockResolvedValue(true),
+  exportVideo: vi.fn().mockResolvedValue({ blobUrl: "blob:test" }),
+  terminateFFmpeg: vi.fn(),
+  FFmpegLoadError: class extends Error {},
+}));
+
+vi.mock("@/lib/sessionDB", () => ({
+  saveSessionFile: vi.fn().mockResolvedValue(undefined),
+  loadSessionFile: vi.fn().mockResolvedValue(null),
+  clearSessionFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock browser APIs
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] || null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value.toString(); }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+  };
+})();
+Object.defineProperty(window, "localStorage", { value: localStorageMock });
+Object.defineProperty(window, "URL", {
+  value: {
+    createObjectURL: vi.fn().mockReturnValue("blob:test"),
+    revokeObjectURL: vi.fn(),
+  },
+});
+
+describe("useVideoEditor core controller", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorageMock.clear();
+  });
+
+  it("should initialize with the default recipe", () => {
+    const { result } = renderHook(() => useVideoEditor());
+    expect(result.current.recipe).toEqual({
+      ...DEFAULT_RECIPE,
+      soundOnCompletion: false,
+    });
+    expect(result.current.status).toBe("idle");
+    expect(result.current.file).toBeNull();
+  });
+
+  it("should safely update recipe with valid patch values", () => {
+    const { result } = renderHook(() => useVideoEditor());
+    act(() => {
+      result.current.updateRecipe({ speed: 2, quality: 20 });
+    });
+    expect(result.current.recipe.speed).toBe(2);
+    expect(result.current.recipe.quality).toBe(20);
+  });
+
+  it("should ignore invalid patch values via isValidValue check", () => {
+    const { result } = renderHook(() => useVideoEditor());
+    act(() => {
+      // 9999 is invalid for speed, -50 is invalid for quality
+      result.current.updateRecipe({ speed: 9999, quality: -50 } as any);
+    });
+    // Values should remain as defaults
+    expect(result.current.recipe.speed).toBe(DEFAULT_RECIPE.speed);
+    expect(result.current.recipe.quality).toBe(DEFAULT_RECIPE.quality);
+  });
+
+  it("should reset settings to default when resetSettings is called", () => {
+    const { result } = renderHook(() => useVideoEditor());
+    act(() => {
+      result.current.updateRecipe({ speed: 1.5 });
+    });
+    expect(result.current.recipe.speed).toBe(1.5);
+    
+    act(() => {
+      result.current.resetSettings();
+    });
+    expect(result.current.recipe.speed).toBe(DEFAULT_RECIPE.speed);
+  });
+});


### PR DESCRIPTION
## Description
This PR addresses issue #1334 by implementing a robust integration test suite for the primary core controller of the app: `useVideoEditor.ts`.

While the Vitest framework was previously configured, `useVideoEditor` lacked test coverage despite containing the majority of the application's business logic, state transitions, and validation layers.

### Fixes Made:
- **`src/hooks/tests/useVideoEditor.test.ts`**: Implemented a comprehensive test suite using `@testing-library/react` (`renderHook`, `act`).
- **Environment Mocking**: Implemented safe, isolated stubs for `localStorage`, `URL.createObjectURL`, `sessionDB`, and FFmpeg workers to ensure tests run reliably without invoking actual IndexedDB or WASM binaries.
- **Coverage**: 
  - Verified initial state integrity (`DEFAULT_RECIPE`).
  - Verified valid state transitions (`updateRecipe`).
  - Verified the strict validation/sanitization layer actively blocks malformed patches (e.g., `speed: 9999`).
  - Verified `resetSettings` functionality.

## Related Issues
Closes #1334

## Type of Change
- [x] Testing (Setting up automated unit/integration tests)

## Additional Notes
- Contributing under GSSoC 2026.
